### PR TITLE
feat(tmux): modernize status bar with mise runtime versions

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -78,18 +78,18 @@ bind-key -T copy-mode-vi 'C-\' select-pane -l
 # Status bar #
 # -----------#
 
-set-option -g status-justify left
-set-option -g status-left '#[bg=colour72] #[bg=colour237] #[bg=colour236] #[bg=colour235]#[fg=colour185] #S #[bg=colour236] '
-set-option -g status-left-length 16
-set-option -g status-bg colour237
-set-option -g status-right '#[bg=colour236] #[bg=colour235]#[fg=colour185] %a %R #[bg=colour236]#[fg=colour3] #[bg=colour237] #[bg=colour72] #[]'
-set-option -g status-interval 60
+set-option -g status-bg colour235
+set-option -g status-interval 10
+set-option -g status-left '#[fg=colour75,bold] #S #[default]│ '
+set-option -g status-left-length 24
+set-option -g status-right '#[fg=colour245] node #[fg=colour75]#(mise current node 2>/dev/null) #[fg=colour245]│  ruby #[fg=colour75]#(mise current ruby 2>/dev/null) #[fg=colour245]│  %a %d %b  %H:%M '
+set-option -g status-right-length 100
 
-set-option -g pane-active-border-style fg=colour246
 set-option -g pane-border-style fg=colour238
+set-option -g pane-active-border-style fg=colour75
 
-set-window-option -g window-status-format '#[bg=colour238]#[fg=colour107] #I #[bg=colour239]#[fg=colour110] #[bg=colour240]#W#[bg=colour239]#[fg=colour195]#F#[bg=colour238] '
-set-window-option -g window-status-current-format '#[bg=colour236]#[fg=colour215] #I #[bg=colour235]#[fg=colour167] #[bg=colour234]#W#[bg=colour235]#[fg=colour195]#F#[bg=colour236] '
+set-window-option -g window-status-format '#[fg=colour245] #I:#W#F '
+set-window-option -g window-status-current-format '#[fg=colour75,bold] #I:#W#F '
 
 # ---------#
 # Plugins  #


### PR DESCRIPTION
## Summary

Modernize the tmux status bar with a clean, minimal design and live mise runtime version display.

### Changes
- **Accent colour**: switched to `colour75` (blue) for a consistent theme
- **Background**: dark `colour235` base
- **Status left**: bold session name with `│` separator
- **Status right**: shows current Node and Ruby versions via `mise current`, plus date/time
- **Refresh interval**: reduced from 60s to 10s for timely runtime version updates
- **Pane borders**: active pane highlighted with `colour75`
- **Window status**: simplified `#I:#W#F` format — active window in bold blue, inactive in grey

All other sections (General, Keybindings, Plugins) are unchanged.