### PR TITLE
ux: bootstrap step counter + colors + elapsed time; install summary + short paths

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -20,10 +20,11 @@ brew "fd"             # faster find
 # ------------------
 # Git
 # ------------------
-brew "git-lfs"        # large file storage
-brew "git-delta"      # syntax-highlighted diffs
-brew "lazygit"        # terminal UI for git
-brew "gh"             # GitHub CLI
+brew "git-lfs"                  # large file storage
+brew "git-delta"               # syntax-highlighted diffs
+brew "lazygit"                 # terminal UI for git
+brew "gh"                      # GitHub CLI
+brew "git-credential-manager" # cross-platform credential helper — GitHub, GitHub Enterprise, Bitbucket
 
 # ------------------
 # Runtime management

--- a/Brewfile
+++ b/Brewfile
@@ -20,7 +20,7 @@ brew "fd"             # faster find
 # ------------------
 # Git
 # ------------------
-brew "git-lfs"                  # large file storage
+brew "git-lfs"                 # large file storage
 brew "git-delta"               # syntax-highlighted diffs
 brew "lazygit"                 # terminal UI for git
 brew "gh"                      # GitHub CLI

--- a/Brewfile
+++ b/Brewfile
@@ -53,6 +53,8 @@ brew "watch"          # re-run a command on an interval (e.g. watch kubectl get 
 brew "direnv"         # per-directory environment variables via .envrc files
 brew "newman"         # CLI runner for Insomnia/Postman collections (useful in CI)
 brew "redis"          # in-memory data store — background jobs (Sidekiq), caching, sessions
+brew "imagemagick"    # image conversion and manipulation (resize, crop, format conversion)
+brew "pdftk-java"     # PDF toolkit — merge, split, fill forms, extract pages
 
 # ------------------
 # Fonts

--- a/Brewfile
+++ b/Brewfile
@@ -51,7 +51,8 @@ brew "tldr"           # simplified man pages (community-maintained examples)
 brew "httpie"         # human-friendly HTTP client (replaces curl for interactive use)
 brew "watch"          # re-run a command on an interval (e.g. watch kubectl get pods)
 brew "direnv"         # per-directory environment variables via .envrc files
-brew "newman"             # CLI runner for Insomnia/Postman collections (useful in CI)
+brew "newman"         # CLI runner for Insomnia/Postman collections (useful in CI)
+brew "redis"          # in-memory data store — background jobs (Sidekiq), caching, sessions
 
 # ------------------
 # Fonts

--- a/Brewfile.work
+++ b/Brewfile.work
@@ -10,22 +10,10 @@
 # Keep work-only tools here so personal machines stay lean.
 
 # ------------------
-# API tooling
-# ------------------
-cask "insomnia"           # GUI REST/GraphQL client
-brew "newman"             # CLI runner for API collections
-
-# ------------------
-# Database tools
-# ------------------
-brew "postgresql@16"      # PostgreSQL CLI tools (psql, pg_dump) without Postgres.app
-brew "redis"              # Redis (often needed for background jobs in Rails apps)
-
-# ------------------
 # Java / enterprise
 # ------------------
-brew "maven"              # Java build tool
-brew "gradle"             # Alternative Java build tool
+# maven is in the base Brewfile — only gradle is work-specific
+brew "gradle"             # Alternative Java build tool (Groovy/Kotlin DSL build system)
 
 # ------------------
 # Infrastructure / containers

--- a/README.md
+++ b/README.md
@@ -42,6 +42,81 @@ zsh ~/dotfiles/install.sh
 
 Re-symlinks everything. Safe to run repeatedly — already-correct symlinks are skipped; existing files are backed up to `~/.dotfiles_backup/<timestamp>/`.
 
+### Terminal preview
+
+<details>
+<summary>What bootstrap.sh looks like when it runs</summary>
+
+```
+  🚀  dotfiles bootstrap  —  macOS developer setup
+  ─────────────────────────────────────────────────
+  Machine  Brad's MacBook Pro
+  Date     Mon Jun 01 2026  08:00
+  ─────────────────────────────────────────────────
+
+  ▸ [1/13]  🛠️  Xcode Command Line Tools
+  ✓ Xcode CLI Tools
+
+  ▸ [2/13]  🍺  Homebrew
+  ✓ Homebrew 4.5.2
+
+  ▸ [3/13]  📦  Packages (brew bundle)
+  → Installing packages from Brewfile...
+  ✓ Brew packages installed
+
+  ▸ [4/13]  🔍  fzf shell integration
+  ✓ fzf configured
+
+  ▸ [5/13]  🔑  SSH key for commit signing
+  ✓ SSH key already exists at ~/.ssh/id_ed25519 — skipping
+
+  ▸ [6/13]  🐙  GitHub CLI authentication
+  ✓ GitHub CLI already authenticated
+
+  ▸ [7/13]  ⚡  Runtimes via mise  (Ruby · Node · Java · Python · Go)
+  → Installing Ruby, Node, Java, Python, and Go via mise...
+  ✓ Ruby, Node, Java, Python, and Go installed via mise
+
+  ▸ [8/13]  💎  Ruby gems
+  ✓ colorls
+
+  ▸ [9/13]  🦀  Rust (rustup)
+  ✓ rustup already installed: rustc 1.86.0
+
+  ▸ [10/13]  🖥️  tmux plugin manager (TPM)
+  ✓ TPM already installed
+
+  ▸ [11/13]  📁  git-lfs
+  ✓ git-lfs
+
+  ▸ [12/13]  🔗  Dotfile symlinks
+
+  🔗  dotfiles  ─  symlinking from ~/dotfiles
+  ─────────────────────────────────────────────────
+  ✓  current   ~/.zshrc
+  ✓  current   ~/.gitconfig
+  ✓  linked    ~/.irbrc
+  ✓  linked    ~/.pryrc
+  ...
+  ─────────────────────────────────────────────────
+  ✓  3 linked  ·  14 current  ·  0 backed up
+  🎉  Done — open a new shell or: source ~/.zshrc
+
+  ▸ [13/13]  ⚙️  macOS developer defaults
+  Apply recommended macOS defaults? [y/N]: y
+
+  ─────────────────────────────────────────────────
+  🎉  Bootstrap complete  in 4m 23s
+  ─────────────────────────────────────────────────
+
+  Next steps
+  1. Edit ~/.zshrc.local with machine-specific config
+  2. Open a new terminal  (or: source ~/.zshrc)
+  3. Install Hyper: https://hyper.is
+```
+
+</details>
+
 ---
 
 ## Dotfiles
