### PR TITLE
feat: add work machine profile — Brewfile.work, rich zshrc.local template, direnv helpers

### DIFF
--- a/Brewfile.work
+++ b/Brewfile.work
@@ -1,0 +1,34 @@
+# Brewfile.work — work machine additions, layered on top of Brewfile
+#
+# This file uses a layered approach: install the shared base Brewfile first,
+# then install these work-specific additions on top.
+#
+#   brew bundle --file=~/dotfiles/Brewfile        # base (all machines)
+#   brew bundle --file=~/dotfiles/Brewfile.work   # work additions (this file)
+#
+# Keep anything that belongs on every machine in Brewfile.
+# Keep work-only tools here so personal machines stay lean.
+
+# ------------------
+# API tooling
+# ------------------
+cask "insomnia"           # GUI REST/GraphQL client
+brew "newman"             # CLI runner for API collections
+
+# ------------------
+# Database tools
+# ------------------
+brew "postgresql@16"      # PostgreSQL CLI tools (psql, pg_dump) without Postgres.app
+brew "redis"              # Redis (often needed for background jobs in Rails apps)
+
+# ------------------
+# Java / enterprise
+# ------------------
+brew "maven"              # Java build tool
+brew "gradle"             # Alternative Java build tool
+
+# ------------------
+# Infrastructure / containers
+# ------------------
+brew "kubectl"            # Kubernetes CLI
+brew "helm"               # Kubernetes package manager

