### PR TITLE
chore: remove bash_profile shim, add CI badge, add Dependabot for Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependabot"
+    commit-message:
+      prefix: "ci"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Personal macOS dotfiles for zsh, tmux, starship, git, Hyper, and a full suite of developer tooling.
 
+![CI](https://github.com/bradbergeron-us/dotfiles/actions/workflows/ci.yml/badge.svg)
+
 ## Scripts
 
 There are two scripts with distinct purposes:
@@ -265,6 +267,8 @@ For Clipboard History: assign `Cmd+Shift+V` as a direct hotkey in Settings → E
 ## Future considerations
 
 Things worth evaluating as the setup evolves.
+
+**Dependabot for GitHub Actions** — configured in `.github/dependabot.yml` to open weekly PRs that keep pinned Action versions (e.g. `actions/checkout@v4`) current. PRs are labelled `dependabot` and target `main`.
 
 **`1Password CLI` (`op`)** — if using 1Password, the CLI can serve as a secrets manager for the shell. It can inject secrets as environment variables at runtime (`op run -- your-command`) so sensitive values never need to live in `.zshrc.local` or any dotfile at all.
 

--- a/zshrc
+++ b/zshrc
@@ -8,10 +8,6 @@ export EDITOR=code
 # PATH Manipulations
 # ------------------
 
-if [ -f ~/.bash_profile ]; then
-  source ~/.bash_profile
-fi
-
 # mise — polyglot version manager (replaces chruby + nvm)
 # Reads .ruby-version and .nvmrc automatically per project
 if command -v mise &>/dev/null; then


### PR DESCRIPTION
- Remove bash-specific 'source ~/.bash_profile' block from zshrc
- Add CI status badge to README.md
- Create .github/dependabot.yml for weekly GitHub Actions updates
- Add Dependabot note to Future considerations in README
