### PR TITLE
feat: migrate colorls→lsd, bump pre-commit hooks, update docs

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -16,6 +16,7 @@ brew "fzf"            # fuzzy finder (Ctrl+R history, Ctrl+T file picker)
 brew "bat"            # cat with syntax highlighting
 brew "ripgrep"        # faster grep (rg)
 brew "fd"             # faster find
+brew "lsd"            # ls with icons, colors, and Git status (Rust binary; replaces colorls)
 
 # ------------------
 # Git

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 BOOTSTRAP_START=$SECONDS
 STEP=0
-TOTAL_STEPS=13
+TOTAL_STEPS=12
 
 # ── Colors (disabled when not attached to a terminal) ────────────────────────
 if [[ -t 1 ]]; then
@@ -137,11 +137,6 @@ step "⚡  Runtimes via mise  (Ruby · Node · Java · Python · Go)"
 mise install ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
 mise use --global ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
 success "Ruby 3.3.6 · Node 22 · Java 21 · Python 3.12 · Go 1.24  (via mise)"
-
-step "💎  Ruby gems"
-info "Installing colorls..."
-mise exec ruby@3.3.6 -- gem install colorls
-success "colorls"
 
 step "🦀  Rust (rustup)"
 # Note: we check for `rustup`, NOT `rustc` — a system/Homebrew rustc does not

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -32,6 +32,19 @@ A `find` replacement that is faster, uses sensible defaults (ignores hidden file
 ### [tree](https://oldmanprogrammer.net/source.php?page=tree)
 Prints a visual directory tree. Useful for quickly understanding an unfamiliar project structure or documenting a directory layout in a README.
 
+### [lsd](https://github.com/lsd-rs/lsd)
+A modern `ls` replacement written in Rust. Shows file icons, colors, permission indicators, and Git status by default. Ships as a single binary — no Ruby runtime, no `gem install`, no version manager activation required. Works correctly in non-interactive shells and scripts where `colorls` would fail silently.
+
+Aliased in `zshrc` as `ls`, `la`, `l`, `ll`, and `lc`:
+
+```sh
+lsd                              # listing with icons and colors (aliased as ls)
+lsd -lA --group-dirs first       # long format, hidden files, dirs first (aliased as ll)
+lsd --tree --depth 2             # inline tree view without a separate command
+```
+
+Replaces `colorls`, which required an active mise Ruby context and could produce broken output in cron jobs, git hooks, or any non-interactive shell where Ruby was not in PATH.
+
 ---
 
 ## Git
@@ -134,7 +147,7 @@ The `gitconfig` in this repo sets `core.hooksPath = ~/.config/git/hooks`, which 
 |----------|---------|
 | `templates/pre-commit-ruby-rails.yaml` | Ruby on Rails — RuboCop (with all plugins), Brakeman, bundler-audit |
 | `templates/pre-commit-javascript.yaml` | JavaScript/React — ESLint, Stylelint, Prettier |
-| `templates/pre-commit-java.yaml` | Java/Maven — Google Java Format, Checkstyle; SpotBugs optional |
+| `templates/pre-commit-java.yaml` | Java/Maven — Checkstyle; Google Java Format (see comments — mirror archived); SpotBugs optional |
 | `templates/pre-commit-config.yaml` | General purpose — hygiene hooks + RuboCop + secrets detection |
 
 **Adding pre-commit to a project:**
@@ -262,6 +275,14 @@ ruff format .           # format (Black-compatible)
 ruff check --select I . # import sorting only
 ```
 
+**`~/.npmrc`** — the npm client reads this file on startup for every install. This config sets:
+- `save-exact=true` — pin exact versions instead of `^` or `~` ranges, preventing dependency drift across team members
+- `fund=false` — suppress funding messages on every install
+- `audit-level=moderate` — only warn on moderate or higher vulnerabilities; info-level noise is suppressed
+- `update-notifier=false` — suppress npm version update prompts
+
+`install.sh` symlinks it to `~/.npmrc`. To override a setting for a specific project, add a `.npmrc` at the project root — npm reads closest-first.
+
 ---
 
 ## Ruby REPLs
@@ -335,3 +356,24 @@ For window management: go to Settings → Extensions → Window Management and a
 For Clipboard History: assign `Cmd+Shift+V` in Settings → Extensions → Clipboard History.
 
 **Official guide:** [manual.raycast.com](https://manual.raycast.com) — [YouTube channel](https://www.youtube.com/@raycastapp) has short walkthroughs of snippets, script commands, and extensions.
+
+---
+
+## Scripts
+
+### [`update.sh`](../update.sh)
+A one-command maintenance script that keeps the machine current without a full re-bootstrap. Run it weekly or after returning from extended time off.
+
+```sh
+bash ~/dotfiles/update.sh
+```
+
+Runs 6 steps in sequence, each color-coded and numbered:
+1. **Dotfiles** — `git pull --rebase --autostash` from origin
+2. **Symlinks** — re-runs `install.sh` (idempotent; picks up new files without clobbering existing ones)
+3. **Homebrew** — `brew update && brew upgrade && brew cleanup`
+4. **Runtimes** — `mise upgrade` across all managed runtimes
+5. **Rust** — `rustup update` to latest stable
+6. **Ruby gems** — `gem update --system` for global gem infrastructure
+
+To schedule it automatically via launchd, see the inline comment at the top of `update.sh` for the `.plist` template and `launchctl load` command.

--- a/templates/pre-commit-config.yaml
+++ b/templates/pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   # General hygiene
   # ------------------
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace       # remove trailing spaces
       - id: end-of-file-fixer         # ensure files end with a newline
@@ -28,7 +28,7 @@ repos:
   # Ruby / Rails
   # ------------------
   - repo: https://github.com/rubocop/rubocop
-    rev: v1.65.0  # pin to a version; update with: pre-commit autoupdate
+    rev: v1.87.0  # pin to a version; update with: pre-commit autoupdate
     hooks:
       - id: rubocop
         args:

--- a/templates/pre-commit-java.yaml
+++ b/templates/pre-commit-java.yaml
@@ -19,7 +19,7 @@ repos:
   # General hygiene
   # ------------------
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -34,13 +34,20 @@ repos:
 
   # ------------------
   # Google Java Format — consistent formatting (like Prettier for Java)
-  # Enforces Google Style Guide formatting. Run `--replace` to auto-fix.
+  # Enforces Google Style Guide formatting.
+  # NOTE: pre-commit/mirrors-google-java-format is archived and no longer works.
+  # Options:
+  #   1. Download the jar and use a local hook (see below)
+  #   2. Use the spotless-maven-plugin in pom.xml (recommended for CI)
+  # Download: https://github.com/google/google-java-format/releases
   # ------------------
-  - repo: https://github.com/pre-commit/mirrors-google-java-format
-    rev: v1.22.0
-    hooks:
-      - id: google-java-format
-        args: ['--replace']
+  # - repo: local
+  #   hooks:
+  #     - id: google-java-format
+  #       name: Google Java Format
+  #       entry: java -jar ~/.local/share/google-java-format.jar --replace
+  #       language: system
+  #       types: [java]
 
   # ------------------
   # Checkstyle — code style and standards

--- a/templates/pre-commit-javascript.yaml
+++ b/templates/pre-commit-javascript.yaml
@@ -19,7 +19,7 @@ repos:
   # General hygiene
   # ------------------
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
         exclude: '\.md$'          # markdown intentional trailing spaces

--- a/templates/pre-commit-ruby-rails.yaml
+++ b/templates/pre-commit-ruby-rails.yaml
@@ -15,7 +15,7 @@ repos:
   # General hygiene
   # ------------------
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -33,7 +33,7 @@ repos:
   # Remove any additional_dependencies your project doesn't use.
   # ------------------
   - repo: https://github.com/rubocop/rubocop
-    rev: v1.65.0  # keep in sync with Gemfile; update with: pre-commit autoupdate
+    rev: v1.87.0  # keep in sync with Gemfile; update with: pre-commit autoupdate
     hooks:
       - id: rubocop
         args:

--- a/update.sh
+++ b/update.sh
@@ -85,7 +85,6 @@ fi
 section "💎  Ruby gems"
 if command -v gem &>/dev/null; then
   gem update --system --no-document 2>/dev/null
-  gem update --no-document colorls 2>/dev/null || true
   success "Global gems updated"
 else
   warn "gem not found — skipping (mise Ruby may not be active)"

--- a/zshrc
+++ b/zshrc
@@ -91,11 +91,11 @@ alias ..='../..'
 alias ...='../../..'
 alias ....='../../../..'
 alias .....='../../../../..'
-alias la='ls -Ah'
-alias l='colorls --group-directories-first --almost-all'
-alias ll='colorls --group-directories-first --almost-all --long'
-alias lc='colorls -lA --sd'
-alias ls='colorls -h --group-directories-first -1'
+alias ls='lsd --group-dirs first'
+alias la='lsd -A'
+alias l='lsd -A --group-dirs first'
+alias ll='lsd -lA --group-dirs first'
+alias lc='lsd -lA --group-dirs first --sort date'
 alias change="code ~/.zshrc"
 alias update="source ~/.zshrc"
 alias history='history 0'
@@ -105,16 +105,6 @@ command -v bat &>/dev/null && alias cat='bat --paging=never'
 
 eval "$(starship init zsh)"
 test -f ~/afs_localprops.sh && source ~/afs_localprops.sh
-
-# colorls completion (guarded)
-if command -v colorls >/dev/null 2>&1; then
-  colorls_gem_path=$(dirname $(gem which colorls 2>/dev/null) 2>/dev/null)
-  if [[ -n "$colorls_gem_path" ]]; then
-    if [[ -d "$colorls_gem_path/zsh" ]]; then
-      fpath=("$colorls_gem_path/zsh" $fpath)
-    fi
-  fi
-fi
 
 # Optional plugins if installed
 if [ -f "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh" ]; then


### PR DESCRIPTION
colorls → lsd:
- Add brew "lsd" to Brewfile (Rust binary; no Ruby runtime dependency)
- Replace all colorls aliases in zshrc with lsd equivalents (ls, la, l, ll, lc — preserving intent, now using lsd flags)
- Remove colorls completion block from zshrc
- Remove 'Ruby gems' bootstrap step (only installed colorls) TOTAL_STEPS 13→12
- Remove colorls-specific gem update from update.sh

pre-commit templates:
- Bump pre-commit-hooks v4.6.0→v6.0.0 across all 4 templates
- Bump rubocop v1.65.0→v1.87.0 (config + ruby-rails templates)
- Fix pre-commit-java.yaml: pre/mirrors-google-java-format mirror is archived; replaced with commented-out local hook + migration notes

docs/tools.md:
- Add lsd section under File & Search
- Add ~/.npmrc section under Runtime Management
- Add update.sh section under new ## Scripts heading
- Update Java template table entry to note archived mirror