--- a/README.md
+++ b/README.md
@@ -306,6 +306,60 @@ cp ~/dotfiles/zshrc.local.example ~/.zshrc.local
 # edit with this machine's specific values
 ```
 
+## Work machine setup
+
+Work machines need extra tools (API clients, database CLIs, Kubernetes, Java build tools) that don't belong on every personal Mac. This repo uses a **layered approach** to keep the base `Brewfile` lean while letting work machines opt in to additional packages.
+
+### 1. Install work-specific Homebrew packages
+
+Run the base Brewfile first, then the work overlay:
+
+```sh
+brew bundle --file=~/dotfiles/Brewfile        # shared base (all machines)
+brew bundle --file=~/dotfiles/Brewfile.work   # work additions
+```
+
+`Brewfile.work` adds: Insomnia, Newman, PostgreSQL 16 CLI tools, Redis, Maven, Gradle, kubectl, and Helm. It does **not** duplicate anything already in `Brewfile`.
+
+### 2. Create `~/.zshrc.local` from the template
+
+`zshrc.local.example` is a richly commented template covering common work-machine needs. Copy it and uncomment the sections relevant to your setup:
+
+```sh
+cp ~/dotfiles/zshrc.local.example ~/.zshrc.local
+```
+
+Includes sections for:
+- **Machine identity** — `MACHINE_NAME` for distinguishing machines
+- **Work PATH entries** — internal tooling, vendored binaries
+- **Maven aliases** — `mci`, `mvnt`, `mvninstall` with `-DskipTests`
+- **Multi-Java switching** — `use-java 17` / `use-java 21` using mise
+- **direnv examples** — sample `.envrc` with `DATABASE_URL`, `REDIS_URL`, `RAILS_ENV`
+- **Corporate proxy** — `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY`
+- **Work git email** — override the global git email for work commits
+- **Sidekiq Pro/Enterprise** — `BUNDLE_ENTERPRISE__CONTRIBSYS__COM` license key
+- **PG_CONFIG** — point at Postgres.app for native gem compilation
+
+Because `~/.zshrc.local` is in `.gitignore`, all secrets and machine-specific config stay out of the repo entirely.
+
+### 3. Global direnv helpers (`direnvrc`)
+
+`install.sh` symlinks `config/direnvrc` to `~/.config/direnv/direnvrc`. This file is sourced by direnv before every `.envrc` evaluation and provides reusable layout helpers:
+
+- **`layout python`** — auto-creates and activates a `.venv` virtualenv in the project directory
+- **`layout node`** — adds `node_modules/.bin` to `PATH` so locally-installed binaries (eslint, tsc, etc.) work without `npx`
+
+Use them in any project's `.envrc`:
+
+```sh
+# .envrc
+layout python
+layout node
+export DATABASE_URL=postgres://localhost/myapp_dev
+```
+
+Then run `direnv allow` once to approve the file.
+
 ## Making changes
 
 Because the dotfiles are symlinked, editing `~/.zshrc` (or any other dotfile)

--- a/config/direnvrc
+++ b/config/direnvrc
@@ -1,0 +1,38 @@
+# ~/.config/direnv/direnvrc — global direnv helpers
+#
+# This file is sourced by direnv before every .envrc evaluation.
+# Any function defined here is available in all .envrc files without
+# repeating the definition. Symlinked by install.sh:
+#   ~/dotfiles/config/direnvrc → ~/.config/direnv/direnvrc
+
+# layout_python — auto-create and activate a .venv virtualenv
+#
+# Usage in .envrc:
+#   layout python
+#   layout python python3.12   # use a specific Python binary
+#
+layout_python() {
+  local python="${1:-python3}"
+  local venv=".venv"
+
+  if [[ ! -d "$venv" ]]; then
+    log_status "Creating virtualenv: $venv (using $python)"
+    "$python" -m venv "$venv"
+  fi
+
+  # Activate the virtualenv
+  export VIRTUAL_ENV="$(pwd)/$venv"
+  PATH_add "$VIRTUAL_ENV/bin"
+}
+
+# layout_node — add node_modules/.bin to PATH
+#
+# Usage in .envrc:
+#   layout node
+#
+# This lets you run locally-installed binaries (eslint, prettier, tsc, etc.)
+# without npx or ./node_modules/.bin/ prefixes.
+#
+layout_node() {
+  PATH_add "node_modules/.bin"
+}

--- a/install.sh
+++ b/install.sh
@@ -82,6 +82,10 @@ fi
 mkdir -p "$HOME/.config"
 symlink "$DOTFILES_DIR/config/starship.toml" "$HOME/.config/starship.toml"
 
+# direnv global helpers (layout_python, layout_node)
+mkdir -p "$HOME/.config/direnv"
+symlink "$DOTFILES_DIR/config/direnvrc" "$HOME/.config/direnv/direnvrc"
+
 # mise global config (pinned Ruby + Node versions)
 mkdir -p "$HOME/.config/mise"
 symlink "$DOTFILES_DIR/config/mise.toml" "$HOME/.config/mise/config.toml"

--- a/zshrc.local.example
+++ b/zshrc.local.example
@@ -1,45 +1,91 @@
 # ~/.zshrc.local — machine-specific configuration
 # This file is sourced at the end of ~/.zshrc but is NOT committed to the dotfiles repo.
 # Copy to ~/.zshrc.local and fill in values for the current machine.
+#
+# cp ~/dotfiles/zshrc.local.example ~/.zshrc.local
+# Then uncomment and edit the sections that apply to this machine.
 
-# ------------------
+# ==================================================
+# Machine identity
+# ==================================================
+# Give this machine a name so scripts/prompts can distinguish it.
+# export MACHINE_NAME=work-mbp
+
+# ==================================================
+# Work-specific PATH entries
+# ==================================================
+# Add internal tooling, vendored binaries, or anything not managed by Homebrew.
+# export PATH="$PATH:/opt/internal-tools/bin"
+# export PATH="$PATH:$HOME/go/bin"
+
+# ==================================================
 # Postgres
-# ------------------
+# ==================================================
+# Point bundler / gem native extensions at Postgres.app's pg_config.
 # export PG_CONFIG=/Applications/Postgres.app/Contents/Versions/latest/bin/pg_config
 
-# ------------------
-# Extra PATH entries (tools installed outside of Homebrew)
-# ------------------
-# export PATH="$PATH:/path/to/your/tool/bin"
-
-# ------------------
-# Sidekiq Pro/Enterprise license
-# ------------------
-# export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=<your-key>
-
-# ------------------
-# Project aliases
-# ------------------
-# alias proj='cd ~/your-project'
-
-# ------------------
-# Maven (if not via Homebrew)
-# ------------------
-# export PATH="$PATH:/path/to/apache-maven/bin"
+# ==================================================
+# Maven aliases
+# ==================================================
 # alias mci='mvn clean install'
-# alias mvninstall='mvn clean install -Dmaven.test.skip=true'
 # alias mvnt='mvn clean test'
+# alias mvninstall='mvn clean install -DskipTests'
 
-# ------------------
-# Java version management
-# ------------------
-# export JAVA_8_HOME=/Library/Java/JavaVirtualMachines/...jdk/Contents/Home
-# export JAVA_17_HOME=/Library/Java/JavaVirtualMachines/...jdk/Contents/Home
+# ==================================================
+# Multi-Java switching (via mise)
+# ==================================================
+# Switch the active Java version in the current shell.
+# Relies on mise having the requested version installed:
+#   mise install java@temurin-17  &&  mise install java@temurin-21
 #
-# function use-java() {
-#   if [[ "$1" == "8" ]]; then
-#     export JAVA_HOME=$JAVA_8_HOME
-#   elif [[ "$1" == "17" ]]; then
-#     export JAVA_HOME=$JAVA_17_HOME
+# use-java() {
+#   local version="$1"
+#   if [[ -z "$version" ]]; then
+#     echo "Usage: use-java <version>  (e.g. use-java 17, use-java 21)"
+#     return 1
 #   fi
+#   mise use --global java@temurin-"$version"
+#   export JAVA_HOME="$(mise where java)"
+#   echo "Switched to Java $version — JAVA_HOME=$JAVA_HOME"
 # }
+
+# ==================================================
+# direnv — per-project environment variables
+# ==================================================
+# direnv automatically loads .envrc files when you cd into a project.
+# Example .envrc for a Rails work project:
+#
+#   export DATABASE_URL=postgres://localhost:5432/myapp_development
+#   export REDIS_URL=redis://localhost:6379/0
+#   export RAILS_ENV=development
+#
+# After creating the .envrc, run: direnv allow
+
+# ==================================================
+# Corporate proxy (uncomment if behind a proxy)
+# ==================================================
+# export HTTP_PROXY=http://proxy.corp.example.com:8080
+# export HTTPS_PROXY=http://proxy.corp.example.com:8080
+# export NO_PROXY=localhost,127.0.0.1,.corp.example.com
+
+# ==================================================
+# Work-specific git config
+# ==================================================
+# Override the global git email for work repos. This sets the default for
+# all repos; use per-repo .gitconfig or includeIf in ~/.gitconfig for
+# finer control.
+# git config --global user.email "brad@work-domain.com"
+
+# ==================================================
+# Sidekiq Pro / Enterprise license
+# ==================================================
+# Required by bundler to pull Sidekiq Pro/Enterprise gems.
+# export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=<your-license-key>
+# export BUNDLE_GEMS__CONTRIBSYS__COM=<your-license-key>
+
+# ==================================================
+# Project aliases
+# ==================================================
+# alias proj='cd ~/code/your-project'
+# alias api='cd ~/code/vets-api'
+# alias web='cd ~/code/vets-website'


### PR DESCRIPTION
## Summary

Adds a work machine profile layer to the dotfiles repo, keeping the base config lean while giving work machines a clean opt-in path for additional tools and configuration.

## Changes

### `Brewfile.work` (new)
Layered Brewfile for work-specific Homebrew packages: Insomnia, Newman, PostgreSQL 16 CLI, Redis, Maven, Gradle, kubectl, and Helm. Install after the base Brewfile — no duplication.

### `zshrc.local.example` (rewritten)
Comprehensive work-machine template with clearly commented sections for:
- Machine identity, work PATH entries, PG_CONFIG
- Maven aliases (`mci`, `mvnt`, `mvninstall`)
- Multi-Java switching via mise (`use-java 17`, `use-java 21`)
- direnv `.envrc` examples (DATABASE_URL, REDIS_URL, RAILS_ENV)
- Corporate proxy settings, work git email, Sidekiq Pro license keys

### `config/direnvrc` (new)
Global direnv helpers symlinked to `~/.config/direnv/direnvrc`:
- `layout python` — auto-creates and activates a `.venv` virtualenv
- `layout node` — adds `node_modules/.bin` to PATH

### `install.sh`
Added symlink entry for `config/direnvrc` → `~/.config/direnv/direnvrc` (with `mkdir -p`).

### `README.md`
New **Work machine setup** section documenting the layered Brewfile approach, `zshrc.local.example` contents, and `direnvrc` global helpers.