### PR TITLE
Add work configuration templates for scripted laptop setup

### DIFF
--- a/certs/.gitignore
+++ b/certs/.gitignore
@@ -1,0 +1,12 @@
+# Certificate files
+# Public certificates can be committed if needed, but be cautious
+*.crt
+*.cer
+*.pem
+*.p12
+*.pfx
+*.key
+*.jks
+
+# Allow README
+!README.md

--- a/certs/README.md
+++ b/certs/README.md
@@ -1,0 +1,131 @@
+# Certificate Storage
+
+This directory is for storing SSL/TLS certificates needed for corporate proxy environments (e.g., Zscaler, corporate CA certificates).
+
+## Purpose
+
+Some corporate networks use SSL inspection/proxies that require custom root certificates to be trusted by development tools. This directory provides a central location to store these certificates.
+
+## Usage
+
+### Obtaining Your Certificate
+
+Contact your IT department or export from your browser:
+
+**From Chrome/Edge:**
+1. Visit any HTTPS site behind your corporate proxy
+2. Click the lock icon → Connection is secure → Certificate is valid
+3. Certificate Viewer → Details tab → Export
+4. Save as `YourOrgRootCertificate.crt` (or your org's name)
+
+**From Firefox:**
+1. Preferences → Privacy & Security → View Certificates
+2. Authorities tab → Find your organization's certificate
+3. Export → Save as `YourOrgRootCertificate.crt`
+
+**From macOS Keychain:**
+1. Open Keychain Access
+2. System or Login keychain → Certificates
+3. Find your organization's root certificate
+4. Right-click → Export → Save as .cer or .crt
+
+### Installing Certificates
+
+```bash
+# Copy certificate to this directory
+cp /path/to/YourOrgRootCertificate.crt ~/dotfiles/certs/
+
+# Install for Node.js tools (Claude Code, Continue, npm, yarn)
+mkdir -p ~/.continue/certs
+cp ~/dotfiles/certs/YourOrgRootCertificate.crt ~/.continue/certs/
+
+# Add to shell environment
+echo 'export NODE_EXTRA_CA_CERTS="$HOME/.continue/certs/YourOrgRootCertificate.crt"' >> ~/.zshrc.local
+source ~/.zshrc
+
+# (Optional) Install to macOS system keychain for system-wide trust
+sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain \
+  ~/dotfiles/certs/YourOrgRootCertificate.crt
+```
+
+## Security Notes
+
+### ✅ Safe to Commit
+
+- **Public root certificates** from trusted CAs (your organization's public root cert)
+- These are public by design and contain no secrets
+
+### ❌ NEVER Commit
+
+- **Private keys** (`.key`, `.p12`, `.pfx` files)
+- **Client certificates** with embedded private keys
+- **Passwords** or passphrases for certificates
+
+## Gitignore
+
+This directory has a `.gitignore` that blocks most certificate file types by default. If you need to commit a public certificate, you can force-add it:
+
+```bash
+git add -f certs/YourPublicCert.crt
+```
+
+But be absolutely certain it's a public certificate with no embedded private key.
+
+## Tools That Use These Certificates
+
+- **Claude Code** - AI coding assistant via AWS Bedrock
+- **Continue IDE** - VS Code AI extension via AWS Bedrock
+- **npm/yarn** - Node.js package managers
+- **curl** - Command-line HTTP client
+- **Python requests** - Via `REQUESTS_CA_BUNDLE` or `CURL_CA_BUNDLE`
+- **Git** - Via `http.sslCAInfo` config
+
+## Troubleshooting
+
+### Still getting SSL errors after installing cert
+
+1. **Verify cert path is correct:**
+   ```bash
+   ls -la ~/.continue/certs/
+   echo $NODE_EXTRA_CA_CERTS
+   ```
+
+2. **Validate certificate:**
+   ```bash
+   openssl x509 -in ~/.continue/certs/YourCert.crt -text -noout
+   ```
+
+3. **Check environment variable is set:**
+   ```bash
+   env | grep NODE_EXTRA_CA_CERTS
+   env | grep CA_BUNDLE
+   ```
+
+4. **Restart terminal** after setting environment variables
+
+5. **System keychain** may be needed for some tools:
+   ```bash
+   security find-certificate -a -c "YourOrgName" -p /Library/Keychains/System.keychain
+   ```
+
+### Certificate expired
+
+Corporate certificates typically expire every 1-3 years. If you get expiration errors:
+
+1. Obtain updated certificate from IT
+2. Replace old certificate
+3. Reinstall to system keychain if you used that method
+
+### Which certificate do I need?
+
+You typically need your organization's **root CA certificate**, not intermediate certificates. Ask your IT department for:
+- "Root CA certificate for SSL inspection"
+- "Corporate proxy root certificate"
+- "Zscaler root certificate" (if using Zscaler)
+
+## See Also
+
+- [Continue Setup](../templates/continue/README.md) - Using certs with Continue IDE
+- [Claude Code Setup](../templates/claude/README.md) - Using certs with Claude Code
+- [OpenSSL Certificate Verification](https://www.openssl.org/docs/man1.1.1/man1/verify.html)

--- a/installers/.gitignore
+++ b/installers/.gitignore
@@ -1,0 +1,8 @@
+# Installer binaries and archives
+# These are typically large and should be downloaded on-demand
+*
+
+# But allow README and specific scripts
+!.gitignore
+!README.md
+!*.sh

--- a/installers/README.md
+++ b/installers/README.md
@@ -1,0 +1,135 @@
+# Installer Storage
+
+This directory is for storing installer scripts and binaries that may not be publicly available or require manual download.
+
+## Purpose
+
+Some tools (like Claude Code) provide installers that need to be downloaded manually. This directory provides a central location to cache these installers for reuse across machines.
+
+## Usage
+
+### Storing Installers
+
+```bash
+# Copy installer to this directory
+cp ~/Downloads/claude-code-installer ~/dotfiles/installers/
+cp ~/Downloads/ClaudeCode-macOS-v1.2.0-20260327/claude ~/dotfiles/installers/
+
+# Make executable if needed
+chmod +x ~/dotfiles/installers/claude-code-installer
+```
+
+### Using Stored Installers
+
+Installation scripts in `~/dotfiles/scripts/` will automatically check this directory:
+
+```bash
+# If installer is in this directory, setup script will use it
+bash ~/dotfiles/scripts/install_claude_code.sh
+```
+
+## Supported Installers
+
+### Claude Code CLI
+
+**Current Version**: 1.2.0 (as of March 2026)
+
+**Download**:
+- Official: https://claude.com/download
+- Direct: Provided by your organization
+
+**Files**:
+- `claude-code-installer` - Installation script
+- `claude` - CLI binary (184.9 MB)
+
+**Installation**:
+```bash
+# If you have the installer package
+cp ~/Downloads/ClaudeCode-macOS-*/claude-code-installer ~/dotfiles/installers/
+cp ~/Downloads/ClaudeCode-macOS-*/claude ~/dotfiles/installers/
+
+# Install manually
+mkdir -p ~/.local/bin
+cp ~/dotfiles/installers/claude ~/.local/bin/
+chmod +x ~/.local/bin/claude
+
+# Or use the installer script
+bash ~/dotfiles/installers/claude-code-installer --prefix="$HOME/.local/bin"
+```
+
+### VS Code Extensions (.vsix files)
+
+Some organizations provide internal VS Code extensions as `.vsix` files.
+
+**Storage**: Place in `~/dotfiles/vscode/extensions/` instead of this directory
+
+**Installation**:
+```bash
+code --install-extension ~/dotfiles/vscode/extensions/your-extension.vsix
+```
+
+## Gitignore
+
+This directory has a `.gitignore` that blocks all binary files by default to prevent accidentally committing large installers to git.
+
+**Why?**
+- Installers are often 100+ MB
+- GitHub has file size limits (100 MB per file)
+- Installers become outdated quickly
+- Better to download fresh from official sources
+
+If you need to track a specific installer script (not binary), you can force-add it:
+
+```bash
+git add -f installers/install-something.sh
+```
+
+## Automation
+
+Future scripts may automatically:
+1. Check this directory for installers
+2. Fall back to official download URLs
+3. Cache downloaded installers here for reuse
+4. Verify checksums for security
+
+## Security Notes
+
+### ✅ Safe Practices
+
+- Download installers from official sources
+- Verify checksums/signatures when available
+- Keep installers updated
+- Document where installers came from
+
+### ❌ Avoid
+
+- Don't commit large binaries (>10 MB) to git
+- Don't use installers from untrusted sources
+- Don't modify installers without verification
+- Don't share installers that contain licensing/DRM
+
+## Alternative: Download on Demand
+
+Instead of storing installers, scripts can download them:
+
+```bash
+#!/usr/bin/env bash
+# Example: download installer if not cached
+
+INSTALLER_URL="https://example.com/installer"
+INSTALLER_PATH="$HOME/dotfiles/installers/tool-installer"
+
+if [[ ! -f "$INSTALLER_PATH" ]]; then
+  echo "Downloading installer..."
+  curl -L "$INSTALLER_URL" -o "$INSTALLER_PATH"
+  chmod +x "$INSTALLER_PATH"
+fi
+
+# Use cached installer
+bash "$INSTALLER_PATH"
+```
+
+## See Also
+
+- [Claude Code Setup](../templates/claude/README.md)
+- [Work Configuration Scripts](../scripts/)

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,266 @@
+# Configuration Templates
+
+This directory contains templates for work-specific configurations that can't be directly included in dotfiles due to environment-specific settings or security considerations.
+
+## Overview
+
+Templates provide a starting point for configuring:
+- Maven (Java build tool) with corporate Nexus/Artifactory
+- Yarn (Node.js package manager) with corporate npm registries
+- AWS CLI for Bedrock (AI model access)
+- Continue IDE for VS Code with AWS Bedrock
+- Claude Code CLI with AWS Bedrock
+
+## Quick Start
+
+### Initial Setup
+
+```bash
+# Copy all templates at once (recommended for new machines)
+bash ~/dotfiles/scripts/setup_work_configs.sh
+
+# Or copy individually as needed (see sections below)
+```
+
+### Individual Templates
+
+#### Maven
+```bash
+mkdir -p ~/.m2
+cp ~/dotfiles/templates/m2/settings.xml.template ~/.m2/settings.xml
+# Edit ~/.m2/settings.xml with your organization's repository URLs
+```
+
+#### Yarn
+```bash
+cp ~/dotfiles/templates/yarnrc.template ~/.yarnrc
+# Edit ~/.yarnrc with your organization's registry URL
+```
+
+#### AWS CLI
+```bash
+mkdir -p ~/.aws
+cp ~/dotfiles/templates/aws/config.template ~/.aws/config
+aws configure sso --profile bedrock
+```
+
+#### Continue IDE
+```bash
+mkdir -p ~/.continue
+cp ~/dotfiles/templates/continue/config.yaml.template ~/.continue/config.yaml
+# Edit ~/.continue/config.yaml with your AWS profile and model IDs
+```
+
+#### Claude Code CLI
+```bash
+mkdir -p ~/.claude
+cp ~/dotfiles/templates/claude/settings.json.template ~/.claude/settings.json
+# Edit ~/.claude/settings.json with your username and AWS settings
+```
+
+## Template Structure
+
+Each template directory contains:
+- `*.template` - The configuration file template with placeholders
+- `README.md` - Detailed setup instructions and troubleshooting
+
+## Security
+
+### ✅ Safe to Commit (Templates)
+
+- Configuration structure and formats
+- Public URLs (registry URLs, API endpoints)
+- Documentation and instructions
+- Example values and placeholders
+
+### ❌ NEVER Commit
+
+- AWS credentials (access keys, session tokens)
+- Maven passwords
+- NPM/Yarn auth tokens
+- Private keys or certificates with private components
+- API keys or secrets
+
+All templates use placeholders like:
+- `REPLACE_WITH_YOUR_USERNAME`
+- `your-org.example.com`
+- `{encrypted-password-here}`
+
+Replace these with actual values after copying to your home directory.
+
+## Template Locations
+
+| Template | Destination | Purpose |
+|----------|-------------|---------|
+| `m2/settings.xml.template` | `~/.m2/settings.xml` | Maven repository config |
+| `yarnrc.template` | `~/.yarnrc` | Yarn registry config |
+| `aws/config.template` | `~/.aws/config` | AWS CLI profiles |
+| `continue/config.yaml.template` | `~/.continue/config.yaml` | Continue IDE AI config |
+| `claude/settings.json.template` | `~/.claude/settings.json` | Claude Code CLI config |
+
+## Credential Management
+
+### AWS Credentials
+
+**Recommended**: Use AWS SSO
+```bash
+aws configure sso --profile bedrock
+aws sso login --profile bedrock
+```
+
+**Alternative**: Use access keys (less secure)
+```bash
+aws configure --profile bedrock
+# Credentials stored in ~/.aws/credentials (NOT tracked by dotfiles)
+```
+
+### Maven Credentials
+
+**Recommended**: Use Maven password encryption
+```bash
+mvn --encrypt-master-password <password>
+# Stored in ~/.m2/settings-security.xml (NOT tracked by dotfiles)
+```
+
+**Alternative**: Use environment variables
+```bash
+export MAVEN_USERNAME="your-username"
+export MAVEN_PASSWORD="your-password"
+```
+
+### NPM/Yarn Credentials
+
+**Recommended**: Use npm login
+```bash
+npm login --registry=https://registry.your-org.com/
+# Token stored in ~/.npmrc (NOT tracked by dotfiles)
+```
+
+**Alternative**: Set auth token manually
+```bash
+npm config set //registry.your-org.com/:_authToken "YOUR-TOKEN"
+```
+
+## Common Workflows
+
+### New Work Machine Setup
+
+1. Clone dotfiles and run bootstrap:
+   ```bash
+   git clone https://github.com/bradbergeron-us/dotfiles.git ~/dotfiles
+   bash ~/dotfiles/bootstrap.sh
+   ```
+
+2. Setup work configurations:
+   ```bash
+   bash ~/dotfiles/scripts/setup_work_configs.sh
+   ```
+
+3. Configure AWS credentials:
+   ```bash
+   aws configure sso --profile bedrock
+   ```
+
+4. Install certificates (if behind corporate proxy):
+   ```bash
+   bash ~/dotfiles/scripts/install_zscaler_cert.sh
+   ```
+
+5. Verify setup:
+   ```bash
+   mvn help:effective-settings
+   yarn config list
+   aws sts get-caller-identity --profile bedrock
+   claude "Hello world"
+   ```
+
+### Updating Templates
+
+When your organization changes URLs or configuration:
+
+1. Update the template:
+   ```bash
+   cd ~/dotfiles
+   git checkout -b update-maven-template
+   # Edit templates/m2/settings.xml.template
+   git add templates/m2/settings.xml.template
+   git commit -m "Update Maven repository URL"
+   git push
+   ```
+
+2. Update your local config:
+   ```bash
+   # Merge changes from template to your active config
+   diff ~/dotfiles/templates/m2/settings.xml.template ~/.m2/settings.xml
+   # Manually apply relevant changes
+   ```
+
+### Sharing Templates with Team
+
+Templates are designed to be shared:
+
+1. Document your organization's specific values in team wiki
+2. Share the dotfiles repo with team members
+3. Provide organization-specific README addendums
+4. Keep templates up-to-date as infrastructure changes
+
+## Troubleshooting
+
+### Template is out of date
+
+```bash
+cd ~/dotfiles
+git pull origin main
+# Re-copy template if needed
+cp ~/dotfiles/templates/m2/settings.xml.template ~/.m2/settings.xml
+```
+
+### Can't find where to put credentials
+
+Each template's README has a "Configuration Steps" section with detailed credential setup instructions.
+
+### Template placeholders not obvious
+
+Search for these patterns in templates:
+- `REPLACE_WITH_*`
+- `your-org.example.com`
+- `{encrypted-*-here}`
+- `123456789012` (example account numbers)
+- Comments with `Replace with...`
+
+### Need help with specific tool
+
+See individual READMEs:
+- [Maven Setup](m2/README.md)
+- [Yarn Setup](yarnrc.README.md)
+- [AWS Setup](aws/README.md)
+- [Continue IDE Setup](continue/README.md)
+- [Claude Code Setup](claude/README.md)
+
+## Future Enhancements
+
+Planned improvements:
+- [ ] Automated template validation
+- [ ] Interactive setup wizard
+- [ ] Environment-specific template variants (dev, staging, prod)
+- [ ] Integration tests for templates
+- [ ] Pre-commit hooks to prevent committing secrets
+
+## Contributing
+
+When adding new templates:
+
+1. Use `.template` extension
+2. Replace all sensitive values with placeholders
+3. Add comprehensive README.md
+4. Document credential management
+5. Include troubleshooting section
+6. Test on fresh machine
+7. Add to this index
+
+## See Also
+
+- [Dotfiles README](../README.md) - Main dotfiles documentation
+- [Work Machine Setup](../docs/work-machine.md) - Complete work setup guide
+- [Certificates](../certs/README.md) - SSL certificate management
+- [Installers](../installers/README.md) - Binary installer storage

--- a/templates/aws/README.md
+++ b/templates/aws/README.md
@@ -1,0 +1,379 @@
+# AWS CLI Configuration Template
+
+This template provides starting configurations for AWS CLI profiles needed for Bedrock, work accounts, and GovCloud.
+
+## Installation
+
+```bash
+mkdir -p ~/.aws
+cp ~/dotfiles/templates/aws/config.template ~/.aws/config
+chmod 600 ~/.aws/config
+```
+
+Then edit `~/.aws/config` to customize for your environment.
+
+## Configuration Methods
+
+### Option 1: AWS SSO (Recommended - Most Secure)
+
+AWS Single Sign-On integrates with your organization's identity provider.
+
+```bash
+# Configure SSO profile
+aws configure sso --profile bedrock
+
+# Follow the prompts:
+# - SSO start URL: https://your-org.awsapps.com/start (or your org's URL)
+# - SSO region: us-gov-west-1 (or your region)
+# - Select account and role when prompted
+# - CLI default region: us-gov-west-1
+# - CLI output format: json
+
+# Login (opens browser)
+aws sso login --profile bedrock
+
+# Test access
+aws sts get-caller-identity --profile bedrock
+aws bedrock list-foundation-models --profile bedrock
+```
+
+#### Using SSO
+
+```bash
+# Login when token expires (every 1-8 hours depending on org settings)
+aws sso login --profile bedrock
+
+# Use in commands
+aws bedrock list-foundation-models --profile bedrock
+
+# Set as default for shell session
+export AWS_PROFILE=bedrock
+
+# Auto-refresh with aws-sso-util (optional)
+brew install aws-sso-util
+aws-sso-util configure populate --profile bedrock
+```
+
+### Option 2: Access Keys (Less Secure, but Simpler)
+
+For environments where SSO is not available.
+
+```bash
+# Configure profile with access keys
+aws configure --profile bedrock
+
+# Enter when prompted:
+# - AWS Access Key ID: AKIAIOSFODNN7EXAMPLE
+# - AWS Secret Access Key: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+# - Default region: us-gov-west-1
+# - Default output format: json
+
+# Test access
+aws sts get-caller-identity --profile bedrock
+```
+
+**Security Note**: Access keys are less secure than SSO. If you must use them:
+- Store in `~/.aws/credentials` (never commit this file!)
+- Rotate keys every 90 days
+- Use MFA when possible
+- Never share or commit keys
+
+### Option 3: Environment Variables (Temporary)
+
+For testing or temporary access:
+
+```bash
+export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+export AWS_DEFAULT_REGION=us-gov-west-1
+
+# Use without --profile flag
+aws bedrock list-foundation-models
+```
+
+## Profile Configuration
+
+### Bedrock Profile (for Claude Code and Continue)
+
+Edit `~/.aws/config`:
+
+**For SSO:**
+```ini
+[profile bedrock]
+sso_start_url = https://your-org.awsapps.com/start
+sso_region = us-gov-west-1
+sso_account_id = 123456789012
+sso_role_name = BedrockUserRole
+region = us-gov-west-1
+output = json
+```
+
+**For Access Keys:**
+```ini
+[profile bedrock]
+region = us-gov-west-1
+output = json
+```
+
+Then add to `~/.aws/credentials`:
+```ini
+[bedrock]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+```
+
+### GovCloud vs Commercial
+
+**Commercial AWS:**
+- Regions: `us-east-1`, `us-west-2`, etc.
+- SSO URL: Usually `https://yourorg.awsapps.com/start`
+- Model example: `anthropic.claude-3-5-sonnet-20241022-v2:0`
+
+**GovCloud:**
+- Regions: `us-gov-west-1`, `us-gov-east-1`
+- SSO URL: Varies by agency
+- Model example: `us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0`
+
+### Multiple Profiles
+
+```ini
+# Development
+[profile dev-bedrock]
+sso_start_url = https://dev.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 111111111111
+sso_role_name = Developer
+region = us-east-1
+
+# Production
+[profile prod-bedrock]
+sso_start_url = https://prod.awsapps.com/start
+sso_region = us-west-2
+sso_account_id = 222222222222
+sso_role_name = BedrockUser
+region = us-west-2
+
+# GovCloud
+[profile gov-bedrock]
+sso_start_url = https://gov.awsapps.com/start
+sso_region = us-gov-west-1
+sso_account_id = 333333333333
+sso_role_name = GovCloudUser
+region = us-gov-west-1
+```
+
+## Enable Bedrock Model Access
+
+Before using Bedrock models, you must enable access:
+
+1. **Login to AWS Console**
+   ```bash
+   # For SSO profiles
+   aws sso login --profile bedrock
+   ```
+
+2. **Navigate to Bedrock**
+   - Go to: https://console.aws.amazon.com/bedrock/
+   - Or: AWS Console → Services → Bedrock
+
+3. **Request Model Access**
+   - Left sidebar → "Model access"
+   - Click "Manage model access"
+   - Select checkboxes for:
+     - ✓ Anthropic Claude 3.5 Sonnet
+     - ✓ Anthropic Claude 3.7 Sonnet
+     - ✓ Anthropic Claude Opus (if available)
+   - Click "Request model access"
+   - Wait 1-2 minutes for approval (usually instant)
+
+4. **Verify Access**
+   ```bash
+   aws bedrock list-foundation-models --region us-gov-west-1 --profile bedrock
+   ```
+
+## Testing Your Configuration
+
+### Test AWS CLI Access
+
+```bash
+# Test authentication
+aws sts get-caller-identity --profile bedrock
+
+# Should return:
+# {
+#     "UserId": "AIDAI...",
+#     "Account": "123456789012",
+#     "Arn": "arn:aws:iam::123456789012:user/yourname"
+# }
+```
+
+### Test Bedrock Access
+
+```bash
+# List available models
+aws bedrock list-foundation-models \
+  --region us-gov-west-1 \
+  --profile bedrock \
+  --query 'modelSummaries[?contains(modelId, `claude`)].[modelId,modelName]' \
+  --output table
+
+# Invoke a model (test actual inference)
+aws bedrock-runtime invoke-model \
+  --model-id anthropic.claude-3-5-sonnet-20241022-v2:0 \
+  --region us-east-1 \
+  --profile bedrock \
+  --body '{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":"Hello"}],"max_tokens":100}' \
+  /dev/stdout
+```
+
+### Test with Claude Code
+
+```bash
+# Set profile
+export AWS_PROFILE=bedrock
+
+# Test Claude Code
+claude "What is 2+2?"
+```
+
+## Required IAM Permissions
+
+Your IAM user or role needs these permissions for Bedrock:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:ListFoundationModels",
+        "bedrock:GetFoundationModel",
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Contact your AWS administrator if you lack these permissions.
+
+## Troubleshooting
+
+### SSO token expired
+
+**Error**: `The SSO session associated with this profile has expired`
+
+**Solution**:
+```bash
+aws sso login --profile bedrock
+```
+
+SSO tokens typically expire every 1-8 hours depending on your organization's settings.
+
+### Profile not found
+
+**Error**: `The config profile (bedrock) could not be found`
+
+**Solution**: Check your profile name:
+```bash
+aws configure list-profiles
+cat ~/.aws/config
+```
+
+### Access denied to Bedrock
+
+**Error**: `AccessDeniedException` or `UnauthorizedException`
+
+**Solutions**:
+1. Enable model access in Bedrock console (see "Enable Bedrock Model Access" above)
+2. Check IAM permissions include `bedrock:InvokeModel`
+3. Verify you're using the correct region
+4. Wait 1-2 minutes after enabling model access
+
+### Wrong region
+
+**Error**: Model not found or not available
+
+**Solution**: Bedrock is not available in all regions. Use:
+- Commercial: `us-east-1`, `us-west-2`, `eu-west-1`
+- GovCloud: `us-gov-west-1`, `us-gov-east-1`
+
+Check available regions:
+```bash
+aws ec2 describe-regions --query 'Regions[].RegionName' --output table
+```
+
+### Credentials file permissions
+
+**Error**: `Unable to locate credentials`
+
+**Solution**: Ensure proper permissions:
+```bash
+chmod 600 ~/.aws/credentials
+chmod 600 ~/.aws/config
+ls -la ~/.aws/
+```
+
+Files should be readable only by you (`-rw-------`).
+
+## Security Best Practices
+
+### ✅ DO:
+- Use AWS SSO when available
+- Use MFA (multi-factor authentication)
+- Rotate access keys every 90 days
+- Use separate profiles for dev/prod
+- Set `chmod 600` on AWS config files
+- Use principle of least privilege (minimal IAM permissions)
+- Keep AWS CLI updated: `brew upgrade awscli`
+
+### ❌ DON'T:
+- Commit `~/.aws/credentials` to git
+- Share AWS access keys
+- Use root account access keys
+- Store keys in environment variables permanently
+- Disable MFA for convenience
+- Use wildcard permissions (`"Resource": "*"`) unless necessary
+
+## Shell Aliases for Multiple Profiles
+
+Add to `~/.zshrc.local`:
+
+```bash
+# AWS profile switchers
+alias aws-bedrock='export AWS_PROFILE=bedrock'
+alias aws-dev='export AWS_PROFILE=dev'
+alias aws-prod='export AWS_PROFILE=prod'
+alias aws-gov='export AWS_PROFILE=govcloud'
+alias aws-default='unset AWS_PROFILE'
+
+# Check current profile
+alias aws-whoami='aws sts get-caller-identity'
+
+# SSO login helpers
+alias aws-login-bedrock='aws sso login --profile bedrock'
+alias aws-login-dev='aws sso login --profile dev'
+alias aws-login-prod='aws sso login --profile prod'
+```
+
+Usage:
+```bash
+# Switch to bedrock profile
+aws-bedrock
+
+# Check current identity
+aws-whoami
+
+# Use Claude with current profile
+claude "Hello world"
+```
+
+## See Also
+
+- [AWS CLI Configuration Docs](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+- [AWS SSO Configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html)
+- [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+- [IAM Best Practices](https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html)

--- a/templates/aws/config.template
+++ b/templates/aws/config.template
@@ -1,0 +1,50 @@
+# AWS CLI Configuration Template
+# Copy to ~/.aws/config and customize for your environment
+# NEVER put credentials in this file - use ~/.aws/credentials or SSO
+#
+# Installation:
+#   mkdir -p ~/.aws
+#   cp ~/dotfiles/templates/aws/config.template ~/.aws/config
+#   chmod 600 ~/.aws/config
+
+# Default profile (optional)
+[default]
+region = us-east-1
+output = json
+
+# AWS Bedrock profile for AI workloads
+# Use SSO for most secure setup: aws configure sso --profile bedrock
+[profile bedrock]
+region = us-gov-west-1
+output = json
+# For SSO (recommended):
+# sso_start_url = https://your-org.awsapps.com/start
+# sso_region = us-gov-west-1
+# sso_account_id = 123456789012
+# sso_role_name = BedrockUserRole
+#
+# For access keys (less secure):
+# No config needed here, put in ~/.aws/credentials instead
+
+# Work AWS account
+[profile work]
+region = us-east-1
+output = json
+
+# GovCloud profile
+[profile govcloud]
+region = us-gov-west-1
+output = json
+
+# Example: Role assumption
+[profile admin]
+role_arn = arn:aws:iam::123456789012:role/AdminRole
+source_profile = work
+region = us-east-1
+output = json
+
+# Example: Multi-factor authentication
+[profile mfa]
+region = us-east-1
+output = json
+mfa_serial = arn:aws:iam::123456789012:mfa/your-username

--- a/templates/claude/README.md
+++ b/templates/claude/README.md
@@ -1,0 +1,329 @@
+# Claude Code Configuration Template
+
+This template configures Claude Code CLI to use AWS Bedrock models.
+
+## Prerequisites
+
+- Claude Code CLI installed (see installation instructions below)
+- AWS account with Bedrock access
+- AWS CLI installed and configured
+- SSL certificate installed (if behind corporate proxy)
+
+## Installation
+
+### 1. Install Claude Code CLI
+
+**Option A: Download from Claude.ai**
+```bash
+# Download from https://claude.com/download
+# Or use the installer from your Downloads folder
+
+# Make installation directory
+mkdir -p ~/.local/bin
+
+# Run installer (adjust path to your downloaded installer)
+bash ~/Downloads/ClaudeCode-macOS-*/claude-code-installer --prefix="$HOME/.local/bin"
+
+# Verify installation
+claude --version
+```
+
+**Option B: Manual Installation**
+```bash
+# If you already have the binary
+mkdir -p ~/.local/bin
+cp /path/to/claude ~/.local/bin/
+chmod +x ~/.local/bin/claude
+
+# Ensure ~/.local/bin is in your PATH (already set in dotfiles zshrc)
+```
+
+### 2. Configure Claude Code Settings
+
+```bash
+mkdir -p ~/.claude
+cp ~/dotfiles/templates/claude/settings.json.template ~/.claude/settings.json
+```
+
+Then edit `~/.claude/settings.json` to customize:
+
+#### Update Placeholders
+
+1. **Username**: Replace `REPLACE_WITH_YOUR_USERNAME` with your actual username
+   ```bash
+   # Quick replace with sed
+   sed -i '' "s/REPLACE_WITH_YOUR_USERNAME/$USER/g" ~/.claude/settings.json
+   ```
+
+2. **Model IDs**: Update if your organization uses different models
+   - Check available models: `aws bedrock list-foundation-models --region us-gov-west-1 --profile bedrock`
+
+3. **AWS Region**: Update if you're using a different region
+   - Commercial: `us-east-1`, `us-west-2`, etc.
+   - GovCloud: `us-gov-west-1`, `us-gov-east-1`
+
+4. **AWS Profile**: Update to match your AWS CLI profile name
+   - Check profiles: `aws configure list-profiles`
+   - Create new profile: `aws configure sso --profile bedrock`
+
+5. **Certificate Path**: Update if your certificate is in a different location
+   - Or remove `NODE_EXTRA_CA_CERTS` line if not behind corporate proxy
+
+#### Settings Explanation
+
+```json
+{
+  "env": {
+    // Primary model for Claude Code
+    "ANTHROPIC_MODEL": "model-id-here",
+
+    // AWS region where Bedrock is available
+    "AWS_REGION": "us-gov-west-1",
+
+    // AWS CLI profile to use (from ~/.aws/config)
+    "AWS_PROFILE": "bedrock",
+
+    // Enable Bedrock mode (required for AWS Bedrock)
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+
+    // Disable telemetry (optional, for air-gapped environments)
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+
+    // Smaller/faster model for quick operations
+    "ANTHROPIC_SMALL_FAST_MODEL": "anthropic.claude-3-7-sonnet-20250219-v1:0",
+
+    // Maximum tokens for long responses
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+
+    // Thinking tokens (extended thinking mode)
+    "MAX_THINKING_TOKENS": "1024",
+
+    // Corporate SSL certificate (if required)
+    "NODE_EXTRA_CA_CERTS": "/path/to/cert.crt"
+  },
+
+  // Enable extended thinking for complex problems
+  "alwaysThinkingEnabled": false,
+
+  // UI theme (light or dark)
+  "theme": "light"
+}
+```
+
+### 3. Configure AWS Credentials
+
+See [../aws/README.md](../aws/README.md) for detailed AWS setup.
+
+Quick start:
+```bash
+# Configure AWS SSO (recommended)
+aws configure sso --profile bedrock
+
+# Login
+aws sso login --profile bedrock
+
+# Test Bedrock access
+aws bedrock list-foundation-models --region us-gov-west-1 --profile bedrock
+```
+
+### 4. Install SSL Certificate (if required)
+
+If behind a corporate proxy/firewall, install your organization's root certificate:
+
+```bash
+# Create certs directory (Continue uses the same location)
+mkdir -p ~/.continue/certs
+
+# Copy certificate
+cp /path/to/YourOrgRootCertificate.crt ~/.continue/certs/
+
+# Update certificate path in settings.json
+# Replace:  "/Users/REPLACE_WITH_YOUR_USERNAME/.continue/certs/YourOrgRootCertificate.crt"
+# With:     "/Users/yourusername/.continue/certs/YourOrgRootCertificate.crt"
+```
+
+See [../continue/README.md](../continue/README.md) for detailed certificate installation instructions.
+
+### 5. Verify Setup
+
+```bash
+# Test Claude Code
+claude --version
+
+# Test with a simple prompt
+claude "What is 2+2?"
+
+# Test code generation
+cd /tmp
+claude "Create a hello world Python script"
+```
+
+If everything is configured correctly, Claude Code should:
+1. Authenticate using your AWS profile
+2. Connect to Bedrock
+3. Return a response
+
+## Usage
+
+### Basic Commands
+
+```bash
+# Ask a question
+claude "How do I reverse a string in Python?"
+
+# Work on current directory
+cd ~/projects/my-app
+claude "Add error handling to the login function"
+
+# Code review
+claude "Review this file for security issues" --file auth.py
+
+# Git integration
+claude "Help me write a commit message for these changes"
+
+# Interactive mode
+claude
+```
+
+### Advanced Usage
+
+```bash
+# Use specific model
+ANTHROPIC_MODEL=anthropic.claude-opus-4-20250514-v1:0 claude "Complex task here"
+
+# Extended thinking mode
+claude "Solve this complex algorithm problem" --thinking
+
+# Different AWS profile
+AWS_PROFILE=prod-bedrock claude "Check production logs"
+
+# Specify working directory
+claude --cwd /path/to/project "Analyze this codebase"
+```
+
+## Troubleshooting
+
+### "Command not found: claude"
+
+**Cause**: `~/.local/bin` not in PATH
+
+**Solution**: Check that `~/.local/bin` is in PATH (should be set by dotfiles zshrc):
+```bash
+echo $PATH | grep -q ".local/bin" && echo "✓ In PATH" || echo "✗ Not in PATH"
+
+# If not in PATH, reload shell config
+source ~/.zshrc
+
+# Or manually add to current session
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+### "Unable to locate credentials"
+
+**Cause**: AWS credentials not configured or expired
+
+**Solution**:
+```bash
+# Check AWS profile exists
+aws configure list-profiles | grep bedrock
+
+# Re-login to SSO
+aws sso login --profile bedrock
+
+# Or configure access keys
+aws configure --profile bedrock
+```
+
+### SSL Certificate errors
+
+**Symptoms**: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, `SELF_SIGNED_CERT_IN_CHAIN`
+
+**Solution**:
+1. Verify certificate is installed: `ls -la ~/.continue/certs/`
+2. Check `NODE_EXTRA_CA_CERTS` path in `settings.json`
+3. Verify certificate is valid: `openssl x509 -in ~/.continue/certs/*.crt -text -noout`
+
+### "Access denied" or "ThrottlingException"
+
+**Cause**: Bedrock access not enabled or rate limits hit
+
+**Solution**:
+1. Enable Bedrock model access in AWS Console → Bedrock → Model access
+2. Wait 1-2 minutes after enabling
+3. Check IAM permissions include `bedrock:InvokeModel`
+4. For rate limits, wait a moment and retry
+
+### Environment variables not loading
+
+**Cause**: Settings file not in correct location or malformed JSON
+
+**Solution**:
+```bash
+# Check file exists
+ls -la ~/.claude/settings.json
+
+# Validate JSON
+python3 -m json.tool ~/.claude/settings.json
+
+# Check for syntax errors
+cat ~/.claude/settings.json
+```
+
+### Different model needed
+
+Update `ANTHROPIC_MODEL` in `settings.json`:
+
+```json
+{
+  "env": {
+    "ANTHROPIC_MODEL": "anthropic.claude-3-5-sonnet-20241022-v2:0"
+  }
+}
+```
+
+Available models (check with AWS CLI):
+```bash
+aws bedrock list-foundation-models \
+  --region us-gov-west-1 \
+  --profile bedrock \
+  --query 'modelSummaries[?contains(modelId, `claude`)].{ID:modelId,Name:modelName}'
+```
+
+## Security Notes
+
+- **NEVER** commit AWS credentials to this config file
+- Use AWS profiles that reference `~/.aws/credentials` or SSO
+- `settings.json` is safe to commit (contains no secrets, only env var configs)
+- Certificate files (public certs) are safe to commit if needed
+- Rotate AWS credentials regularly per your organization's policy
+
+## Configuration for Multiple Environments
+
+If you work with multiple AWS accounts/regions:
+
+**Option 1: Multiple settings files**
+```bash
+# Development
+cp ~/.claude/settings.json ~/.claude/settings.dev.json
+
+# Production
+cp ~/.claude/settings.json ~/.claude/settings.prod.json
+
+# Use with symlink
+ln -sf ~/.claude/settings.dev.json ~/.claude/settings.json
+```
+
+**Option 2: Shell aliases**
+```bash
+# Add to ~/.zshrc.local
+alias claude-dev='AWS_PROFILE=dev-bedrock AWS_REGION=us-east-1 claude'
+alias claude-prod='AWS_PROFILE=prod-bedrock AWS_REGION=us-west-2 claude'
+alias claude-gov='AWS_PROFILE=gov-bedrock AWS_REGION=us-gov-west-1 claude'
+```
+
+## See Also
+
+- [Claude Code Documentation](https://docs.anthropic.com/claude-code)
+- [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+- [AWS CLI Configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+- [Continue IDE Setup](../continue/README.md) - Similar configuration for VS Code

--- a/templates/claude/settings.json.template
+++ b/templates/claude/settings.json.template
@@ -1,0 +1,15 @@
+{
+  "env": {
+    "ANTHROPIC_MODEL": "us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0",
+    "AWS_REGION": "us-gov-west-1",
+    "AWS_PROFILE": "bedrock",
+    "CLAUDE_CODE_USE_BEDROCK": "1",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "ANTHROPIC_SMALL_FAST_MODEL": "anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+    "MAX_THINKING_TOKENS": "1024",
+    "NODE_EXTRA_CA_CERTS": "/Users/REPLACE_WITH_YOUR_USERNAME/.continue/certs/YourOrgRootCertificate.crt"
+  },
+  "alwaysThinkingEnabled": false,
+  "theme": "light"
+}

--- a/templates/continue/README.md
+++ b/templates/continue/README.md
@@ -1,0 +1,257 @@
+# Continue IDE Configuration Template
+
+This template configures the Continue IDE extension to use AWS Bedrock models (Claude Sonnet).
+
+## Prerequisites
+
+- AWS account with Bedrock access
+- AWS CLI installed (`brew install awscli`)
+- Continue IDE extension for VS Code
+- AWS credentials configured (see [../aws/README.md](../aws/README.md))
+
+## Installation
+
+```bash
+mkdir -p ~/.continue
+cp ~/dotfiles/templates/continue/config.yaml.template ~/.continue/config.yaml
+```
+
+Then edit `~/.continue/config.yaml` to customize for your environment.
+
+## Configuration Steps
+
+### 1. Update Model Configuration
+
+Replace these placeholders in `config.yaml`:
+
+```yaml
+# Model ID or ARN - check AWS Bedrock console for available models
+model: us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0
+
+# AWS region where Bedrock is enabled
+region: us-gov-west-1
+
+# AWS profile name from ~/.aws/config
+profile: bedrock
+```
+
+#### Finding Your Model ID
+
+**For AWS Commercial:**
+```bash
+aws bedrock list-foundation-models --region us-east-1 \
+  --query 'modelSummaries[?contains(modelId, `claude`)].modelId'
+```
+
+**For AWS GovCloud:**
+```bash
+aws bedrock list-foundation-models --region us-gov-west-1 \
+  --query 'modelSummaries[?contains(modelId, `claude`)].modelId' \
+  --profile your-govcloud-profile
+```
+
+Common model IDs:
+- Commercial: `anthropic.claude-3-5-sonnet-20241022-v2:0`
+- GovCloud: `us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0`
+
+### 2. Configure AWS Credentials
+
+See [../aws/README.md](../aws/README.md) for detailed AWS credential setup.
+
+Quick start:
+```bash
+# For SSO (recommended)
+aws configure sso --profile bedrock
+
+# Test access
+aws bedrock list-foundation-models --region us-gov-west-1 --profile bedrock
+```
+
+### 3. Install SSL Certificate (if behind corporate proxy)
+
+If your organization uses a custom SSL certificate (e.g., Zscaler), you'll need to install it.
+
+#### Obtaining the Certificate
+
+Ask your IT department for your organization's root certificate, or export it from your browser:
+
+**From Chrome/Edge:**
+1. Visit any HTTPS site
+2. Click the lock icon → Connection is secure → Certificate is valid
+3. Certificate Viewer → Details → Export
+4. Save as `YourOrgRootCertificate.crt`
+
+**From Firefox:**
+1. Preferences → Privacy & Security → View Certificates
+2. Authorities tab → Select your org's certificate
+3. Export → Save as `YourOrgRootCertificate.crt`
+
+#### Installing the Certificate
+
+```bash
+# Create certs directory
+mkdir -p ~/.continue/certs
+
+# Copy certificate
+cp /path/to/YourOrgRootCertificate.crt ~/.continue/certs/
+
+# Add to Node.js environment
+echo 'export NODE_EXTRA_CA_CERTS="$HOME/.continue/certs/YourOrgRootCertificate.crt"' >> ~/.zshrc.local
+
+# Reload shell
+source ~/.zshrc
+```
+
+#### System Keychain (optional but recommended)
+
+Install to macOS System Keychain for system-wide trust:
+```bash
+sudo security add-trusted-cert -d -r trustRoot \
+  -k /Library/Keychains/System.keychain \
+  ~/.continue/certs/YourOrgRootCertificate.crt
+```
+
+### 4. Verify Setup
+
+```bash
+# Check AWS credentials work
+aws bedrock list-foundation-models --region us-gov-west-1 --profile bedrock
+
+# Test Continue in VS Code
+# 1. Open VS Code
+# 2. Open Continue panel (Cmd+L or click Continue icon)
+# 3. Type a test prompt: "Hello, can you help me write code?"
+```
+
+## Customization
+
+### Adding Additional Models
+
+You can add more models to support different use cases:
+
+```yaml
+models:
+  - name: Claude Opus (Powerful)
+    provider: bedrock
+    model: anthropic.claude-opus-4-20250514-v1:0
+    env:
+      region: us-east-1
+      profile: bedrock
+    roles: [chat, edit]
+
+  - name: Claude Haiku (Fast)
+    provider: bedrock
+    model: anthropic.claude-3-5-haiku-20241022-v1:0
+    env:
+      region: us-east-1
+      profile: bedrock
+    roles: [chat]
+    defaultCompletionOptions:
+      temperature: 0.3
+      maxTokens: 4096
+```
+
+### Custom Rules
+
+Modify the `rules` section to customize AI behavior:
+
+```yaml
+rules:
+  - Use TypeScript for all JavaScript code
+  - Follow Airbnb style guide for JavaScript/TypeScript
+  - Always include JSDoc comments for public functions
+  - Write Jest tests for all new functions
+  - Use functional programming patterns when possible
+```
+
+### Context Providers
+
+Enable/disable context providers based on your workflow:
+
+```yaml
+context:
+  - provider: codebase      # Semantic code search
+  - provider: code          # Code snippets
+  - provider: open          # Open files
+  - provider: problems      # Linter errors
+  - provider: currentFile   # Current file
+  - provider: docs          # Documentation
+  - provider: diff          # Git diff
+  - provider: folder        # Folder tree
+  - provider: terminal      # Terminal output
+  # - provider: postgres    # Database schema (requires setup)
+  # - provider: database    # General database
+```
+
+## Troubleshooting
+
+### "Unable to invoke model" error
+
+**Cause**: Bedrock access not enabled for your AWS account/region
+
+**Solution**:
+1. Go to AWS Bedrock console
+2. Navigate to "Model access" in the left sidebar
+3. Click "Manage model access"
+4. Enable access for Claude models
+5. Wait 1-2 minutes for access to be granted
+
+### SSL Certificate errors
+
+**Symptoms**: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, `CERT_HAS_EXPIRED`, `SELF_SIGNED_CERT_IN_CHAIN`
+
+**Solution**: Install your organization's root certificate (see step 3 above)
+
+### "Invalid AWS credentials" error
+
+**Cause**: AWS profile not configured or credentials expired
+
+**Solution**:
+```bash
+# For SSO, re-login
+aws sso login --profile bedrock
+
+# For access keys, reconfigure
+aws configure --profile bedrock
+```
+
+### Models appear but don't respond
+
+**Cause**: Network/firewall blocking AWS Bedrock API calls
+
+**Solution**:
+1. Check corporate proxy settings
+2. Verify `NO_PROXY` environment variable doesn't block AWS
+3. Test with `curl` to verify connectivity:
+   ```bash
+   aws bedrock-runtime invoke-model \
+     --model-id anthropic.claude-3-5-sonnet-20241022-v2:0 \
+     --body '{"anthropic_version":"bedrock-2023-05-31","messages":[{"role":"user","content":"Hello"}],"max_tokens":100}' \
+     --region us-east-1 \
+     --profile bedrock \
+     /dev/stdout
+   ```
+
+### Continue extension not loading config
+
+**Location**: Verify config file is in the correct location:
+```bash
+ls -la ~/.continue/config.yaml
+```
+
+**Reload**: Restart VS Code or reload the window (Cmd+Shift+P → "Reload Window")
+
+## Security Notes
+
+- **NEVER** commit AWS credentials to this config file
+- Use AWS profiles (references to `~/.aws/credentials`)
+- Rotate AWS access keys regularly per your organization's policy
+- Use AWS SSO/IAM Identity Center when available (more secure than access keys)
+- Certificate files are safe to commit (public certificates only)
+
+## See Also
+
+- [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+- [Continue Documentation](https://docs.continue.dev/)
+- [AWS CLI Configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)
+- [AWS SSO Configuration](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-sso.html)

--- a/templates/continue/config.yaml.template
+++ b/templates/continue/config.yaml.template
@@ -1,0 +1,63 @@
+---
+# Continue IDE Configuration Template for AWS Bedrock
+# Copy to ~/.continue/config.yaml and customize for your environment
+# See README.md for detailed setup instructions
+
+name: AWS Bedrock Configuration
+version: 0.0.1
+schema: v1
+
+models:
+  - name: AWS Bedrock - Claude 4.5 Sonnet
+    provider: bedrock
+    # Replace with your model ARN or ID
+    model: us-gov.anthropic.claude-sonnet-4-5-20250929-v1:0
+    env:
+      # Replace with your AWS region
+      region: us-gov-west-1
+      # Replace with your AWS profile name (from ~/.aws/config)
+      profile: bedrock
+    roles:
+      - chat
+      - edit
+      - apply
+      - summarize
+    defaultCompletionOptions:
+      temperature: 0.5
+      maxTokens: 8192
+
+  - name: AWS Bedrock - Claude 3.7 Sonnet
+    provider: bedrock
+    # Replace with your model ARN or ID
+    model: arn:aws-us-gov:bedrock:us-gov-west-1::foundation-model/anthropic.claude-3-7-sonnet-20250219-v1:0
+    env:
+      # Replace with your AWS region
+      region: us-gov-west-1
+      # Replace with your AWS profile name
+      profile: bedrock
+    roles:
+      - chat
+      - edit
+      - apply
+      - summarize
+    defaultCompletionOptions:
+      temperature: 0.5
+      maxTokens: 8192
+
+context:
+  - provider: codebase
+  - provider: code
+  - provider: open
+  - provider: problems
+  - provider: currentFile
+  - provider: docs
+  - provider: diff
+  - provider: folder
+  - provider: terminal
+
+rules:
+  - Act as an expert software developer that can write code that is clean,
+    efficient, and well-documented as well as write unit tests for the code
+    proposed
+  - Give concise responses
+  - Always annotate functions with their parameter and return types

--- a/templates/m2/README.md
+++ b/templates/m2/README.md
@@ -1,0 +1,99 @@
+# Maven Configuration Template
+
+This template provides a starting point for Maven configuration on work machines with corporate Nexus/Artifactory repositories.
+
+## Installation
+
+```bash
+mkdir -p ~/.m2
+cp ~/dotfiles/templates/m2/settings.xml.template ~/.m2/settings.xml
+```
+
+Then edit `~/.m2/settings.xml` to replace placeholder URLs with your organization's actual repository URLs.
+
+## Configuration Steps
+
+### 1. Update Repository URLs
+
+Replace these placeholder URLs with your actual organization URLs:
+- `https://nexus.example.com/repository/maven-public/`
+
+### 2. Configure Credentials
+
+Maven credentials should **never** be stored in plain text. Use one of these methods:
+
+#### Option A: Maven Password Encryption (Recommended)
+
+```bash
+# Step 1: Create a master password
+mvn --encrypt-master-password your-master-password
+
+# Step 2: Store it in ~/.m2/settings-security.xml
+cat > ~/.m2/settings-security.xml << 'EOF'
+<settingsSecurity>
+  <master>{YOUR-ENCRYPTED-MASTER-PASSWORD-HERE}</master>
+</settingsSecurity>
+EOF
+
+# Step 3: Encrypt your server password
+mvn --encrypt-password your-server-password
+
+# Step 4: Add encrypted password to ~/.m2/settings.xml under <servers>
+```
+
+#### Option B: Environment Variables
+
+```bash
+# Add to ~/.zshrc.local
+export MAVEN_USERNAME="your-username"
+export MAVEN_PASSWORD="your-password"
+```
+
+Then reference in settings.xml:
+```xml
+<server>
+  <id>nexus</id>
+  <username>${env.MAVEN_USERNAME}</username>
+  <password>${env.MAVEN_PASSWORD}</password>
+</server>
+```
+
+#### Option C: Credential Helper (if available)
+
+Some organizations provide credential helpers that integrate with your SSO or credential manager.
+
+### 3. Verify Setup
+
+```bash
+# Test Maven can access your repository
+mvn help:effective-settings
+
+# Try a simple dependency download
+mvn dependency:get -Dartifact=org.apache.commons:commons-lang3:3.12.0
+```
+
+## Troubleshooting
+
+### "Unable to find valid certification path"
+
+Your organization likely uses a custom SSL certificate. See [../continue/README.md](../continue/README.md) for certificate installation instructions.
+
+### "Unauthorized" or "403 Forbidden"
+
+Check your credentials are configured correctly. Verify with your organization's documentation.
+
+### Repository returns 404 for valid artifacts
+
+Verify your mirror and repository URLs are correct. Some organizations have separate repositories for releases vs snapshots.
+
+## Security Notes
+
+- **NEVER** commit `~/.m2/settings.xml` with real credentials
+- Use encrypted passwords or credential helpers
+- The `settings-security.xml` file should also not be committed
+- Rotate your credentials regularly per your organization's policy
+
+## See Also
+
+- [Maven Password Encryption Guide](https://maven.apache.org/guides/mini/guide-encryption.html)
+- [Maven Settings Reference](https://maven.apache.org/settings.html)

--- a/templates/m2/settings.xml.template
+++ b/templates/m2/settings.xml.template
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Maven Settings Template for Work Machines
+     Copy to ~/.m2/settings.xml and customize for your environment
+     DO NOT commit this file with actual credentials -->
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                              http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+    <mirrors>
+        <mirror>
+            <id>nexus</id>
+            <mirrorOf>*</mirrorOf>
+            <!-- Replace with your organization's Nexus/Artifactory URL -->
+            <url>https://nexus.example.com/repository/maven-public/</url>
+        </mirror>
+    </mirrors>
+
+    <profiles>
+        <profile>
+            <id>corporate</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <!-- Replace with your organization's Maven repository URL -->
+                    <url>https://nexus.example.com/repository/maven-public</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                    </snapshots>
+                    <releases>
+                        <enabled>true</enabled>
+                        <updatePolicy>always</updatePolicy>
+                        <checksumPolicy>warn</checksumPolicy>
+                    </releases>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <activeProfiles>
+        <activeProfile>corporate</activeProfile>
+    </activeProfiles>
+
+    <servers>
+        <server>
+            <id>nexus</id>
+            <!-- Credentials should be encrypted using Maven password encryption
+                 See: https://maven.apache.org/guides/mini/guide-encryption.html
+
+                 To encrypt your password:
+                 1. Create master password: mvn --encrypt-master-password <password>
+                 2. Store in ~/.m2/settings-security.xml
+                 3. Encrypt server password: mvn --encrypt-password <password>
+                 4. Add encrypted password below
+
+                 Alternative: Use credential helpers or environment variables
+            -->
+            <!-- <username>your-username</username> -->
+            <!-- <password>{encrypted-password-here}</password> -->
+        </server>
+    </servers>
+</settings>

--- a/templates/yarnrc.README.md
+++ b/templates/yarnrc.README.md
@@ -1,0 +1,103 @@
+# Yarn Configuration Template
+
+This template configures Yarn to use your organization's npm registry (JFrog Artifactory, Nexus, etc.).
+
+## Installation
+
+```bash
+cp ~/dotfiles/templates/yarnrc.template ~/.yarnrc
+```
+
+Then edit `~/.yarnrc` to replace the placeholder registry URL.
+
+## Configuration Steps
+
+### 1. Update Registry URL
+
+Replace `https://registry.example.com/artifactory/api/npm/npm-proxy/` with your organization's actual npm registry URL.
+
+Common formats:
+- JFrog Artifactory: `https://your-org.jfrog.io/artifactory/api/npm/npm-proxy/`
+- Nexus: `https://nexus.your-org.com/repository/npm-group/`
+- Azure Artifacts: `https://pkgs.dev.azure.com/your-org/_packaging/your-feed/npm/registry/`
+
+### 2. Configure Authentication
+
+Authentication credentials should be stored separately in `~/.npmrc`, not in `.yarnrc`.
+
+```bash
+# Set authentication for your registry
+npm config set //registry.example.com/artifactory/api/npm/npm-proxy/:_authToken "YOUR-TOKEN-HERE"
+
+# Or use npm login if your registry supports it
+npm login --registry=https://registry.example.com/artifactory/api/npm/npm-proxy/
+```
+
+### 3. SSL Certificate (if required)
+
+If your organization uses a custom SSL certificate (e.g., Zscaler), you may need to:
+
+**Option A: Set strict-ssl to false** (less secure, but sometimes required)
+```bash
+yarn config set strict-ssl false
+```
+
+**Option B: Install the certificate** (more secure)
+```bash
+# See ../continue/README.md for certificate installation instructions
+# Add to ~/.zshrc.local:
+export NODE_EXTRA_CA_CERTS="$HOME/.continue/certs/YourOrgRootCertificate.crt"
+```
+
+### 4. Verify Setup
+
+```bash
+# Test yarn can access your registry
+yarn config list
+
+# Try installing a package
+yarn add lodash
+```
+
+## Yarn vs NPM
+
+This setup works for both Yarn and NPM since they share the `~/.npmrc` authentication config.
+
+```bash
+# Both should work after configuration
+yarn add package-name
+npm install package-name
+```
+
+## Troubleshooting
+
+### "Couldn't find package" errors
+
+Verify your registry URL is correct and accessible:
+```bash
+curl -I https://registry.example.com/artifactory/api/npm/npm-proxy/
+```
+
+### SSL/Certificate errors
+
+Either install your organization's root certificate or set `strict-ssl false`.
+
+### Authentication failures
+
+Check your auth token is set correctly:
+```bash
+npm config get //registry.example.com/artifactory/api/npm/npm-proxy/:_authToken
+```
+
+## Security Notes
+
+- **NEVER** commit auth tokens to `.yarnrc` or `.npmrc`
+- Tokens should be stored in `~/.npmrc` (not tracked by dotfiles)
+- The `.yarnrc` file is safe to commit (only contains public registry URLs)
+- Rotate your tokens regularly per your organization's policy
+
+## See Also
+
+- [Yarn Configuration Docs](https://classic.yarnpkg.com/en/docs/yarnrc/)
+- [NPM Config Docs](https://docs.npmjs.com/cli/v9/configuring-npm/npmrc)
+- [JFrog Artifactory NPM Setup](https://www.jfrog.com/confluence/display/JFROG/npm+Registry)

--- a/templates/yarnrc.template
+++ b/templates/yarnrc.template
@@ -1,0 +1,22 @@
+# Yarn Configuration Template for Work Machines
+# Copy to ~/.yarnrc and customize for your environment
+# DO NOT commit this file with actual auth tokens
+#
+# Installation:
+#   cp ~/dotfiles/templates/yarnrc.template ~/.yarnrc
+#
+# Note: Authentication is typically handled by a separate .npmrc file
+# or yarn config commands. Never commit auth tokens to this file.
+
+# Replace with your organization's npm registry URL
+registry "https://registry.example.com/artifactory/api/npm/npm-proxy/"
+
+# Require authentication for all packages
+always-auth true
+
+# SSL configuration
+# Set to false only if your organization requires it (security risk)
+# strict-ssl true
+
+# Update check
+# lastUpdateCheck is managed by yarn, safe to commit


### PR DESCRIPTION
Created template structure for work-specific configurations:
- Maven (.m2/settings.xml) for corporate Nexus/Artifactory
- Yarn (.yarnrc) for corporate npm registries
- AWS CLI profiles for Bedrock access
- Continue IDE configuration for AWS Bedrock models
- Claude Code CLI configuration for AWS Bedrock

Each template includes:
- Safe placeholder values (no real credentials)
- Comprehensive README with setup instructions
- Troubleshooting guides and security notes
- .gitignore to prevent accidental secret commits

Security measures:
- All sensitive values use placeholders
- Credential management documented separately
- Templates safe to commit to public repos
- .gitignore blocks actual certs and installers

This enables fully scripted work laptop setup from fresh macOS install without manual configuration or risk of committing secrets.

See templates/README.md for usage instructions.