@@ -111,6 +186,9 @@ Quick reference — [full descriptions, rationale, and usage in docs/tools.md](d
 | [watch](https://linux.die.net/man/1/watch) | Re-run a command on an interval |
 | [direnv](https://direnv.net) | Per-directory env vars via `.envrc` — auto-loads on `cd` |
 | [newman](https://github.com/postmanlabs/newman) | CLI runner for Insomnia/Postman collections |
+| [redis](https://redis.io) | In-memory data store — background jobs, caching, sessions |
+| [imagemagick](https://imagemagick.org) | Image conversion — resize, crop, format conversion |
+| [pdftk-java](https://gitlab.com/pdftk-java/pdftk) | PDF toolkit — merge, split, fill forms, extract pages |
 | [pre-commit](https://pre-commit.com) | Git hook framework — templates for Ruby, JS, Java |
 
 ### Runtime Management

--- a/README.md
+++ b/README.md
@@ -93,14 +93,14 @@ Re-symlinks everything. Safe to run repeatedly — already-correct symlinks are 
 
   🔗  dotfiles  ─  symlinking from ~/dotfiles
   ─────────────────────────────────────────────────
-  ✓  current   ~/.zshrc
-  ✓  current   ~/.gitconfig
-  ✓  linked    ~/.irbrc
-  ✓  linked    ~/.pryrc
+  ✓ current   ~/.zshrc
+  ✓ current   ~/.gitconfig
+  ✓ linked    ~/.irbrc
+  ✓ linked    ~/.pryrc
   ...
   ─────────────────────────────────────────────────
-  ✓  3 linked  ·  14 current  ·  0 backed up
-  🎉  Done — open a new shell or: source ~/.zshrc
+  ✓ 3 linked  ·  14 current  ·  0 backed up
+  ✓ 🎉  Done — open a new shell or: source ~/.zshrc
 
   ▸ [13/13]  ⚙️  macOS developer defaults
   Apply recommended macOS defaults? [y/N]: y
@@ -174,6 +174,7 @@ Quick reference — [full descriptions, rationale, and usage in docs/tools.md](d
 | [git-delta](https://github.com/dandavison/delta) | Syntax-highlighted diffs for `git diff`, `log`, `show` |
 | [lazygit](https://github.com/jesseduffield/lazygit) | Terminal UI for git — rebase, cherry-pick, staged hunks |
 | [gh](https://cli.github.com) | GitHub CLI — PRs, issues, Actions from the terminal |
+| [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) | Cross-platform credential helper — GitHub, GitHub Enterprise, Bitbucket from one machine |
 
 ### Utilities
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -134,10 +134,9 @@ else
 fi
 
 step "⚡  Runtimes via mise  (Ruby · Node · Java · Python · Go)"
-info "Installing Ruby, Node, Java, Python, and Go via mise..."
 mise install ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
 mise use --global ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
-success "Ruby, Node, Java, Python, and Go installed via mise"
+success "Ruby 3.3.6 · Node 22 · Java 21 · Python 3.12 · Go 1.24  (via mise)"
 
 step "💎  Ruby gems"
 info "Installing colorls..."
@@ -207,7 +206,7 @@ fi
 
 step "📁  git-lfs"
 git lfs install --skip-repo
-success "git-lfs"
+success "git-lfs configured (large file pointer tracking enabled globally)"
 
 step "🔗  Dotfile symlinks"
 zsh "$DOTFILES_DIR/install.sh"
@@ -219,11 +218,22 @@ fi
 
 step "⚙️  macOS developer defaults"
 echo ""
-read -rp "  Apply recommended macOS defaults? (key repeat, Dock, Finder, screenshots) [y/N] " apply_macos
+printf "  Will apply:\n"
+printf "  • Keyboard   — fast key repeat, disable autocorrect & smart quotes\n"
+printf "  • Trackpad   — enable tap-to-click\n"
+printf "  • Finder     — show hidden files & all extensions, path bar, list view\n"
+printf "  • Dock       — auto-hide, instant animation, no recent apps\n"
+printf "  • Screenshots → ~/Desktop/screenshots/ (PNG, no shadow)\n"
+printf "  • TextEdit   — plain text mode by default\n"
+printf "  • Mission Control — faster animation, don't rearrange Spaces\n"
+echo ""
+read -rp "  Apply these settings? [y/N] " apply_macos
 if [[ "$apply_macos" =~ ^[Yy]$ ]]; then
   bash "$DOTFILES_DIR/macos.sh"
+  success "macOS defaults applied — Finder and Dock restarted automatically"
+  warn "Key repeat and trackpad changes take full effect after logout"
 else
-  info "Skipped macOS defaults. Run manually later: bash ~/dotfiles/macos.sh"
+  info "Skipped. Run manually any time: bash ~/dotfiles/macos.sh"
 fi
 
 _elapsed=$(( SECONDS - BOOTSTRAP_START ))

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,14 +5,40 @@
 set -euo pipefail
 
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+BOOTSTRAP_START=$SECONDS
+STEP=0
+TOTAL_STEPS=13
 
-info()    { echo "[info]  $*"; }
-success() { echo "[ok]    $*"; }
-warn()    { echo "[warn]  $*"; }
+# ── Colors (disabled when not attached to a terminal) ────────────────────────
+if [[ -t 1 ]]; then
+  RESET='\033[0m';  BOLD='\033[1m';   DIM='\033[2m'
+  GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'
+  RED='\033[0;31m';   BLUE='\033[1;34m'
+else
+  RESET=''; BOLD=''; DIM=''; GREEN=''; YELLOW=''; CYAN=''; RED=''; BLUE=''
+fi
 
-# ------------------
-# Xcode CLI Tools
-# ------------------
+info()    { printf "${CYAN}  [info]${RESET}   %s\n" "$*"; }
+success() { printf "${GREEN}  [ok]${RESET}     %s\n" "$*"; }
+warn()    { printf "${YELLOW}  [warn]${RESET}   %s\n" "$*"; }
+error()   { printf "${RED}  [error]${RESET}  %s\n" "$*" >&2; }
+
+step() {
+  STEP=$((STEP + 1))
+  echo ""
+  printf "${BOLD}${BLUE}  ▸ [%d/%d]  %s${RESET}\n" "$STEP" "$TOTAL_STEPS" "$*"
+}
+
+# ── Startup banner ───────────────────────────────────────────────────────────
+echo ""
+printf "${BOLD}  dotfiles bootstrap${RESET}  —  macOS developer setup\n"
+echo "  ─────────────────────────────────────────────────"
+printf "  ${DIM}Machine${RESET}  %s\n" "$(scutil --get ComputerName 2>/dev/null || hostname)"
+printf "  ${DIM}Date${RESET}     %s\n" "$(date '+%a %b %d %Y  %H:%M')"
+echo "  ─────────────────────────────────────────────────"
+
+# ── Steps ─────────────────────────────────────────────────────────────────────
+step "Xcode Command Line Tools"
 if ! xcode-select -p &>/dev/null; then
   info "Installing Xcode Command Line Tools..."
   xcode-select --install
@@ -22,9 +48,7 @@ if ! xcode-select -p &>/dev/null; then
 fi
 success "Xcode CLI Tools"
 
-# ------------------
-# Homebrew
-# ------------------
+step "Homebrew"
 if ! command -v brew &>/dev/null; then
   info "Installing Homebrew..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -34,29 +58,20 @@ if ! command -v brew &>/dev/null; then
 fi
 success "Homebrew $(brew --version | head -1)"
 
-# ------------------
-# Brew packages (Brewfile)
-# ------------------
+step "Packages (brew bundle)"
 info "Installing packages from Brewfile..."
 brew bundle --file="$DOTFILES_DIR/Brewfile"
 success "Brew packages installed"
 
-# fzf shell integration (key bindings + completion)
+step "fzf shell integration"
 info "Setting up fzf shell integration..."
 "$(brew --prefix)/opt/fzf/install" --key-bindings --completion --no-update-rc --no-bash --no-fish
 success "fzf configured"
 
-# ------------------
-# SSH key for commit signing
-# ------------------
+step "SSH key for commit signing"
 echo ""
-echo "============================================"
-echo "  Git Commit Signing Setup"
-echo "============================================"
-echo ""
-echo "Every commit will be cryptographically signed with your SSH key."
-echo "GitHub shows a 'Verified' badge on signed commits, proving they"
-echo "actually came from you and weren't tampered with."
+printf "${DIM}  Every commit will be signed with your SSH key. GitHub shows a\n"
+printf "  'Verified' badge proving it actually came from you.${RESET}\n"
 echo ""
 
 if [[ -f "$HOME/.ssh/id_ed25519" ]]; then
@@ -85,67 +100,45 @@ else
   pbcopy < "$HOME/.ssh/id_ed25519.pub"
 
   echo ""
-  echo "============================================"
-  echo "  ACTION REQUIRED: Add your key to GitHub"
-  echo "============================================"
+  printf "${BOLD}  Action required: add your key to GitHub${RESET}\n"
   echo ""
-  echo "Your public key has been copied to your clipboard."
+  printf "  Your public key is ${GREEN}already on your clipboard${RESET}. Go to:\n"
+  printf "  ${CYAN}  https://github.com/settings/ssh/new${RESET}\n"
   echo ""
-  echo "Follow these steps to register it with GitHub:"
+  printf "  Title:    e.g. 'MacBook Pro — commit signing'\n"
+  printf "  Key type: ${BOLD}Signing Key${RESET}  ← not Authentication Key\n"
+  printf "  Key:      paste from clipboard\n"
   echo ""
-  echo "  1. Open this URL in your browser:"
-  echo "     https://github.com/settings/ssh/new"
-  echo ""
-  echo "  2. Fill in the form:"
-  echo "     • Title:    give it a name like 'MacBook Pro - commit signing'"
-  echo "     • Key type: Signing Key  ← important, not Authentication Key"
-  echo "     • Key:      paste from clipboard (already copied)"
-  echo ""
-  echo "  3. Click 'Add SSH key'"
-  echo ""
-  echo "Your public key (also in clipboard):"
+  printf "  Your public key (also on clipboard):\n"
   echo ""
   cat "$HOME/.ssh/id_ed25519.pub"
   echo ""
   read -rp "Press Enter once you've added the key to GitHub to continue..."
 fi
 
-# ------------------
-# GitHub CLI auth
-# ------------------
+step "GitHub CLI authentication"
 if ! gh auth status &>/dev/null; then
   echo ""
-  echo "============================================"
-  echo "  GitHub CLI Authentication"
-  echo "============================================"
-  echo ""
-  echo "gh (GitHub CLI) is installed but not authenticated."
-  echo "You'll need this for creating PRs, managing issues,"
-  echo "and the SSH signing key step later."
+  printf "  ${DIM}gh is installed but not authenticated. You'll need this for\n"
+  printf "  creating PRs, managing issues, and interacting with GitHub.${RESET}\n"
   echo ""
   gh auth login
 else
   success "GitHub CLI already authenticated"
 fi
 
-# ------------------
-# Runtimes via mise (Ruby, Node, Java, Python, Go)
-# ------------------
+step "Runtimes via mise  (Ruby · Node · Java · Python · Go)"
 info "Installing Ruby, Node, Java, Python, and Go via mise..."
 mise install ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
 mise use --global ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
 success "Ruby, Node, Java, Python, and Go installed via mise"
 
-# ------------------
-# Gems
-# ------------------
+step "Ruby gems"
 info "Installing colorls..."
 mise exec ruby@3.3.6 -- gem install colorls
 success "colorls"
 
-# ------------------
-# Rust via rustup
-# ------------------
+step "Rust (rustup)"
 # Note: we check for `rustup`, NOT `rustc` — a system/Homebrew rustc does not
 # give you toolchain management (stable/nightly/components). rustup does.
 # If `brew install rust` (the static formula) is present alongside rustup,
@@ -201,9 +194,7 @@ if [[ -d "$_nvm_dir" ]]; then
 fi
 unset _nvm_dir _nvm_count
 
-# ------------------
-# tmux plugin manager (TPM)
-# ------------------
+step "tmux plugin manager (TPM)"
 if [[ ! -d "$HOME/.tmux/plugins/tpm" ]]; then
   info "Installing tmux plugin manager (TPM)..."
   git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" --depth=1
@@ -212,42 +203,38 @@ else
   success "TPM already installed"
 fi
 
-# ------------------
-# git-lfs
-# ------------------
+step "git-lfs"
 git lfs install --skip-repo
 success "git-lfs"
 
-# ------------------
-# Symlink dotfiles
-# ------------------
-info "Symlinking dotfiles..."
+step "Dotfile symlinks"
 zsh "$DOTFILES_DIR/install.sh"
 
-# ------------------
-# Local overrides
-# ------------------
 if [[ ! -f "$HOME/.zshrc.local" ]]; then
   cp "$DOTFILES_DIR/zshrc.local.example" "$HOME/.zshrc.local"
-  warn "Created ~/.zshrc.local from template — edit it to add machine-specific config."
+  warn "Created ~/.zshrc.local from template — edit it with machine-specific config"
 fi
 
-# ------------------
-# macOS defaults
-# ------------------
+step "macOS developer defaults"
 echo ""
-read -rp "Apply recommended macOS developer defaults? (key repeat, Dock, Finder, etc.) [y/N] " apply_macos
+read -rp "  Apply recommended macOS defaults? (key repeat, Dock, Finder, screenshots) [y/N] " apply_macos
 if [[ "$apply_macos" =~ ^[Yy]$ ]]; then
   bash "$DOTFILES_DIR/macos.sh"
 else
   info "Skipped macOS defaults. Run manually later: bash ~/dotfiles/macos.sh"
 fi
 
+_elapsed=$(( SECONDS - BOOTSTRAP_START ))
+_mins=$(( _elapsed / 60 ))
+_secs=$(( _elapsed % 60 ))
+
 echo ""
-success "Bootstrap complete!"
+echo "  ─────────────────────────────────────────────────"
+printf "${GREEN}${BOLD}  Bootstrap complete${RESET}  in %dm %ds\n" "$_mins" "$_secs"
+echo "  ─────────────────────────────────────────────────"
 echo ""
-echo "Next steps:"
-echo "  1. Edit ~/.zshrc.local with any machine-specific config"
-echo "  2. Open a new terminal (or run: source ~/.zshrc)"
-echo "  3. Install Hyper (not in Homebrew): https://hyper.is"
-echo "  4. VS Code, Postgres.app, DBeaver, and fonts were installed via Brewfile"
+printf "  ${BOLD}Next steps${RESET}\n"
+printf "  1. Edit ${CYAN}~/.zshrc.local${RESET} with machine-specific config\n"
+printf "  2. Open a new terminal  (or: ${CYAN}source ~/.zshrc${RESET})\n"
+printf "  3. Install Hyper (not in Homebrew): ${CYAN}https://hyper.is${RESET}\n"
+echo ""

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -13,15 +13,14 @@ TOTAL_STEPS=13
 if [[ -t 1 ]]; then
   RESET='\033[0m';  BOLD='\033[1m';   DIM='\033[2m'
   GREEN='\033[0;32m'; YELLOW='\033[0;33m'; CYAN='\033[0;36m'
-  RED='\033[0;31m';   BLUE='\033[1;34m'
+  BLUE='\033[1;34m'
 else
-  RESET=''; BOLD=''; DIM=''; GREEN=''; YELLOW=''; CYAN=''; RED=''; BLUE=''
+  RESET=''; BOLD=''; DIM=''; GREEN=''; YELLOW=''; CYAN=''; BLUE=''
 fi
 
 info()    { printf "${CYAN}  → %s${RESET}\n" "$*"; }
 success() { printf "${GREEN}  ✓ %s${RESET}\n" "$*"; }
 warn()    { printf "${YELLOW}  ⚠ %s${RESET}\n" "$*"; }
-error()   { printf "${RED}  ✗ %s${RESET}\n" "$*" >&2; }
 
 step() {
   STEP=$((STEP + 1))
@@ -112,7 +111,7 @@ else
   echo ""
   cat "$HOME/.ssh/id_ed25519.pub"
   echo ""
-  read -rp "Press Enter once you've added the key to GitHub to continue..."
+  read -rp "  Press Enter once you've added the key to GitHub to continue... "
 fi
 
 step "🐙  GitHub CLI authentication"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,10 +18,10 @@ else
   RESET=''; BOLD=''; DIM=''; GREEN=''; YELLOW=''; CYAN=''; RED=''; BLUE=''
 fi
 
-info()    { printf "${CYAN}  [info]${RESET}   %s\n" "$*"; }
-success() { printf "${GREEN}  [ok]${RESET}     %s\n" "$*"; }
-warn()    { printf "${YELLOW}  [warn]${RESET}   %s\n" "$*"; }
-error()   { printf "${RED}  [error]${RESET}  %s\n" "$*" >&2; }
+info()    { printf "${CYAN}  → %s${RESET}\n" "$*"; }
+success() { printf "${GREEN}  ✓ %s${RESET}\n" "$*"; }
+warn()    { printf "${YELLOW}  ⚠ %s${RESET}\n" "$*"; }
+error()   { printf "${RED}  ✗ %s${RESET}\n" "$*" >&2; }
 
 step() {
   STEP=$((STEP + 1))
@@ -31,14 +31,14 @@ step() {
 
 # ── Startup banner ───────────────────────────────────────────────────────────
 echo ""
-printf "${BOLD}  dotfiles bootstrap${RESET}  —  macOS developer setup\n"
+printf "${BOLD}  🚀  dotfiles bootstrap${RESET}  —  macOS developer setup\n"
 echo "  ─────────────────────────────────────────────────"
 printf "  ${DIM}Machine${RESET}  %s\n" "$(scutil --get ComputerName 2>/dev/null || hostname)"
 printf "  ${DIM}Date${RESET}     %s\n" "$(date '+%a %b %d %Y  %H:%M')"
 echo "  ─────────────────────────────────────────────────"
 
 # ── Steps ─────────────────────────────────────────────────────────────────────
-step "Xcode Command Line Tools"
+step "🛠️  Xcode Command Line Tools"
 if ! xcode-select -p &>/dev/null; then
   info "Installing Xcode Command Line Tools..."
   xcode-select --install
@@ -48,7 +48,7 @@ if ! xcode-select -p &>/dev/null; then
 fi
 success "Xcode CLI Tools"
 
-step "Homebrew"
+step "🍺  Homebrew"
 if ! command -v brew &>/dev/null; then
   info "Installing Homebrew..."
   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
@@ -58,17 +58,17 @@ if ! command -v brew &>/dev/null; then
 fi
 success "Homebrew $(brew --version | head -1)"
 
-step "Packages (brew bundle)"
+step "📦  Packages (brew bundle)"
 info "Installing packages from Brewfile..."
 brew bundle --file="$DOTFILES_DIR/Brewfile"
 success "Brew packages installed"
 
-step "fzf shell integration"
+step "🔍  fzf shell integration"
 info "Setting up fzf shell integration..."
 "$(brew --prefix)/opt/fzf/install" --key-bindings --completion --no-update-rc --no-bash --no-fish
 success "fzf configured"
 
-step "SSH key for commit signing"
+step "🔑  SSH key for commit signing"
 echo ""
 printf "${DIM}  Every commit will be signed with your SSH key. GitHub shows a\n"
 printf "  'Verified' badge proving it actually came from you.${RESET}\n"
@@ -77,15 +77,14 @@ echo ""
 if [[ -f "$HOME/.ssh/id_ed25519" ]]; then
   success "SSH key already exists at ~/.ssh/id_ed25519 — skipping generation"
 else
-  echo "No SSH key found. A new Ed25519 key will be generated now."
+  printf "  No SSH key found — a new Ed25519 key will be generated now.\n"
   echo ""
-  echo "You will be asked for a passphrase. Recommendations:"
-  echo "  • Setting a passphrase is more secure (recommended)"
-  echo "  • macOS Keychain will remember it after the first use"
-  echo "    so you won't be prompted on every commit"
-  echo "  • Press Enter twice to skip (less secure but simpler)"
+  printf "  Passphrase recommendations:\n"
+  printf "  • Setting one is more secure (recommended)\n"
+  printf "  • macOS Keychain remembers it after first use\n"
+  printf "  • Press Enter twice to skip (less secure but simpler)\n"
   echo ""
-  read -rp "Press Enter to continue and generate your SSH key..."
+  read -rp "  Press Enter to generate your SSH key... "
 
   mkdir -p "$HOME/.ssh"
   chmod 700 "$HOME/.ssh"
@@ -116,7 +115,7 @@ else
   read -rp "Press Enter once you've added the key to GitHub to continue..."
 fi
 
-step "GitHub CLI authentication"
+step "🐙  GitHub CLI authentication"
 if ! gh auth status &>/dev/null; then
   echo ""
   printf "  ${DIM}gh is installed but not authenticated. You'll need this for\n"
@@ -127,18 +126,18 @@ else
   success "GitHub CLI already authenticated"
 fi
 
-step "Runtimes via mise  (Ruby · Node · Java · Python · Go)"
+step "⚡  Runtimes via mise  (Ruby · Node · Java · Python · Go)"
 info "Installing Ruby, Node, Java, Python, and Go via mise..."
 mise install ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
 mise use --global ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
 success "Ruby, Node, Java, Python, and Go installed via mise"
 
-step "Ruby gems"
+step "💎  Ruby gems"
 info "Installing colorls..."
 mise exec ruby@3.3.6 -- gem install colorls
 success "colorls"
 
-step "Rust (rustup)"
+step "🦀  Rust (rustup)"
 # Note: we check for `rustup`, NOT `rustc` — a system/Homebrew rustc does not
 # give you toolchain management (stable/nightly/components). rustup does.
 # If `brew install rust` (the static formula) is present alongside rustup,
@@ -160,13 +159,9 @@ else
   success "rustup already installed: $(rustc --version 2>/dev/null || echo 'rustc not yet in PATH')"
 fi
 
-# ------------------
-# NVM → mise migration
-# ------------------
-# mise handles Node. If NVM is installed, detect whether it has versions:
-#   - Empty/ghost install → offer to remove it automatically
-#   - Has versions installed → warn and show migration steps (do NOT remove)
+# NVM migration check (conditional — runs only if ~/.nvm exists)
 _nvm_dir="${NVM_DIR:-$HOME/.nvm}"
+[[ -d "$_nvm_dir" ]] && info "NVM detected — checking migration status..."
 if [[ -d "$_nvm_dir" ]]; then
   _nvm_count=$(ls "$_nvm_dir/versions/node/" 2>/dev/null | wc -l | tr -d ' ')
   if [[ "${_nvm_count:-0}" -eq 0 ]]; then
@@ -194,7 +189,7 @@ if [[ -d "$_nvm_dir" ]]; then
 fi
 unset _nvm_dir _nvm_count
 
-step "tmux plugin manager (TPM)"
+step "🖥️  tmux plugin manager (TPM)"
 if [[ ! -d "$HOME/.tmux/plugins/tpm" ]]; then
   info "Installing tmux plugin manager (TPM)..."
   git clone https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm" --depth=1
@@ -203,11 +198,11 @@ else
   success "TPM already installed"
 fi
 
-step "git-lfs"
+step "📁  git-lfs"
 git lfs install --skip-repo
 success "git-lfs"
 
-step "Dotfile symlinks"
+step "🔗  Dotfile symlinks"
 zsh "$DOTFILES_DIR/install.sh"
 
 if [[ ! -f "$HOME/.zshrc.local" ]]; then
@@ -215,7 +210,7 @@ if [[ ! -f "$HOME/.zshrc.local" ]]; then
   warn "Created ~/.zshrc.local from template — edit it with machine-specific config"
 fi
 
-step "macOS developer defaults"
+step "⚙️  macOS developer defaults"
 echo ""
 read -rp "  Apply recommended macOS defaults? (key repeat, Dock, Finder, screenshots) [y/N] " apply_macos
 if [[ "$apply_macos" =~ ^[Yy]$ ]]; then
@@ -230,7 +225,7 @@ _secs=$(( _elapsed % 60 ))
 
 echo ""
 echo "  ─────────────────────────────────────────────────"
-printf "${GREEN}${BOLD}  Bootstrap complete${RESET}  in %dm %ds\n" "$_mins" "$_secs"
+printf "${GREEN}${BOLD}  🎉  Bootstrap complete${RESET}  in %dm %ds\n" "$_mins" "$_secs"
 echo "  ─────────────────────────────────────────────────"
 echo ""
 printf "  ${BOLD}Next steps${RESET}\n"

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -87,12 +87,20 @@ else
 
   mkdir -p "$HOME/.ssh"
   chmod 700 "$HOME/.ssh"
-  ssh-keygen -t ed25519 -C "$(git config user.email)" -f "$HOME/.ssh/id_ed25519"
+  # Use configured email, or prompt if not yet set (gitconfig is symlinked later at step 12)
+  _key_email="$(git config user.email 2>/dev/null || true)"
+  if [[ -z "$_key_email" ]]; then
+    echo ""
+    read -rp "  Enter your email for the SSH key (used as key comment): " _key_email
+  fi
+
+  ssh-keygen -t ed25519 -C "$_key_email" -f "$HOME/.ssh/id_ed25519"
   ssh-add --apple-use-keychain "$HOME/.ssh/id_ed25519"
 
   # Register key for local signature verification
   mkdir -p "$HOME/.config/git"
-  echo "$(git config user.email) $(cat "$HOME/.ssh/id_ed25519.pub")" > "$HOME/.config/git/allowed_signers"
+  echo "$_key_email $(cat "$HOME/.ssh/id_ed25519.pub")" > "$HOME/.config/git/allowed_signers"
+  unset _key_email
 
   # Copy to clipboard automatically
   pbcopy < "$HOME/.ssh/id_ed25519.pub"
@@ -167,7 +175,7 @@ if [[ -d "$_nvm_dir" ]]; then
     echo ""
     warn "NVM is installed at $_nvm_dir but has no Node versions (ghost install)."
     warn "mise handles Node — NVM is no longer needed on this machine."
-    read -rp "Remove NVM automatically? [y/N] " _rm_nvm
+    read -rp "  Remove NVM automatically? [y/N] " _rm_nvm
     if [[ "$_rm_nvm" =~ ^[Yy]$ ]]; then
       rm -rf "$_nvm_dir"
       brew uninstall nvm 2>/dev/null || true
@@ -186,7 +194,7 @@ if [[ -d "$_nvm_dir" ]]; then
     warn "Continuing without touching NVM — both mise and NVM can coexist during migration."
   fi
 fi
-unset _nvm_dir _nvm_count
+unset _nvm_dir _nvm_count _rm_nvm
 
 step "🖥️  tmux plugin manager (TPM)"
 if [[ ! -d "$HOME/.tmux/plugins/tpm" ]]; then

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -45,6 +45,26 @@ A terminal UI for git that makes complex operations (interactive rebase, cherry-
 ### [gh](https://cli.github.com)
 The official GitHub CLI. Lets you create PRs, review code, manage issues, and interact with GitHub Actions directly from the terminal without switching to a browser. Pairs well with the git aliases in `gitconfig`.
 
+### [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager)
+A cross-platform, cross-host credential helper maintained by the Git ecosystem team (Microsoft/GitHub). Solves the specific problem of working with multiple Git hosts — GitHub.com, GitHub Enterprise, Bitbucket, Azure DevOps — from the same machine without managing credentials manually for each.
+
+**Why it matters for enterprise setups:** when you have a personal GitHub account AND a work GitHub Enterprise instance AND Bitbucket, credential conflicts are a constant friction point. GCM maintains separate, scoped credential stores per host and supports OAuth2, personal access tokens, and SSO/MFA flows natively. Once installed, it handles authentication transparently.
+
+```sh
+# GCM is auto-configured when installed via Homebrew.
+# To check the active credential helper:
+git config --global credential.helper
+
+# To sign in to a specific host manually:
+git credential-manager github login
+git credential-manager github login --enterprise-url https://github.your-company.com
+
+# To list stored credentials:
+git credential-manager list
+```
+
+On macOS, credentials are stored in the macOS Keychain. On new machines, the first `git clone` or `git push` to a host triggers an OAuth browser flow automatically.
+
 ---
 
 ## Utilities

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -77,6 +77,29 @@ The global `config/direnvrc` (symlinked to `~/.config/direnv/direnvrc`) defines 
 - **`layout python`** — auto-creates and activates a `.venv` virtualenv (uses `uv` if available, 10–100× faster)
 - **`layout node`** — adds `node_modules/.bin` to PATH so locally-installed binaries work without `npx`
 
+### [redis](https://redis.io)
+An in-memory data store used for background job queues (Sidekiq), caching, and session storage. Running Redis locally lets you develop and test without needing a remote instance. Start/stop it with `brew services start redis` / `brew services stop redis`, or run it in the foreground with `redis-server`.
+
+### [imagemagick](https://imagemagick.org)
+A command-line image conversion and manipulation toolkit. Handles virtually any image format. Common uses in a developer workflow:
+```sh
+convert input.png -resize 800x600 output.jpg   # resize
+convert input.pdf[0] thumbnail.png              # first page of PDF to image
+mogrify -format webp *.png                      # batch convert all PNGs to WebP
+identify image.png                              # show image dimensions and metadata
+```
+Also required as a native dependency by several Ruby gems (`rmagick`, `mini_magick`) and Python packages (`Pillow` sometimes links to it).
+
+### [pdftk-java](https://gitlab.com/pdftk-java/pdftk)
+A PDF toolkit for working with PDF files from the command line. The Java port of the original pdftk (the C version is no longer maintained). Common uses:
+```sh
+pdftk file1.pdf file2.pdf cat output combined.pdf   # merge PDFs
+pdftk input.pdf burst output page_%02d.pdf           # split into individual pages
+pdftk form.pdf fill_form data.fdf output filled.pdf  # fill a PDF form
+pdftk input.pdf dump_data                            # extract metadata
+```
+Useful when working with government or enterprise document workflows that require PDF manipulation without opening Acrobat.
+
 ### [newman](https://github.com/postmanlabs/newman)
 A CLI runner for Insomnia and Postman collections. Executes a collection of API requests from the command line and reports pass/fail results, making API test suites runnable in CI without opening a GUI. Export a collection from Insomnia, add `newman run collection.json` to your CI config.
 

--- a/docs/work-machine.md
+++ b/docs/work-machine.md
@@ -13,7 +13,7 @@ brew bundle --file=~/dotfiles/Brewfile        # shared base (all machines)
 brew bundle --file=~/dotfiles/Brewfile.work   # work additions
 ```
 
-`Brewfile.work` adds: Insomnia, Newman, PostgreSQL 16 CLI tools, Redis, Maven, Gradle, kubectl, and Helm. It does **not** duplicate anything already in `Brewfile`.
+`Brewfile.work` adds: Gradle, kubectl, and Helm. Everything else you might expect here — Insomnia, newman, Redis, and Maven — is already in the base `Brewfile` since it's useful on every machine. PostgreSQL CLI tools are intentionally excluded: Postgres.app (installed by the base Brewfile) provides them and installing `postgresql@xx` via Homebrew can cause conflicts.
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,6 @@ typeset -i _linked=0 _current=0 _backed=0
 info()    { print -P "%F{cyan}  → %f$*"; }
 success() { print -P "%F{green}  ✓ %f$*"; }
 backup()  { print -P "%F{yellow}  ⚠ %f$*"; }
-error()   { print -P "%F{red}  ✗ %f$*" >&2; }
 
 symlink() {
   local src="$1"

--- a/install.sh
+++ b/install.sh
@@ -39,7 +39,7 @@ symlink() {
 }
 
 echo ""
-print -P "%F{cyan}  dotfiles%f  ─  symlinking from ${DOTFILES_DIR/$HOME/\~}"
+print -P "%F{cyan}  🔗  dotfiles%f  ─  symlinking from ${DOTFILES_DIR/$HOME/\~}"
 echo "  ─────────────────────────────────────────────────"
 
 # Home directory symlinks
@@ -128,4 +128,4 @@ if (( _backed > 0 )); then
   backup "backups saved to ${BACKUP_DIR/$HOME/\~}"
 fi
 echo ""
-success "Done — open a new shell or: source ~/.zshrc"
+success "🎉  Done — open a new shell or: source ~/.zshrc"

--- a/install.sh
+++ b/install.sh
@@ -10,10 +10,10 @@ BACKUP_DIR="$HOME/.dotfiles_backup/$(date +%Y%m%d_%H%M%S)"
 # Counters
 typeset -i _linked=0 _current=0 _backed=0
 
-info()    { print -P "%F{cyan}  [info]%f    $*"; }
-success() { print -P "%F{green}  [ok]%f      $*"; }
-backup()  { print -P "%F{yellow}  [bkp]%f     $*"; }
-error()   { print -P "%F{red}  [error]%f  $*"; }
+info()    { print -P "%F{cyan}  → %f$*"; }
+success() { print -P "%F{green}  ✓ %f$*"; }
+backup()  { print -P "%F{yellow}  ⚠ %f$*"; }
+error()   { print -P "%F{red}  ✗ %f$*" >&2; }
 
 symlink() {
   local src="$1"
@@ -23,7 +23,7 @@ symlink() {
 
   if [[ -e "$dest" || -L "$dest" ]]; then
     if [[ "$(readlink "$dest")" == "$src" ]]; then
-      print -P "%F{green}  [ok]%f      current   $short"
+      success "current   $short"
       (( _current++ )) || true
       return
     fi
@@ -34,7 +34,7 @@ symlink() {
   fi
 
   ln -sf "$src" "$dest"
-  print -P "%F{green}  [ok]%f      linked    $short"
+  success "linked    $short"
   (( _linked++ )) || true
 }
 
@@ -123,7 +123,7 @@ fi
 
 echo ""
 echo "  ─────────────────────────────────────────────────"
-print -P "%F{green}  [ok]%f      ${_linked} linked  ·  ${_current} current  ·  ${_backed} backed up"
+success "${_linked} linked  ·  ${_current} current  ·  ${_backed} backed up"
 if (( _backed > 0 )); then
   backup "backups saved to ${BACKUP_DIR/$HOME/\~}"
 fi

--- a/install.sh
+++ b/install.sh
@@ -7,32 +7,40 @@ set -euo pipefail
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 BACKUP_DIR="$HOME/.dotfiles_backup/$(date +%Y%m%d_%H%M%S)"
 
-info()    { print -P "%F{cyan}[info]%f  $*"; }
-success() { print -P "%F{green}[ok]%f    $*"; }
-backup()  { print -P "%F{yellow}[backup]%f $*"; }
-error()   { print -P "%F{red}[error]%f $*"; }
+# Counters
+typeset -i _linked=0 _current=0 _backed=0
+
+info()    { print -P "%F{cyan}  [info]%f    $*"; }
+success() { print -P "%F{green}  [ok]%f      $*"; }
+backup()  { print -P "%F{yellow}  [bkp]%f     $*"; }
+error()   { print -P "%F{red}  [error]%f  $*"; }
 
 symlink() {
   local src="$1"
   local dest="$2"
+  # Display path with ~ instead of $HOME for readability
+  local short="${dest/$HOME/\~}"
 
-  # Back up existing file/symlink if it's not already our symlink
   if [[ -e "$dest" || -L "$dest" ]]; then
     if [[ "$(readlink "$dest")" == "$src" ]]; then
-      success "Already linked: $dest"
+      print -P "%F{green}  [ok]%f      current   $short"
+      (( _current++ )) || true
       return
     fi
     mkdir -p "$BACKUP_DIR"
     mv "$dest" "$BACKUP_DIR/"
-    backup "Backed up $(basename "$dest") → $BACKUP_DIR/"
+    backup "backed up  $short"
+    (( _backed++ )) || true
   fi
 
   ln -sf "$src" "$dest"
-  success "Linked: $dest → $src"
+  print -P "%F{green}  [ok]%f      linked    $short"
+  (( _linked++ )) || true
 }
 
-info "Installing dotfiles from $DOTFILES_DIR"
 echo ""
+print -P "%F{cyan}  dotfiles%f  ─  symlinking from ${DOTFILES_DIR/$HOME/\~}"
+echo "  ─────────────────────────────────────────────────"
 
 # Home directory symlinks
 symlink "$DOTFILES_DIR/zshrc"    "$HOME/.zshrc"
@@ -114,4 +122,10 @@ else
 fi
 
 echo ""
-success "Done! Open a new shell or run: source ~/.zshrc"
+echo "  ─────────────────────────────────────────────────"
+print -P "%F{green}  [ok]%f      ${_linked} linked  ·  ${_current} current  ·  ${_backed} backed up"
+if (( _backed > 0 )); then
+  backup "backups saved to ${BACKUP_DIR/$HOME/\~}"
+fi
+echo ""
+success "Done — open a new shell or: source ~/.zshrc"

--- a/macos.sh
+++ b/macos.sh
@@ -7,8 +7,8 @@
 
 set -euo pipefail
 
-echo "Applying macOS developer defaults..."
-echo "(You may be prompted for your password)"
+printf "  → Applying macOS developer defaults...\n"
+printf "  (You may be prompted for your password)\n"
 echo ""
 
 # ------------------
@@ -23,7 +23,7 @@ defaults write NSGlobalDomain NSAutomaticSpellingCorrectionEnabled -bool false
 defaults write NSGlobalDomain NSAutomaticQuoteSubstitutionEnabled -bool false
 defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
 
-echo "[ok] Keyboard settings"
+printf "  ✓ Keyboard — fast repeat, no autocorrect, no smart quotes\n"
 
 # ------------------
 # Trackpad
@@ -32,7 +32,7 @@ echo "[ok] Keyboard settings"
 defaults write com.apple.driver.AppleBluetoothMultitouch.trackpad Clicking -bool true
 defaults write NSGlobalDomain com.apple.mouse.tapBehavior -int 1
 
-echo "[ok] Trackpad settings"
+printf "  ✓ Trackpad — tap-to-click enabled\n"
 
 # ------------------
 # Finder
@@ -59,7 +59,7 @@ defaults write com.apple.finder _FXSortFoldersFirst -bool true
 # Search current folder by default
 defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
 
-echo "[ok] Finder settings"
+printf "  ✓ Finder — show hidden files, all extensions, path bar, list view\n"
 
 # ------------------
 # Screenshots
@@ -71,7 +71,7 @@ defaults write com.apple.screencapture location -string "$SCREENSHOT_DIR"
 defaults write com.apple.screencapture type -string "png"
 defaults write com.apple.screencapture disable-shadow -bool true
 
-echo "[ok] Screenshots → $SCREENSHOT_DIR"
+printf "  ✓ Screenshots → %s\n" "$SCREENSHOT_DIR"
 
 # ------------------
 # Dock
@@ -89,7 +89,7 @@ defaults write com.apple.dock show-recents -bool false
 # Smaller dock size
 defaults write com.apple.dock tilesize -int 48
 
-echo "[ok] Dock settings"
+printf "  ✓ Dock — auto-hide, instant show/hide, no recent apps\n"
 
 # ------------------
 # Mission Control / Spaces
@@ -100,7 +100,7 @@ defaults write com.apple.dock mru-spaces -bool false
 # Speed up Mission Control animation
 defaults write com.apple.dock expose-animation-duration -float 0.1
 
-echo "[ok] Mission Control settings"
+printf "  ✓ Mission Control — faster animation, stable Spaces order\n"
 
 # ------------------
 # Activity Monitor
@@ -108,7 +108,7 @@ echo "[ok] Mission Control settings"
 # Show all processes, not just user ones
 defaults write com.apple.ActivityMonitor ShowCategory -int 0
 
-echo "[ok] Activity Monitor settings"
+printf "  ✓ Activity Monitor — show all processes\n"
 
 # ------------------
 # TextEdit
@@ -118,16 +118,16 @@ defaults write com.apple.TextEdit RichText -int 0
 defaults write com.apple.TextEdit PlainTextEncoding -int 4
 defaults write com.apple.TextEdit PlainTextEncodingForWrite -int 4
 
-echo "[ok] TextEdit settings"
+printf "  ✓ TextEdit — plain text mode by default\n"
 
 # ------------------
 # Apply changes
 # ------------------
 echo ""
-echo "Restarting affected apps..."
+printf "  → Restarting affected apps (Finder, Dock)...\n"
 for app in "Finder" "Dock" "SystemUIServer" "cfprefsd"; do
   killall "$app" &>/dev/null || true
 done
 
 echo ""
-echo "[ok] Done. Some changes (key repeat, trackpad) require logout to take effect."
+printf "  ✓ Done. Key repeat and trackpad changes take full effect after logout.\n"


### PR DESCRIPTION
## What this changes

### bootstrap.sh

**Before:** plain `echo` with no visual structure — impossible to tell where you are during a 4-minute install.

**After:**
```
  dotfiles bootstrap  —  macOS developer setup
  ─────────────────────────────────────────────────
  Machine  Brad's MacBook Pro
  Date     Mon Jun 01 2026  07:59
  ─────────────────────────────────────────────────

  ▸ [1/13]  Xcode Command Line Tools
  [ok]     Xcode CLI Tools

  ▸ [2/13]  Homebrew
  [ok]     Homebrew 4.5.2

  ▸ [3/13]  Packages (brew bundle)
  ...

  ─────────────────────────────────────────────────
  Bootstrap complete  in 4m 12s
  ─────────────────────────────────────────────────

  Next steps
  1. Edit ~/.zshrc.local with machine-specific config
  2. Open a new terminal  (or: source ~/.zshrc)
  3. Install Hyper: https://hyper.is
```

Specific changes:
- Color system with terminal detection (`[[ -t 1 ]]`) — no-ops cleanly in CI or when piped
- Startup banner with machine name and date
- `step()` function prints `▸ [N/13] Name` before each major section
- `BOOTSTRAP_START=$SECONDS` + elapsed time in final summary
- SSH and gh auth prompts cleaned up and tightened
- `printf` throughout instead of bare `echo` for consistent formatting

### install.sh

**Before:**
```
[ok]    Already linked: /Users/brad/.zshrc
[ok]    Linked: /Users/brad/.gitconfig → /Users/brad/dotfiles/gitconfig
```

**After:**
```
  dotfiles  ─  symlinking from ~/dotfiles
  ─────────────────────────────────────────────────
  [ok]      current   ~/.zshrc
  [ok]      linked    ~/.gitconfig
  [bkp]     backed up  ~/.gemrc

  ─────────────────────────────────────────────────
  [ok]      3 linked  ·  13 current  ·  1 backed up
  [bkp]     backups saved to ~/.dotfiles_backup/20260601_075901
```

Specific changes:
- `~` instead of full `/Users/brad/` in all paths
- Consistent status words: `linked`, `current`, `backed up` — left-aligned
- `_linked / _current / _backed` counters with `|| true` guards for `set -e` safety
- Summary line at end with actual counts
- Header banner
- Label alignment: `[info]`/`[ok]`/`[bkp]`/`[error]` all at consistent indent