### PR TITLE
fix: reconcile Java to temurin-21, add Python 3.12, remove dead stubs, guard env loader

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -30,6 +30,7 @@ brew "gh"             # GitHub CLI
 # ------------------
 brew "mise"           # polyglot version manager (Ruby, Node, Python, etc.)
 brew "openssl@3"      # required for building Ruby via mise
+brew "maven"          # Java build tool — required for Maven projects
 
 # ------------------
 # Terminal multiplexer

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ What it does, in order:
 4. Sets up `fzf` shell integration (key bindings + tab completion)
 5. Authenticates `gh` (GitHub CLI) if not already logged in
 6. Generates an SSH key for commit signing and prompts you to add it to GitHub
-7. Installs Ruby 3.3.6, Node 22, and Java 17 (Temurin) via mise
+7. Installs Ruby 3.3.6, Node 22, Java 21 (Temurin), and Python 3.12 via mise
 8. Installs the `colorls` gem
 9. Calls `install.sh` to symlink all dotfiles including VS Code settings and mise config
 10. Creates `~/.zshrc.local` from `zshrc.local.example`
@@ -57,7 +57,7 @@ already-correct symlinks are left untouched.
 | `hyper.js` | `~/.hyper.js` | Hyper terminal — Tokyo Night theme, JetBrains Mono |
 | `config/starship.toml` | `~/.config/starship.toml` | Starship prompt — Ruby module disabled, 2s timeout |
 | `Brewfile` | _(used by bootstrap)_ | Declarative list of all Homebrew packages and casks |
-| `config/mise.toml` | `~/.config/mise/config.toml` | mise global runtime versions (Ruby, Node, Java) |
+| `config/mise.toml` | `~/.config/mise/config.toml` | mise global runtime versions (Ruby, Node, Java, Python) |
 | `ssh_config` | `~/.ssh/config` | SSH agent + Keychain config |
 | `vscode/settings.json` | `~/Library/.../Code/User/settings.json` | VS Code editor, terminal, and git settings |
 | `vscode/extensions.txt` | _(installed by install.sh)_ | Core VS Code extensions for every machine |
@@ -200,11 +200,12 @@ git commit --no-verify           # skip hooks entirely (use sparingly)
 **[mise](https://mise.jdx.dev)** — a polyglot version manager written in Rust that replaces `chruby`, `nvm`, and `pyenv` with a single tool. It manages Ruby, Node, Python, Java, Go, and dozens of other runtimes from one interface. Versions are set globally in `~/.config/mise/config.toml` and can be overridden per project using `.mise.toml`, `.ruby-version`, or `.nvmrc` — so existing projects need no changes. Activation is a single line in `zshrc` and adds ~5ms to startup. Common commands:
 
 ```sh
-mise install ruby@3.3.6   # install a specific version
-mise use node@22          # set globally
-mise use --local ruby@3.4 # set for current project only (writes .mise.toml)
-mise current              # show active versions
-mise ls                   # list all installed versions
+mise install ruby@3.3.6       # install a specific version
+mise install python@3.12      # install Python
+mise use node@22              # set globally
+mise use --local ruby@3.4     # set for current project only (writes .mise.toml)
+mise current                  # show active versions
+mise ls                       # list all installed versions
 ```
 
 This replaced `chruby` + `ruby-install` + `nvm` — three separate tools, three shell init blocks, ~500ms of startup overhead between them.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -131,10 +131,10 @@ fi
 # ------------------
 # Ruby + Node + Java via mise
 # ------------------
-info "Installing Ruby 3.3.6, Node 22, and Java 17 via mise..."
-mise install ruby@3.3.6 node@22 java@temurin-17
-mise use --global ruby@3.3.6 node@22 java@temurin-17
-success "Ruby, Node, and Java installed via mise"
+info "Installing Ruby 3.3.6, Node 22, Java 21, and Python 3.12 via mise..."
+mise install ruby@3.3.6 node@22 java@temurin-21 python@3.12
+mise use --global ruby@3.3.6 node@22 java@temurin-21 python@3.12
+success "Ruby, Node, Java, and Python installed via mise"
 
 # ------------------
 # Gems

--- a/config/mise.toml
+++ b/config/mise.toml
@@ -2,3 +2,4 @@
 node = "22"
 ruby = "3.3.6"
 java = "temurin-21"
+python = "3.12"

--- a/zshrc
+++ b/zshrc
@@ -140,15 +140,7 @@ if command -v node &>/dev/null && command -v ng &>/dev/null; then
   fi
 fi
 
-# rbenv and pyenv if installed
-if command -v rbenv >/dev/null 2>&1; then
-  eval "$(rbenv init - zsh)"
-fi
-
-if command -v pyenv >/dev/null 2>&1; then
-  eval "$(pyenv init --path)"
-fi
-
 # Machine-specific overrides (not committed to dotfiles)
 [[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
-. "$HOME/.local/bin/env"
+# uv (Python package manager) shell integration — only if installed
+[[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"


### PR DESCRIPTION
## Summary

Reconcile runtime versions across all config files, add Python 3.12 support, clean up dead code in zshrc, and harden the env file loader.

## Changes

### 1. Reconcile Java version (bug fix)
`bootstrap.sh` was installing `java@temurin-17` while `config/mise.toml` already specified `temurin-21`. Updated `bootstrap.sh` lines 134-136 to use `java@temurin-21` in both `mise install` and `mise use --global` commands, plus the info message.

### 2. Add Python to mise.toml
Added `python = "3.12"` to `config/mise.toml` under `[tools]`.

### 3. Add Python to bootstrap.sh
Added `python@3.12` to both the `mise install` and `mise use --global` commands, and updated the info/success messages to include Python.

### 4. Add maven to Brewfile
Added `brew "maven"` to the Runtime management section with comment `# Java build tool — required for Maven projects`.

### 5. Remove dead rbenv/pyenv stubs from zshrc
Removed the guarded `rbenv init` and `pyenv init` blocks — these are dead code since mise handles all runtime management now.

### 6. Guard the unprotected env file line
Replaced the bare `. "$HOME/.local/bin/env"` at the end of zshrc with a guarded version that checks for the file's existence first, preventing errors on machines without uv installed.

### 7. Update README
Updated the bootstrap step list (Java 17 → 21, added Python 3.12), added `mise install python@3.12` to the mise command examples, and updated the `config/mise.toml` row in the Dotfiles table to say `Ruby, Node, Java, Python`.
