### PR TITLE
feat: add Insomnia and newman; document GUI vs CLI API tooling

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -47,6 +47,7 @@ brew "tldr"           # simplified man pages (community-maintained examples)
 brew "httpie"         # human-friendly HTTP client (replaces curl for interactive use)
 brew "watch"          # re-run a command on an interval (e.g. watch kubectl get pods)
 brew "direnv"         # per-directory environment variables via .envrc files
+brew "newman"             # CLI runner for Insomnia/Postman collections (useful in CI)
 
 # ------------------
 # Fonts
@@ -57,6 +58,7 @@ cask "font-jetbrains-mono-nerd-font"   # JetBrains Mono with Nerd Font icons (te
 # ------------------
 # Apps (casks)
 # ------------------
+cask "insomnia"            # GUI REST/GraphQL client — API design, collections, team sharing
 cask "raycast"             # launcher, clipboard history, window management
 cask "visual-studio-code"  # editor
 cask "postgres-app"        # Postgres.app — PostgreSQL with a macOS GUI

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ echo 'export DATABASE_URL=postgres://localhost/myapp_dev' >> .envrc
 direnv allow   # approve the .envrc once; it runs automatically after that
 ```
 
+**[newman](https://github.com/postmanlabs/newman)** — a CLI runner for Insomnia and Postman collections. It executes a collection of API requests from the command line and reports pass/fail results, making API test suites runnable in CI pipelines without opening a GUI. Export a collection from Insomnia, add `newman run collection.json` to your CI config, and your API contracts are validated on every push.
+
 **[pre-commit](https://pre-commit.com)** — a framework for managing git pre-commit hooks. Hooks are defined in a `.pre-commit-config.yaml` file at the root of each project and run automatically before every `git commit`. This repo includes a template at `templates/pre-commit-config.yaml` covering Ruby/Rails projects.
 
 The `gitconfig` in this repo sets `core.hooksPath = ~/.config/git/hooks`, which points to a global hook stub installed by `install.sh`. This means pre-commit runs automatically in **any repo** that has a `.pre-commit-config.yaml` — no need to run `pre-commit install` in each project individually.
@@ -229,6 +231,10 @@ Pairs naturally with Postgres.app. No additional setup needed — `install.sh` s
 The global `~/.editorconfig` acts as a fallback for any project that doesn't have its own `.editorconfig`. It sets sane defaults (UTF-8, LF line endings, 2-space indent, final newline) with overrides for Java/Kotlin/Groovy (4 spaces), Go (tabs), and Makefiles (tabs). Any project-level `.editorconfig` takes precedence — this is purely a safety net for projects that don't define their own.
 
 ### Apps
+
+**[Insomnia](https://insomnia.rest)** — a GUI REST and GraphQL API client, and a solid replacement for Postman. Use it when you need to design, document, and share API collections with a team — it supports environments and variables, OAuth2 and other auth flows, saved request collections, and full GraphQL support. Collections can be exported as files and checked into a repo alongside your code.
+
+**When to use Insomnia vs HTTPie:** they serve different purposes and complement each other. Use Insomnia for building and maintaining organized API collections, testing complex auth flows visually, and sharing API definitions across a team. Use HTTPie (or `curl | jq`) for quick terminal one-liners, scripting, and piping responses into other tools. If you're exploring a single endpoint, HTTPie is faster. If you're managing a suite of requests across environments (dev, staging, prod), Insomnia is the right tool.
 
 **[OrbStack](https://orbstack.dev)** — a fast, lightweight replacement for Docker Desktop on macOS. It starts in under a second (vs Docker Desktop's 10–30s), uses significantly less RAM and CPU, and runs Linux VMs natively on Apple Silicon. The CLI is fully compatible with Docker (`docker`, `docker-compose`) so no workflow changes are needed. Free for personal use; worth switching to immediately if you run containers locally.
 


### PR DESCRIPTION
## What

Adds [Insomnia](https://insomnia.rest) (GUI API client) and [newman](https://github.com/postmanlabs/newman) (CLI collection runner) to the dotfiles toolchain.

## Changes

### Brewfile
- `cask "insomnia"` — GUI REST/GraphQL client for designing, documenting, and sharing API collections
- `brew "newman"` — CLI runner for Insomnia/Postman collections, useful in CI pipelines

### README
- **Apps section:** Added Insomnia entry before Raycast with guidance on when to use Insomnia (GUI collections, team sharing, auth flows) vs HTTPie (terminal one-liners, scripting, piping)
- **Utilities section:** Added newman entry explaining how it runs exported collections from the command line for CI integration

## Why

HTTPie covers quick terminal API calls, but there was no GUI tool for building organized request collections, testing complex auth flows visually, or sharing API definitions with a team. Insomnia fills that gap. newman complements it by making those collections executable in CI.