### PR TITLE
feat: roadmap quick wins — launchd scheduler, verify.sh extensions, README sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ jobs:
       - name: shellcheck update.sh
         run: shellcheck -S warning update.sh
 
+      - name: shellcheck setup-scheduler.sh
+        run: shellcheck -S warning setup-scheduler.sh
+
+      - name: shellcheck verify.sh
+        run: shellcheck -S warning verify.sh
+
   # ------------------------------------------------------------------
   # 2. zsh-syntax — syntax-check every shell file + parse the Brewfile
   #    Uses macOS because zsh -n on zsh-specific syntax needs a real zsh.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 # runs from the dotfiles directory instead of the project root
 *.vscode-*
 ms-*.*
+logs/*.log

--- a/LaunchAgents/com.dotfiles.update.plist
+++ b/LaunchAgents/com.dotfiles.update.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.dotfiles.update</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>__DOTFILES_DIR__/update.sh</string>
+    </array>
+
+    <!-- Run daily at 9 AM — edit Hour/Minute to change the schedule -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>__DOTFILES_DIR__/logs/update.log</string>
+    <key>StandardErrorPath</key>
+    <string>__DOTFILES_DIR__/logs/update.log</string>
+
+    <!-- Do not run immediately when loaded, only on the next scheduled time -->
+    <key>RunAtLoad</key>
+    <false/>
+</dict>
+</plist>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,11 @@ bash ~/dotfiles/bootstrap.sh
 bash ~/dotfiles/update.sh
 ```
 
-Pulls the latest dotfiles, re-symlinks, upgrades all Homebrew packages, updates mise runtimes, Rust toolchain, and global gems. Finishes with a health check — also runnable standalone: `bash ~/dotfiles/verify.sh`. Safe to run any time.
+Pulls the latest dotfiles, re-symlinks, upgrades all Homebrew packages, updates mise runtimes, Rust toolchain, and global gems. Finishes with a health check. Safe to run any time.
+
+To schedule daily automatic runs via launchd (9 AM): `bash ~/dotfiles/setup-scheduler.sh`
+
+To run the health check standalone: `bash ~/dotfiles/verify.sh`
 
 To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
 

--- a/README.md
+++ b/README.md
@@ -24,11 +24,10 @@ bash ~/dotfiles/bootstrap.sh
 6. SSH key for commit signing — generated, added to Keychain, copied to clipboard
 7. Ruby 3.3.6, Node 22, Java 21, Python 3.12, Go 1.24 via mise
 8. Rust stable via rustup (+ rustfmt, clippy)
-9. `colorls` gem
-10. TPM (tmux plugin manager)
-11. `install.sh` — symlinks all dotfiles
-12. `~/.zshrc.local` from template
-13. macOS developer defaults (optional prompt)
+9. TPM (tmux plugin manager)
+10. `install.sh` — symlinks all dotfiles
+11. `~/.zshrc.local` from template
+12. macOS developer defaults (optional prompt)
 
 </details>
 
@@ -54,42 +53,39 @@ To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
   Date     Mon Jun 01 2026  08:00
   ─────────────────────────────────────────────────
 
-  ▸ [1/13]  🛠️  Xcode Command Line Tools
+  ▸ [1/12]  🛠️  Xcode Command Line Tools
   ✓ Xcode CLI Tools
 
-  ▸ [2/13]  🍺  Homebrew
+  ▸ [2/12]  🍺  Homebrew
   ✓ Homebrew 4.5.2
 
-  ▸ [3/13]  📦  Packages (brew bundle)
+  ▸ [3/12]  📦  Packages (brew bundle)
   → Installing packages from Brewfile...
   ✓ Brew packages installed
 
-  ▸ [4/13]  🔍  fzf shell integration
+  ▸ [4/12]  🔍  fzf shell integration
   ✓ fzf configured
 
-  ▸ [5/13]  🔑  SSH key for commit signing
+  ▸ [5/12]  🔑  SSH key for commit signing
   ✓ SSH key already exists at ~/.ssh/id_ed25519 — skipping
 
-  ▸ [6/13]  🐙  GitHub CLI authentication
+  ▸ [6/12]  🐙  GitHub CLI authentication
   ✓ GitHub CLI already authenticated
 
-  ▸ [7/13]  ⚡  Runtimes via mise  (Ruby · Node · Java · Python · Go)
+  ▸ [7/12]  ⚡  Runtimes via mise  (Ruby · Node · Java · Python · Go)
   → Installing Ruby, Node, Java, Python, and Go via mise...
   ✓ Ruby, Node, Java, Python, and Go installed via mise
 
-  ▸ [8/13]  💎  Ruby gems
-  ✓ colorls
-
-  ▸ [9/13]  🦀  Rust (rustup)
+  ▸ [8/12]  🦀  Rust (rustup)
   ✓ rustup already installed: rustc 1.86.0
 
-  ▸ [10/13]  🖥️  tmux plugin manager (TPM)
+  ▸ [9/12]  🖥️  tmux plugin manager (TPM)
   ✓ TPM already installed
 
-  ▸ [11/13]  📁  git-lfs
+  ▸ [10/12]  📁  git-lfs
   ✓ git-lfs
 
-  ▸ [12/13]  🔗  Dotfile symlinks
+  ▸ [11/12]  🔗  Dotfile symlinks
 
   🔗  dotfiles  ─  symlinking from ~/dotfiles
   ─────────────────────────────────────────────────
@@ -102,7 +98,7 @@ To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
   ✓ 3 linked  ·  14 current  ·  0 backed up
   ✓ 🎉  Done — open a new shell or: source ~/.zshrc
 
-  ▸ [13/13]  ⚙️  macOS developer defaults
+  ▸ [12/12]  ⚙️  macOS developer defaults
   Apply recommended macOS defaults? [y/N]: y
 
   ─────────────────────────────────────────────────
@@ -144,6 +140,7 @@ To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
 | `npmrc` | `~/.npmrc` | npm defaults — `save-exact`, no fund/update noise |
 | `update.sh` | _(run to update)_ | Upgrade all packages, runtimes, and gems; runs health check at end |
 | `verify.sh` | _(run to verify)_ | Health check — symlinks, version drift, missing tools, stale backups |
+| `setup-scheduler.sh` | _(run once)_ | Install launchd job to run `update.sh` daily at 9 AM |
 | `macos.sh` | _(run once)_ | macOS developer defaults |
 | `zshrc.local.example` | _(template)_ | Template for machine-specific overrides |
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -362,18 +362,65 @@ For Clipboard History: assign `Cmd+Shift+V` in Settings → Extensions → Clipb
 ## Scripts
 
 ### [`update.sh`](../update.sh)
-A one-command maintenance script that keeps the machine current without a full re-bootstrap. Run it weekly or after returning from extended time off.
+A one-command maintenance script that keeps the machine current without a full re-bootstrap. Run it manually any time, or automate it with `setup-scheduler.sh`.
 
 ```sh
 bash ~/dotfiles/update.sh
 ```
 
-Runs 6 steps in sequence, each color-coded and numbered:
+Runs 7 steps in sequence, each color-coded and numbered:
 1. **Dotfiles** — `git pull --rebase --autostash` from origin
 2. **Symlinks** — re-runs `install.sh` (idempotent; picks up new files without clobbering existing ones)
 3. **Homebrew** — `brew update && brew upgrade && brew cleanup`
 4. **Runtimes** — `mise upgrade` across all managed runtimes
 5. **Rust** — `rustup update` to latest stable
 6. **Ruby gems** — `gem update --system` for global gem infrastructure
+7. **Health check** — runs `verify.sh` and surfaces any warnings before the session ends
 
-To schedule it automatically via launchd, see the inline comment at the top of `update.sh` for the `.plist` template and `launchctl load` command.
+Logs are written to `~/dotfiles/logs/update.log` when running via launchd.
+
+---
+
+### [`verify.sh`](../verify.sh)
+A standalone environment health check. Run it any time to confirm the machine is in a good state — useful when returning to a machine after time away, after a failed update, or when something feels broken.
+
+```sh
+bash ~/dotfiles/verify.sh
+```
+
+Runs 7 checks, exits 0 unless broken symlinks are found:
+
+| Check | Severity |
+|-------|----------|
+| Broken or missing symlinks | **error** — exits 1 |
+| Version drift (`mise.toml` vs `bootstrap.sh`) | warning |
+| Missing required tools | warning |
+| Stale backups (>30 days in `~/.dotfiles_backup`) | warning |
+| SSH key present and loaded in agent | warning |
+| git-lfs globally initialized | warning |
+| mise runtimes actually installed | warning |
+
+Errors require action (run `install.sh`). Warnings are informational — the exit code stays 0 so `update.sh` can surface them without aborting.
+
+---
+
+### [`setup-scheduler.sh`](../setup-scheduler.sh)
+Installs a launchd `LaunchAgent` that runs `update.sh` daily at 9 AM. Uses the modern `launchctl bootstrap`/`bootout` API.
+
+```sh
+bash ~/dotfiles/setup-scheduler.sh             # install
+bash ~/dotfiles/setup-scheduler.sh --uninstall # remove
+```
+
+What it does:
+- Substitutes the actual dotfiles path into `LaunchAgents/com.dotfiles.update.plist`
+- Copies the plist to `~/Library/LaunchAgents/`
+- Calls `launchctl bootstrap gui/<uid>` to activate it immediately (no login required)
+- Creates `~/dotfiles/logs/` for capturing stdout/stderr
+
+The plist template is tracked at `LaunchAgents/com.dotfiles.update.plist`. To change the schedule, edit `Hour` and `Minute` in that file and re-run `setup-scheduler.sh`.
+
+Logs land at `~/dotfiles/logs/update.log`. To monitor:
+```sh
+tail -f ~/dotfiles/logs/update.log
+```

--- a/scripts/test_verify_helpers.sh
+++ b/scripts/test_verify_helpers.sh
@@ -349,6 +349,122 @@ else
   fail "check_stale_backups: stale dir path in STALE_BACKUP_LIST" "got: $stale_paths"
 fi
 
+# ── check_ssh_key ───────────────────────────────────────────────────────────────
+echo ""
+echo "=== check_ssh_key ==="
+
+# Case 1: key file does not exist → SSH_KEY_OK=false, SSH_KEY_ISSUE non-empty
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  check_ssh_key "$TMPDIR_BASE/nonexistent_key"
+  [[ "$SSH_KEY_OK" == "false" ]] || { printf "  FAIL  SSH_KEY_OK should be false\n"; exit 1; }
+  [[ -n "$SSH_KEY_ISSUE" ]] || { printf "  FAIL  SSH_KEY_ISSUE should be non-empty\n"; exit 1; }
+); then
+  pass "check_ssh_key: missing key file → SSH_KEY_OK=false, issue set"
+else
+  fail "check_ssh_key: missing key file" "subshell exited non-zero"
+fi
+
+# Case 2: key file exists but agent doesn't have it → SSH_KEY_OK=false
+# Generate a throwaway key in a temp dir; it won't be in the agent.
+TMP_KEY="$TMPDIR_BASE/test_id_ed25519"
+ssh-keygen -t ed25519 -f "$TMP_KEY" -N "" -C "test" &>/dev/null
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  check_ssh_key "$TMP_KEY"
+  # Key exists but almost certainly not in this subshell's agent
+  [[ "$SSH_KEY_OK" == "false" ]] || [[ "$SSH_KEY_OK" == "true" ]] || { printf "  FAIL  SSH_KEY_OK must be boolean\n"; exit 1; }
+  # SSH_KEY_ISSUE should be empty only if somehow loaded
+  [[ -n "$SSH_KEY_ISSUE" || "$SSH_KEY_OK" == "true" ]] || { printf "  FAIL  expected issue or ok=true\n"; exit 1; }
+); then
+  pass "check_ssh_key: key exists but not in agent → SSH_KEY_OK=false (or OK if agent has it)"
+else
+  fail "check_ssh_key: key exists, agent check" "subshell exited non-zero"
+fi
+
+# ── check_git_lfs_global ───────────────────────────────────────────────────
+echo ""
+echo "=== check_git_lfs_global ==="
+
+# Case 1: git-lfs not initialized (empty global config)
+TMP_GIT_CONFIG="$TMPDIR_BASE/gitconfig_empty"
+touch "$TMP_GIT_CONFIG"
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export GIT_CONFIG_GLOBAL="$TMP_GIT_CONFIG"
+  check_git_lfs_global
+  # If git-lfs is installed on this machine, it should report not-initialized
+  # If git-lfs is not installed, GIT_LFS_ISSUE should mention "not installed"
+  [[ "$GIT_LFS_OK" == "false" ]] || { printf "  FAIL  GIT_LFS_OK should be false with empty config\n"; exit 1; }
+  [[ -n "$GIT_LFS_ISSUE" ]] || { printf "  FAIL  GIT_LFS_ISSUE should be non-empty\n"; exit 1; }
+); then
+  pass "check_git_lfs_global: empty config → GIT_LFS_OK=false, issue set"
+else
+  fail "check_git_lfs_global: empty config" "subshell exited non-zero"
+fi
+
+# Case 2: config has filter.lfs.clean set → GIT_LFS_OK=true (only if git-lfs is installed)
+TMP_GIT_CONFIG_WITH_LFS="$TMPDIR_BASE/gitconfig_lfs"
+cat > "$TMP_GIT_CONFIG_WITH_LFS" << 'EOF'
+[filter "lfs"]
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+	required = true
+EOF
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export GIT_CONFIG_GLOBAL="$TMP_GIT_CONFIG_WITH_LFS"
+  check_git_lfs_global
+  if command -v git-lfs &>/dev/null; then
+    [[ "$GIT_LFS_OK" == "true" ]] || { printf "  FAIL  GIT_LFS_OK should be true when lfs config present\n"; exit 1; }
+  else
+    # git-lfs not installed — GIT_LFS_OK=false regardless of config
+    [[ "$GIT_LFS_OK" == "false" ]] || { printf "  FAIL  GIT_LFS_OK should be false without git-lfs binary\n"; exit 1; }
+  fi
+); then
+  pass "check_git_lfs_global: lfs config present → GIT_LFS_OK matches binary availability"
+else
+  fail "check_git_lfs_global: lfs config present" "subshell exited non-zero"
+fi
+
+# ── check_mise_installed ──────────────────────────────────────────────────
+echo ""
+echo "=== check_mise_installed ==="
+
+# Case 1: mise not on PATH → silently returns count=0 (no-op)
+mkdir -p "$TMPDIR_BASE/empty_bin"
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export PATH="$TMPDIR_BASE/empty_bin"
+  check_mise_installed "$TMPDIR_BASE/mise_match.toml"
+  [[ "$MISE_UNINSTALLED_COUNT" -eq 0 ]] || { printf "  FAIL  count should be 0 when mise absent, got %s\n" "$MISE_UNINSTALLED_COUNT"; exit 1; }
+); then
+  pass "check_mise_installed: mise not on PATH → silently skipped (count=0)"
+else
+  fail "check_mise_installed: mise not on PATH" "subshell exited non-zero"
+fi
+
+# Case 2: all tools installed (reuse TOML_MATCH from earlier; only runs if mise is present)
+if command -v mise &>/dev/null; then
+  if (
+    source "$SCRIPT_DIR/verify_helpers.sh"
+    check_mise_installed "$TOML_MATCH"
+    # We can't assert count=0 since tools may not be installed in CI,
+    # but we can verify the function runs without error and sets the globals.
+    [[ -n "${MISE_UNINSTALLED_COUNT+set}" ]] || { printf "  FAIL  MISE_UNINSTALLED_COUNT not set\n"; exit 1; }
+  ); then
+    pass "check_mise_installed: mise present → runs without error, count is set"
+  else
+    fail "check_mise_installed: mise present" "subshell exited non-zero"
+  fi
+else
+  pass "check_mise_installed: mise not installed — skipped"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────"

--- a/scripts/verify_helpers.sh
+++ b/scripts/verify_helpers.sh
@@ -140,6 +140,88 @@ check_required_tools() {
   done
 }
 
+# check_ssh_key [KEY_FILE]
+# Checks that the SSH key file exists and is loaded in the SSH agent.
+# Defaults to ~/.ssh/id_ed25519 when KEY_FILE is omitted.
+# Sets:
+#   SSH_KEY_OK    — true if key file exists and agent has it loaded
+#   SSH_KEY_ISSUE — human-readable problem description (empty when OK)
+check_ssh_key() {
+  local key_file="${1:-$HOME/.ssh/id_ed25519}"
+  SSH_KEY_OK=false
+  SSH_KEY_ISSUE=""
+
+  if [[ ! -f "$key_file" ]]; then
+    SSH_KEY_ISSUE="$key_file not found — run bootstrap.sh to generate"
+    return
+  fi
+
+  local fingerprint
+  fingerprint=$(ssh-keygen -lf "$key_file" 2>/dev/null | awk '{print $2}') || true
+
+  if [[ -z "$fingerprint" ]]; then
+    SSH_KEY_ISSUE="could not read fingerprint from $key_file"
+    return
+  fi
+
+  if ssh-add -l 2>/dev/null | grep -qF "$fingerprint"; then
+    SSH_KEY_OK=true
+  else
+    SSH_KEY_ISSUE="key not loaded in SSH agent — run: ssh-add --apple-use-keychain ~/.ssh/id_ed25519"
+  fi
+}
+
+# check_git_lfs_global
+# Checks that git-lfs is installed and initialized in the global git config.
+# Sets:
+#   GIT_LFS_OK    — true if git-lfs is installed and globally initialized
+#   GIT_LFS_ISSUE — human-readable problem description (empty when OK)
+check_git_lfs_global() {
+  GIT_LFS_OK=false
+  GIT_LFS_ISSUE=""
+
+  if ! command -v git-lfs &>/dev/null; then
+    GIT_LFS_ISSUE="git-lfs not installed — run: brew install git-lfs"
+    return
+  fi
+
+  local clean_filter
+  clean_filter=$(git config --global filter.lfs.clean 2>/dev/null) || true
+
+  if [[ -n "$clean_filter" ]]; then
+    GIT_LFS_OK=true
+  else
+    GIT_LFS_ISSUE="git-lfs not initialized globally — run: git lfs install --skip-repo"
+  fi
+}
+
+# check_mise_installed TOML_FILE
+# Checks that the tools declared in TOML_FILE are actually installed via mise.
+# Silently skips if mise is not on PATH (check_required_tools covers that).
+# Sets:
+#   MISE_UNINSTALLED_COUNT — number of tools not installed
+#   MISE_UNINSTALLED_LIST  — array of problem descriptions
+check_mise_installed() {
+  local toml_file="$1"
+  MISE_UNINSTALLED_COUNT=0
+  MISE_UNINSTALLED_LIST=()
+
+  command -v mise &>/dev/null || return 0
+
+  local tools=(ruby node java python go)
+  for tool in "${tools[@]}"; do
+    local toml_ver
+    toml_ver=$(grep -E "^${tool}[[:space:]]*=" "$toml_file" 2>/dev/null \
+      | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/' | tr -d '[:space:]')
+    [[ -z "$toml_ver" ]] && continue
+
+    if ! mise where "$tool" &>/dev/null 2>&1; then
+      MISE_UNINSTALLED_COUNT=$(( MISE_UNINSTALLED_COUNT + 1 ))
+      MISE_UNINSTALLED_LIST+=("$tool@$toml_ver not installed — run: mise install")
+    fi
+  done
+}
+
 # check_stale_backups BACKUP_DIR [DAYS]
 # Finds backup directories inside BACKUP_DIR that are older than DAYS (default: 30).
 # Sets:

--- a/setup-scheduler.sh
+++ b/setup-scheduler.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# setup-scheduler.sh — schedule update.sh to run daily via launchd
+#
+# Usage:
+#   bash ~/dotfiles/setup-scheduler.sh             # install (runs at 9 AM daily)
+#   bash ~/dotfiles/setup-scheduler.sh --uninstall # remove the scheduled job
+#
+# Logs are written to ~/dotfiles/logs/update.log
+# Edit LaunchAgents/com.dotfiles.update.plist to change the schedule.
+
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLIST_LABEL="com.dotfiles.update"
+PLIST_SRC="$DOTFILES_DIR/LaunchAgents/$PLIST_LABEL.plist"
+PLIST_DEST="$HOME/Library/LaunchAgents/$PLIST_LABEL.plist"
+LOG_DIR="$DOTFILES_DIR/logs"
+
+# shellcheck source=scripts/bootstrap_helpers.sh
+source "$DOTFILES_DIR/scripts/bootstrap_helpers.sh"
+setup_colors
+
+echo ""
+printf "${BOLD}  ⏰  dotfiles scheduler${RESET}  —  launchd setup\n"
+echo "  ─────────────────────────────────────────────────"
+
+# ── Uninstall ─────────────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--uninstall" ]]; then
+  if launchctl list "$PLIST_LABEL" &>/dev/null 2>&1; then
+    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+    success "Unloaded $PLIST_LABEL"
+  fi
+  if [[ -f "$PLIST_DEST" ]]; then
+    rm -f "$PLIST_DEST"
+    success "Removed $PLIST_DEST"
+  fi
+  echo ""
+  info "Daily update scheduling removed"
+  echo ""
+  exit 0
+fi
+
+# ── Install ───────────────────────────────────────────────────────────────────
+mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
+
+# Substitute __DOTFILES_DIR__ placeholder with the actual path
+sed "s|__DOTFILES_DIR__|$DOTFILES_DIR|g" "$PLIST_SRC" > "$PLIST_DEST"
+
+# Reload idempotently — unload any existing version first
+launchctl unload "$PLIST_DEST" 2>/dev/null || true
+launchctl load "$PLIST_DEST"
+
+echo ""
+success "update.sh scheduled — runs daily at 9 AM"
+info "Log:       $LOG_DIR/update.log"
+info "Plist:     $PLIST_DEST"
+info "Uninstall: bash ~/dotfiles/setup-scheduler.sh --uninstall"
+echo ""

--- a/setup-scheduler.sh
+++ b/setup-scheduler.sh
@@ -26,8 +26,8 @@ echo "  ────────────────────────
 
 # ── Uninstall ─────────────────────────────────────────────────────────────────
 if [[ "${1:-}" == "--uninstall" ]]; then
-  if launchctl list "$PLIST_LABEL" &>/dev/null 2>&1; then
-    launchctl unload "$PLIST_DEST" 2>/dev/null || true
+  if launchctl print "gui/$(id -u)/$PLIST_LABEL" &>/dev/null 2>&1; then
+    launchctl bootout "gui/$(id -u)" "$PLIST_DEST" 2>/dev/null || true
     success "Unloaded $PLIST_LABEL"
   fi
   if [[ -f "$PLIST_DEST" ]]; then
@@ -46,9 +46,9 @@ mkdir -p "$LOG_DIR" "$HOME/Library/LaunchAgents"
 # Substitute __DOTFILES_DIR__ placeholder with the actual path
 sed "s|__DOTFILES_DIR__|$DOTFILES_DIR|g" "$PLIST_SRC" > "$PLIST_DEST"
 
-# Reload idempotently — unload any existing version first
-launchctl unload "$PLIST_DEST" 2>/dev/null || true
-launchctl load "$PLIST_DEST"
+# Reload idempotently — bootout any existing version first, then bootstrap
+launchctl bootout "gui/$(id -u)" "$PLIST_DEST" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
 
 echo ""
 success "update.sh scheduled — runs daily at 9 AM"

--- a/update.sh
+++ b/update.sh
@@ -2,12 +2,9 @@
 # update.sh — keep your development environment current
 #
 # Run manually:     bash ~/dotfiles/update.sh
-# Schedule daily with launchd (optional):
-#   Create ~/Library/LaunchAgents/dev.dotfiles.update.plist with:
-#     ProgramArguments: ["/bin/bash", "/Users/YOU/dotfiles/update.sh"]
-#     StartCalendarInterval: { Hour: 9, Minute: 0 }   # 9 AM daily
-#     StandardOutPath / StandardErrorPath: ~/dotfiles/logs/update.log
-#   Then: launchctl load ~/Library/LaunchAgents/dev.dotfiles.update.plist
+# Schedule daily with launchd (one command):
+#   bash ~/dotfiles/setup-scheduler.sh             # install
+#   bash ~/dotfiles/setup-scheduler.sh --uninstall # remove
 #
 # What it does:
 #   1. Pulls latest dotfiles from GitHub

--- a/verify.sh
+++ b/verify.sh
@@ -19,7 +19,7 @@ WARNINGS=0
 # shellcheck disable=SC2034  # used by step() in helpers
 STEP=0
 # shellcheck disable=SC2034
-TOTAL_STEPS=4
+TOTAL_STEPS=7
 
 # shellcheck source=scripts/bootstrap_helpers.sh
 source "$DOTFILES_DIR/scripts/bootstrap_helpers.sh"
@@ -97,6 +97,42 @@ else
   done
   warn "$STALE_BACKUP_COUNT backup(s) older than 30 days — consider: rm -rf ~/.dotfiles_backup"
   WARNINGS=$(( WARNINGS + STALE_BACKUP_COUNT ))
+fi
+
+# ── 5. SSH key ─────────────────────────────────────────────────────────
+step "🔑  SSH key"
+check_ssh_key
+
+if [[ "$SSH_KEY_OK" == "true" ]]; then
+  success "SSH key present and loaded in agent"
+else
+  warn "$SSH_KEY_ISSUE"
+  WARNINGS=$(( WARNINGS + 1 ))
+fi
+
+# ── 6. git-lfs ─────────────────────────────────────────────────────────
+step "🐙  git-lfs"
+check_git_lfs_global
+
+if [[ "$GIT_LFS_OK" == "true" ]]; then
+  success "git-lfs installed and initialized globally"
+else
+  warn "$GIT_LFS_ISSUE"
+  WARNINGS=$(( WARNINGS + 1 ))
+fi
+
+# ── 7. mise tools installed ──────────────────────────────────────────────
+step "⚡  mise tools installed"
+check_mise_installed "$DOTFILES_DIR/config/mise.toml"
+
+if [[ "$MISE_UNINSTALLED_COUNT" -eq 0 ]]; then
+  success "All mise-managed runtimes installed"
+else
+  for item in "${MISE_UNINSTALLED_LIST[@]}"; do
+    warn "$item"
+  done
+  warn "$MISE_UNINSTALLED_COUNT runtime(s) not installed — run: mise install"
+  WARNINGS=$(( WARNINGS + MISE_UNINSTALLED_COUNT ))
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────

--- a/verify.sh
+++ b/verify.sh
@@ -2,10 +2,13 @@
 # verify.sh — dotfiles environment health check
 #
 # Reports:
-#   1. Broken symlinks      (errors   — exit 1)
-#   2. Version drift        (warnings — exit 0)
+#   1. Broken symlinks        (errors   — exit 1)
+#   2. Version drift          (warnings — exit 0)
 #   3. Missing required tools (warnings — exit 0)
-#   4. Stale backups        (warnings — exit 0)
+#   4. Stale backups          (warnings — exit 0)
+#   5. SSH key                (warnings — exit 0)
+#   6. git-lfs global init    (warnings — exit 0)
+#   7. mise tools installed   (warnings — exit 0)
 #
 # Usage:   bash ~/dotfiles/verify.sh
 # Called by update.sh automatically after each update cycle.
@@ -110,8 +113,8 @@ else
   WARNINGS=$(( WARNINGS + 1 ))
 fi
 
-# ── 6. git-lfs ─────────────────────────────────────────────────────────
-step "🐙  git-lfs"
+# ── 6. git-lfs ──────────────────────────────────────────────────────
+step "📁  git-lfs"
 check_git_lfs_global
 
 if [[ "$GIT_LFS_OK" == "true" ]]; then


### PR DESCRIPTION
## Summary

Five roadmap items tackled in one pass. Worktree cleanup was done directly on the local machine (no branch needed). All other work is on this branch.

---

## What changed

### `LaunchAgents/com.dotfiles.update.plist` _(new)_
Tracked plist template for scheduling `update.sh` via launchd. Uses `__DOTFILES_DIR__` as a placeholder (substituted at install time). Defaults to 9 AM daily, `RunAtLoad=false`. Edit `Hour`/`Minute` to change the schedule.

### `setup-scheduler.sh` _(new)_
One-command install/uninstall for the launchd job:
```sh
bash ~/dotfiles/setup-scheduler.sh             # install
bash ~/dotfiles/setup-scheduler.sh --uninstall # remove
```
`sed`-substitutes `__DOTFILES_DIR__`, creates `logs/`, copies the plist to `~/Library/LaunchAgents/`, and loads it via `launchctl`. Idempotent — safe to re-run.

### `logs/.gitkeep` + `.gitignore`
Tracks the `logs/` directory so `update.sh` can write there immediately after clone, without committing actual log files (`logs/*.log` is ignored).

### `update.sh`
Replaces the inline multi-line launchd instructions with a two-line reference to `setup-scheduler.sh`.

### `verify.sh` — 3 new checks (TOTAL_STEPS 4 → 7)

| Step | Check | Pass | Warning |
|------|-------|------|---------|
| 5 | SSH key | file exists + fingerprint in agent | key missing or not loaded |
| 6 | git-lfs global init | `git-lfs` binary + `filter.lfs.clean` in global config | not installed or not initialized |
| 7 | mise tools installed | `mise where <tool>` succeeds for every tool in `mise.toml` | tool not installed (silently skips if mise absent) |

### `scripts/verify_helpers.sh`
Three new pure helper functions:
- `check_ssh_key [KEY_FILE]` — sets `SSH_KEY_OK`, `SSH_KEY_ISSUE`
- `check_git_lfs_global` — sets `GIT_LFS_OK`, `GIT_LFS_ISSUE`; respects `GIT_CONFIG_GLOBAL` env var for testability
- `check_mise_installed TOML_FILE` — sets `MISE_UNINSTALLED_COUNT`, `MISE_UNINSTALLED_LIST`

### `scripts/test_verify_helpers.sh`
6 new tests (26 total, all passing locally):
- `check_ssh_key`: missing key → issue set; key exists but not in agent → false (or true if agent has it)
- `check_git_lfs_global`: empty config → false; config with lfs filter → true iff binary present
- `check_mise_installed`: mise absent → count=0 (silent skip); mise present → globals set

### `.github/workflows/ci.yml`
Adds `shellcheck` steps for `setup-scheduler.sh` and `verify.sh` to the existing lint job.

### `README.md`
- Bootstrap step list: remove step 9 (`colorls` gem), renumber 10–13 → 9–12
- Terminal preview: remove `[8/13] 💎 Ruby gems`, renumber all `[N/13]` → `[N/12]`
- Dotfiles table: add `setup-scheduler.sh` row
- "Keeping everything current": already had `verify.sh` standalone mention from PR #17

### Worktree cleanup (done locally, no branch needed)
Removed 3 stale worktrees for branches already merged into main:
- `~/dotfiles-bootstrap-ci` (PR #17)
- `~/dotfiles-tmux-status` (PR #14)
- `~/dotfiles-vscode-ext` (PR #15)

