### PR TITLE
feat: Ruby REPLs (irbrc/pryrc), TPM plugins, uv, Python venv auto-activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,8 @@ jobs:
             .zshrc .zprofile \
             .gitconfig .gitignore_global \
             .tmux.conf .hyper.js \
-            .gemrc .psqlrc .editorconfig; do
+            .gemrc .psqlrc .editorconfig \
+            .irbrc .pryrc; do
             if [[ -L "$HOME/$link" ]]; then
               echo "OK  $link"
             else

--- a/Brewfile
+++ b/Brewfile
@@ -31,6 +31,7 @@ brew "gh"             # GitHub CLI
 brew "mise"           # polyglot version manager (Ruby, Node, Python, etc.)
 brew "openssl@3"      # required for building Ruby via mise
 brew "maven"          # Java build tool — required for Maven projects
+brew "uv"             # fast Python package and project manager (replaces pip + virtualenv)
 
 # ------------------
 # Terminal multiplexer

--- a/README.md
+++ b/README.md
@@ -199,6 +199,44 @@ pre-commit autoupdate            # bump all remote hook versions to latest
 git commit --no-verify           # skip hooks entirely (use sparingly)
 ```
 
+### tmux
+**[tmux](https://github.com/tmux/tmux)** — a terminal multiplexer that lets you run multiple terminal sessions within a single window, detach from them without losing state, and restore them later. Essential for long-running processes, remote development, and keeping a structured workspace across panes and windows.
+
+This config uses `C-a` as the prefix (instead of the default `C-b`) to mirror GNU Screen muscle memory.
+
+**Key bindings (prefix = `C-a`):**
+
+| Binding | Action |
+|---|---|
+| `prefix + \` | Split pane horizontally |
+| `prefix + -` | Split pane vertically |
+| `prefix + c` | New window (remembers current path) |
+| `prefix + b` | Break pane into its own window |
+| `prefix + r` | Reload `tmux.conf` live |
+| `C-h/j/k/l` | Navigate panes (vim-aware — works across Vim splits too) |
+| `v` in copy-mode | Begin selection (vim-style) |
+| `y` in copy-mode | Copy selection to macOS clipboard |
+
+**Plugins (managed by [TPM](https://github.com/tmux-plugins/tpm)):**
+
+`bootstrap.sh` clones TPM automatically. After first install, open tmux and press `prefix + I` to install plugins.
+
+| Plugin | What it does |
+|---|---|
+| [tmux-sensible](https://github.com/tmux-plugins/tmux-sensible) | Sensible defaults everyone agrees on — fixes common papercuts |
+| [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) | Save and restore sessions across reboots. `prefix + Ctrl-s` to save, `prefix + Ctrl-r` to restore |
+| [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) | Auto-saves sessions every 15 minutes; auto-restores on tmux start |
+
+With resurrect + continuum, a machine restart no longer means losing your workspace layout — windows, panes, and working directories all come back.
+
+**Adding a new plugin:**
+```sh
+# In tmux.conf, add:
+set -g @plugin 'author/plugin-name'
+# Then in tmux:
+prefix + I   # install
+```
+
 ### Runtime management
 
 **[mise](https://mise.jdx.dev)** — a polyglot version manager written in Rust that replaces `chruby`, `nvm`, and `pyenv` with a single tool. It manages Ruby, Node, Python, Java, Go, and dozens of other runtimes from one interface. Versions are set globally in `~/.config/mise/config.toml` and can be overridden per project using `.mise.toml`, `.ruby-version`, or `.nvmrc` — so existing projects need no changes. Activation is a single line in `zshrc` and adds ~5ms to startup. Common commands:
@@ -215,6 +253,26 @@ mise ls                       # list all installed versions
 This replaced `chruby` + `ruby-install` + `nvm` — three separate tools, three shell init blocks, ~500ms of startup overhead between them.
 
 **`~/.gemrc`** — a one-line config (`gem: --no-document`) that tells Rubygems to skip generating `ri` and `rdoc` documentation on every `gem install`. This makes gem installs noticeably faster and avoids accumulating hundreds of megabytes of documentation that most developers never read locally.
+
+**[uv](https://docs.astral.sh/uv/)** — a fast Python package and project manager written in Rust by [Astral](https://astral.sh) (the same team behind `ruff`). It replaces `pip`, `virtualenv`, `pipx`, and `pip-tools` with a single tool that is 10–100× faster. Common usage:
+```sh
+uv venv                   # create .venv in the current directory
+uv pip install requests   # install into the active venv
+uv run python script.py   # run in the project's venv without activating it
+uv tool install black     # install a CLI tool globally (like pipx)
+```
+The `direnvrc` `layout_python` helper uses `uv` automatically when it's available — so `echo 'layout python' >> .envrc && direnv allow` is all you need to get an auto-activating virtualenv in any Python project.
+
+### Ruby REPLs
+
+**`~/.irbrc`** — IRB is Ruby's built-in REPL and powers `rails console`. This config enables tab completion, persistent history (2000 entries in `~/.irb_history`), auto-indent, syntax-highlighted output, and a cleaner `>>` prompt. The `q` alias exits without typing `exit` or `quit`.
+
+**`~/.pryrc`** — [Pry](https://github.com/pry/pry) is an enhanced Ruby REPL with syntax highlighting, source/doc browsing, and a debugger plugin ecosystem. It's often used as the default Rails console (`gem 'pry-rails'`). This config sets a short prompt, defines shell-like aliases (`q`, `c`/`n`/`s` for byebug stepping when `pry-byebug` is available), enables the pager for long output, and stores history in `~/.pry_history`.
+
+Install Pry once, globally:
+```sh
+gem install pry pry-byebug   # pry-rails is installed per-project via Gemfile
+```
 
 ### Database
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -144,6 +144,17 @@ mise exec ruby@3.3.6 -- gem install colorls
 success "colorls"
 
 # ------------------
+# tmux plugin manager (TPM)
+# ------------------
+if [[ ! -d "$HOME/.tmux/plugins/tpm" ]]; then
+  info "Installing tmux plugin manager (TPM)..."
+  git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" --depth=1
+  success "TPM installed — open tmux and press prefix+I to install plugins"
+else
+  success "TPM already installed"
+fi
+
+# ------------------
 # git-lfs
 # ------------------
 git lfs install --skip-repo

--- a/config/direnvrc
+++ b/config/direnvrc
@@ -16,13 +16,20 @@ layout_python() {
   local venv=".venv"
 
   if [[ ! -d "$venv" ]]; then
-    log_status "Creating virtualenv: $venv (using $python)"
-    "$python" -m venv "$venv"
+    if command -v uv &>/dev/null; then
+      # uv is ~10-100x faster than python -m venv
+      log_status "Creating virtualenv with uv: $venv"
+      uv venv "$venv" --python "$python" 2>/dev/null || uv venv "$venv"
+    else
+      log_status "Creating virtualenv: $venv (using $python)"
+      "$python" -m venv "$venv"
+    fi
   fi
 
-  # Activate the virtualenv
   export VIRTUAL_ENV="$(pwd)/$venv"
   PATH_add "$VIRTUAL_ENV/bin"
+  # Tell pip and uv where the venv is
+  export UV_PROJECT_ENVIRONMENT="$VIRTUAL_ENV"
 }
 
 # layout_node — add node_modules/.bin to PATH

--- a/install.sh
+++ b/install.sh
@@ -47,6 +47,10 @@ symlink "$DOTFILES_DIR/gitignore_global" "$HOME/.gitignore_global"
 # Ruby — skip docs on every gem install
 symlink "$DOTFILES_DIR/gemrc" "$HOME/.gemrc"
 
+# Ruby REPL defaults (IRB + Pry)
+symlink "$DOTFILES_DIR/irbrc" "$HOME/.irbrc"
+symlink "$DOTFILES_DIR/pryrc" "$HOME/.pryrc"
+
 # PostgreSQL client defaults (pairs with Postgres.app)
 symlink "$DOTFILES_DIR/psqlrc" "$HOME/.psqlrc"
 

--- a/irbrc
+++ b/irbrc
@@ -1,0 +1,21 @@
+# ~/.irbrc — IRB (Interactive Ruby) configuration
+# Applies to `irb` and `rails console` (which uses IRB under the hood).
+
+require 'irb/completion'  # tab completion for methods and constants
+
+# Persistent history across sessions
+IRB.conf[:SAVE_HISTORY] = 2000
+IRB.conf[:HISTORY_FILE]  = "#{Dir.home}/.irb_history"
+
+# Quality-of-life settings
+IRB.conf[:AUTO_INDENT]  = true   # auto-indent multi-line expressions
+IRB.conf[:USE_COLORIZE] = true   # syntax-highlighted output (IRB 1.3+)
+IRB.conf[:PROMPT_MODE]  = :SIMPLE  # cleaner prompt: >> instead of irb(main):001:0>
+
+# Shorter aliases for frequent operations
+# `q` to exit without typing `exit` or `quit`
+if defined?(IRB::Context)
+  IRB::Context.class_eval do
+    alias_method :q, :exit
+  end
+end

--- a/pryrc
+++ b/pryrc
@@ -1,0 +1,27 @@
+# ~/.pryrc — Pry REPL configuration
+# Pry is an enhanced Ruby REPL with syntax highlighting, source browsing,
+# and a plugin ecosystem. Used as the default Rails console in many setups.
+# Install: gem install pry pry-byebug pry-rails
+
+# Colour and editor
+Pry.config.color  = true
+Pry.config.editor = ENV.fetch('EDITOR', 'vim')
+
+# Shorter prompt: `[1] pry> ` instead of `[1] pry(main)> `
+Pry.config.prompt_name = 'pry'
+
+# Aliases — feel like the shell
+Pry.commands.alias_command 'q',  'exit'
+Pry.commands.alias_command 'e',  'exit'
+Pry.commands.alias_command 'c',  'continue' rescue nil  # needs pry-byebug
+Pry.commands.alias_command 'n',  'next'     rescue nil
+Pry.commands.alias_command 's',  'step'     rescue nil
+
+# Pager — use bat for syntax-highlighted output if available
+if system('command -v bat > /dev/null 2>&1')
+  Pry.config.pager = true
+end
+
+# History
+Pry.config.history_save = true
+Pry.config.history_file = File.expand_path('~/.pry_history')

--- a/tmux.conf
+++ b/tmux.conf
@@ -90,3 +90,32 @@ set-option -g pane-border-style fg=colour238
 
 set-window-option -g window-status-format '#[bg=colour238]#[fg=colour107] #I #[bg=colour239]#[fg=colour110] #[bg=colour240]#W#[bg=colour239]#[fg=colour195]#F#[bg=colour238] '
 set-window-option -g window-status-current-format '#[bg=colour236]#[fg=colour215] #I #[bg=colour235]#[fg=colour167] #[bg=colour234]#W#[bg=colour235]#[fg=colour195]#F#[bg=colour236] '
+
+# ---------#
+# Plugins  #
+# ---------#
+# TPM — Tmux Plugin Manager
+# First-time setup: git clone https://github.com/tmux-plugins/tpm ~/.tmux/plugins/tpm
+# (bootstrap.sh does this automatically)
+#
+# Key bindings (after tmux is running):
+#   prefix + I        install new plugins
+#   prefix + U        update all plugins
+#   prefix + alt + u  remove unused plugins
+
+set -g @plugin 'tmux-plugins/tpm'
+set -g @plugin 'tmux-plugins/tmux-sensible'    # sensible defaults everyone can agree on
+set -g @plugin 'tmux-plugins/tmux-resurrect'   # persist sessions across reboots
+set -g @plugin 'tmux-plugins/tmux-continuum'   # auto-save sessions every 15 min
+
+# tmux-resurrect: save/restore key bindings
+# prefix + Ctrl-s  → save session
+# prefix + Ctrl-r  → restore session
+set -g @resurrect-capture-pane-contents 'on'   # restore pane contents too
+
+# tmux-continuum: auto-save and auto-restore
+set -g @continuum-restore 'on'                  # restore last saved session on tmux start
+set -g @continuum-save-interval '15'            # save every 15 minutes
+
+# IMPORTANT: keep this line at the very bottom of tmux.conf
+run '~/.tmux/plugins/tpm/tpm'


### PR DESCRIPTION
## What this adds

### Ruby REPL defaults
- **`irbrc`** → `~/.irbrc` — tab completion, 2000-entry persistent history, syntax-highlighted output, auto-indent, cleaner `>>` prompt, `q` alias to exit. Applies to `irb` and `rails console`.
- **`pryrc`** → `~/.pryrc` — color, short prompt, shell-like aliases (`q`, `c`/`n`/`s` for [pry-byebug](https://github.com/deivid-rodriguez/pry-byebug) stepping), bat pager, persistent history. Works immediately after `gem install pry pry-byebug`.

### tmux plugin manager (TPM)
- Added [TPM](https://github.com/tmux-plugins/tpm) block to `tmux.conf` with three plugins:
  - [tmux-sensible](https://github.com/tmux-plugins/tmux-sensible) — sane defaults
  - [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) — save/restore sessions across reboots (`prefix+Ctrl-s` / `prefix+Ctrl-r`)
  - [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) — auto-save every 15 min + auto-restore on tmux start
- `bootstrap.sh` now clones TPM automatically — no manual setup needed

### uv — fast Python package manager
- Added `brew "uv"` to [Brewfile](https://docs.astral.sh/uv/) — replaces `pip` + `virtualenv` + `pipx` with one tool that is 10–100× faster
- `config/direnvrc` `layout_python` helper now prefers `uv venv` when available, falls back to `python3 -m venv`. Also exports `UV_PROJECT_ENVIRONMENT` so both `pip` and `uv` find the venv.

### CI + install.sh
- `install.sh`: symlinks `irbrc` and `pryrc` to `~/.irbrc` / `~/.pryrc`
- `ci.yml` smoke test: `.irbrc` and `.pryrc` added to the verified symlinks list

### README
- New **tmux** section: key bindings table, TPM setup instructions, plugin descriptions
- New **Ruby REPLs** section: irbrc and pryrc usage
- New **uv** entry in Runtime management with common commands