### PR TITLE
docs: add CONTRIBUTING.md and consolidate GPG signing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,97 @@
+# Contributing
+
+A maintainer-facing guide to how this repository is wired together and the conventions to follow when changing it. For day-to-day usage (install, update, the tool list), see the [README](README.md).
+
+## Lifecycle
+
+Four entry-point scripts form the pipeline; everything in `scripts/` exists to support them.
+
+1. **`bootstrap.sh`** (bash) — one-time setup on a fresh Mac. Runs `scripts/preflight.sh` first (unless `--skip-preflight` or `--dry-run`), installs Homebrew and the `Brewfile`, language runtimes via `mise`, Rust via `rustup`, and `git-lfs`, then hands off to `install.sh` for symlinks, and finally prompts for work configs (`scripts/setup_work_configs.sh`) and macOS defaults (`macos.sh`). Supports `--dry-run` and `--skip-preflight`.
+2. **`install.sh`** (zsh) — the symlinker. Links every tracked dotfile into `$HOME`, backing up any pre-existing real file to `~/.dotfiles_backup/<timestamp>/`. It also seeds `~/.config/git/local.gitconfig` from `gitconfig.local.example` and installs a global pre-commit hook at `~/.config/git/hooks/pre-commit`. Idempotent: a second run relinks nothing already correct and reports `linked / current / backed up`.
+3. **`update.sh`** (bash) — keep-current. `git pull --rebase --autostash`, re-runs `install.sh` to pick up new symlinks, upgrades Homebrew / `mise` / `rustup` / gems / `uv` tools, then runs `verify.sh`. Schedulable via `setup-scheduler.sh` (launchd, daily at 9 AM).
+4. **`verify.sh`** (bash) — health check. Seven checks: symlinks, `mise.toml` vs `bootstrap.sh` version drift, required tools, stale backups, SSH key, global git-lfs init, and mise-installed runtimes. Broken symlinks are the only hard error (exit 1); everything else is a warning (exit 0).
+
+```
+bootstrap.sh ──▶ install.sh ──▶ update.sh ──▶ verify.sh
+  (preflight)    (symlinks +     (re-link +     (health
+                  backups)        upgrades)       check)
+```
+
+## Layout
+
+- **Root** — entry scripts (`bootstrap.sh`, `install.sh`, `update.sh`, `verify.sh`, `setup-scheduler.sh`, `macos.sh`) and the tracked dotfiles themselves (`zshrc`, `zprofile`, `gitconfig`, `tmux.conf`, …).
+- **`scripts/`** — helpers, supporting/work-setup scripts, and unit tests (see below). Has its own [README](scripts/README.md).
+- **`config/`** — XDG configs symlinked under `~/.config` (`starship.toml`, `mise.toml`, `direnvrc`).
+- **`templates/`** — work / secret-bearing configs shipped as `*.template` placeholders (see [templates/README.md](templates/README.md)).
+- **`docs/`** — long-form documentation. **`.github/workflows/`** — CI.
+
+## Helpers
+
+- **`scripts/bootstrap_helpers.sh`** — sourced by `bootstrap.sh`, `update.sh`, and `verify.sh`. Side-effect-free output helpers: `setup_colors`, `step`, `info`, `success`, `warn`. Call `setup_colors` once after sourcing.
+- **`scripts/verify_helpers.sh`** — sourced by `verify.sh`. Pure check functions (`check_symlinks`, `check_mise_version_drift`, `check_required_tools`, `check_ssh_key`, `check_git_lfs_global`, `check_mise_installed`, `check_stale_backups`). Each sets result globals (e.g. `SYMLINK_BROKEN_COUNT`, `SYMLINK_BROKEN_LIST`) rather than printing or exiting, which makes them unit-testable. The canonical symlink map lives here as the `DOTFILES_SYMLINKS` array.
+- **`scripts/dryrun_helpers.sh`** — sourced by `bootstrap.sh` only when `--dry-run` is set. Provides `dry_run_step`, per-step `check_*` previews that record intended actions via `dry_run_log`, and `show_dry_run_summary`.
+- **`scripts/preflight.sh`** — standalone (defines its own colors and `error`/`warn`/`success`/`info`). Validates the system before bootstrap.
+
+## Dry-run and pre-flight
+
+Two independent safety layers; full user-facing detail is in [docs/DRY_RUN_AND_PREFLIGHT.md](docs/DRY_RUN_AND_PREFLIGHT.md).
+
+- **Pre-flight** (`scripts/preflight.sh`) — read-only system checks (OS, arch, disk, network, permissions, existing dotfiles, …). Exit codes: `0` ready, `1` critical failure, `2` warnings only; `--strict` promotes warnings to failure. `bootstrap.sh` runs it automatically and aborts on exit 1.
+- **Dry-run** (`bootstrap.sh --dry-run`) — sources `dryrun_helpers.sh` and reports what each step *would* do without changing anything, ending in a numbered summary. When you change a real bootstrap step, update its matching `check_*` preview in `dryrun_helpers.sh` in lockstep so dry-run stays honest.
+
+## Tests
+
+Tests are plain bash scripts under `scripts/test_*.sh` — there is no test framework. Run one directly:
+
+```bash
+bash scripts/test_verify_helpers.sh
+bash scripts/test_bootstrap_helpers.sh
+```
+
+Convention (see `scripts/test_verify_helpers.sh` for the reference implementation):
+
+- `set -euo pipefail`; `pass` / `fail` helpers that increment run/pass/fail counters.
+- Build fixtures under a single `mktemp -d` directory and clean it up with `trap '...' EXIT`.
+- Source the helper under test inside a subshell `( ... )` so its globals don't leak between cases.
+- Assert on the result globals the helper sets, and `exit 1` at the end if any test failed.
+
+Because the helpers are side-effect-free, tests exercise them directly against temporary `$HOME` / fixture directories.
+
+## CI
+
+- **`.github/workflows/ci.yml`** — three jobs: `shellcheck` (bash scripts, `-S warning`), `zsh-syntax` (`zsh -n` on the zsh files plus a `Brewfile` parse check), and `install-smoke` (runs `zsh install.sh` against a throwaway `$HOME` and asserts every expected symlink exists).
+- **`.github/workflows/test-bootstrap.yml`** — runs the `scripts/test_*.sh` unit tests (currently `test_bootstrap_helpers.sh` and `test_verify_helpers.sh`) plus `bash -n` syntax checks when the relevant scripts change.
+
+## Common tasks
+
+### Add a managed dotfile
+
+A tracked dotfile is represented in several independent lists. Update all of them so install, verify, dry-run, CI, and the docs stay in agreement:
+
+1. Add the file to the repo (root, or `config/` for XDG configs).
+2. **`install.sh`** — add a `symlink "$DOTFILES_DIR/<src>" "$HOME/<dest>"` line.
+3. **`scripts/verify_helpers.sh`** — add `"<src>:<dest>"` to the `DOTFILES_SYMLINKS` array so `verify.sh` checks it.
+4. **`scripts/dryrun_helpers.sh`** — add the same pair to the list in `check_dotfile_symlinks` so `--dry-run` previews it.
+5. **`README.md`** — add a row to the Dotfiles table.
+6. **`.github/workflows/ci.yml`** — add the destination to the install-smoke symlink list so the smoke test verifies it.
+
+### Add a configuration template
+
+Templates exist for configs that can't be committed verbatim because they carry environment-specific or secret values. See [templates/README.md](templates/README.md).
+
+1. Add `templates/<area>/<file>.template` (or a top-level `*.template`).
+2. **Placeholders only** — never commit real secrets, tokens, keys, or internal URLs. Use obvious placeholders such as `REPLACE_WITH_YOUR_USERNAME`, `your-org.example.com`, or `{encrypted-password-here}`, to be replaced after the file is copied into place.
+3. Document it: add a short README in the template directory and a row to the index table in `templates/README.md`.
+4. If it is part of work-machine setup, wire copying into `scripts/setup_work_configs.sh`.
+
+### Add a verify check
+
+Add a side-effect-free `check_*` function to `scripts/verify_helpers.sh` that sets result globals, add cases for it to `scripts/test_verify_helpers.sh`, then wire a `step` + report block into `verify.sh`.
+
+## Before you commit
+
+- Run `shellcheck -S warning <script>` on any bash you touched, and `zsh -n <file>` on zsh files (`install.sh`, `scripts/setup_gpg_signing.sh`, `zshrc`, `zprofile`).
+- Run the relevant `scripts/test_*.sh`.
+- For changes to install/verify behavior, exercise them against an isolated `HOME=$(mktemp -d)`.
+- New bash scripts start with `#!/usr/bin/env bash` and `set -euo pipefail`, and reuse `scripts/bootstrap_helpers.sh` for output.
+- A repo-local pre-commit hook runs when `pre-commit` is installed and a `.pre-commit-config.yaml` is present.

--- a/README.md
+++ b/README.md
@@ -264,146 +264,17 @@ Covers Go/Rust overrides, Maven aliases, Java switching, direnv examples, corpor
 
 ## Git Commit Signing
 
-This dotfiles repo uses **conditional GPG signing** based on repository location. Commits are automatically signed with the appropriate key depending on which organization the repository belongs to.
-
-### Directory Structure
-
-Organize your repositories by organization for automatic signing:
-
-```
-~/Code/
-├── work1/            # Work organization 1 (auto-signs with work email)
-│   ├── project-a
-│   ├── project-b
-│   └── ...
-├── work2/            # Work organization 2 (auto-signs with work email)
-│   ├── client-x
-│   ├── client-y
-│   └── ...
-└── personal/         # Personal projects (unsigned or use personal key)
-    ├── my-app
-    ├── dotfiles
-    └── side-projects
-```
-
-### Setting Up GPG Keys
-
-#### 1. Generate work-specific GPG keys
+Commit signing is wired up but **off by default** in the committed `gitconfig` (`commit.gpgsign = false`). Enable it per machine in `~/.config/git/local.gitconfig`, or sign automatically per organization for repositories under `~/Code/workN/` via Git's `includeIf` directives.
 
 ```bash
-# Work organization 1 key
-gpg --full-generate-key
-# Choose: RSA and RSA, 4096 bits, no expiration
-# Email: your.name@work1.com
+# Generate or select a GPG key and record it in ~/.config/git/local.gitconfig
+zsh ~/dotfiles/scripts/setup_gpg_signing.sh
 
-# Work organization 2 key (if applicable)
-gpg --full-generate-key
-# Email: your.name@work2.com
-
-# Personal key (optional, for personal repos)
-gpg --full-generate-key
-# Email: your.name@personal.com
-```
-
-#### 2. Get your GPG key IDs
-
-```bash
-gpg --list-secret-keys --keyid-format=long
-
-# Example output:
-# sec   rsa4096/7FF14C4EDCDD84B3 2026-06-09 [SCEAR]
-#       ^^^^^^^^^^^^^^^^^^^^
-#       This is your key ID
-```
-
-#### 3. Add public keys to respective services
-
-```bash
-# Export public keys (replace KEY_ID with your actual key IDs)
-gpg --armor --export YOUR_WORK1_KEY_ID
-gpg --armor --export YOUR_WORK2_KEY_ID
-gpg --armor --export YOUR_PERSONAL_KEY_ID
-```
-
-Add to respective services:
-- **Work GitHub/GitLab**: Your organization's git service settings
-- **Personal GitHub**: https://github.com/settings/gpg/new
-- **Other services**: Bitbucket, Azure DevOps, etc.
-
-#### 4. Configure conditional git configs
-
-Create config files from templates:
-
-```bash
-# Work organization 1 configuration
-cp ~/dotfiles/templates/config/git/work.gitconfig.template ~/.config/git/work1.gitconfig
-# Edit ~/.config/git/work1.gitconfig and set your work email and GPG key ID
-
-# Work organization 2 configuration (if applicable)
-cp ~/dotfiles/templates/config/git/work.gitconfig.template ~/.config/git/work2.gitconfig
-# Edit ~/.config/git/work2.gitconfig and set your work email and GPG key ID
-```
-
-#### 5. Verify configuration
-
-```bash
+# Verify per-organization signing once configured
 bash ~/dotfiles/scripts/verify_git_signing.sh
 ```
 
-Expected output:
-```
-🔍 Verifying git signing configuration...
-
-✅ PASS Work Organization 1
-  Email:      your.name@work1.com
-  Signing key: YOUR_WORK1_KEY_ID
-  Auto-sign:  true
-
-✅ PASS Work Organization 2
-  Email:      your.name@work2.com
-  Signing key: YOUR_WORK2_KEY_ID
-  Auto-sign:  true
-
-✅ All git signing configurations are correct!
-```
-
-### How It Works
-
-The main `gitconfig` uses `includeIf` directives to automatically load organization-specific configs:
-
-```gitconfig
-# Auto-loads when working in ~/Code/work1/
-[includeIf "gitdir:~/Code/work1/"]
-    path = ~/.config/git/work1.gitconfig
-
-# Auto-loads when working in ~/Code/work2/
-[includeIf "gitdir:~/Code/work2/"]
-    path = ~/.config/git/work2.gitconfig
-```
-
-Each organization config overrides:
-- `user.email` → Organization-specific email
-- `user.signingkey` → Organization-specific GPG key
-- `commit.gpgsign` → Enable signing
-
-### Troubleshooting
-
-**Commits not being signed:**
-```bash
-# Check which config is active
-cd ~/Code/work1/your-project
-git config --list --show-origin | grep -E 'user|commit|signing'
-```
-
-**Verify GPG key works:**
-```bash
-echo "test" | gpg --clearsign --default-key YOUR_GPG_KEY_ID
-```
-
-**Disable signing globally (emergency rollback):**
-```bash
-git config --global commit.gpgsign false
-```
+See **[docs/GPG_SIGNING.md](docs/GPG_SIGNING.md)** for the full guide — GPG and SSH signing, per-organization (`work1`/`work2`) conditional configs, uploading keys to GitHub/GitLab/Bitbucket, and troubleshooting.
 
 ---
 

--- a/docs/GPG_SIGNING.md
+++ b/docs/GPG_SIGNING.md
@@ -61,7 +61,14 @@ Edit `~/.config/git/local.gitconfig`:
 	signingkey = EFF15FEC389D0F89
 ```
 
-The main `~/.gitconfig` is already configured to sign all commits and tags.
+The main `~/.gitconfig` sets `gpg.format = openpgp` and points Git at your `gpg` program, but leaves `commit.gpgsign = false` by default. To sign every commit on this machine, also enable signing in `~/.config/git/local.gitconfig`:
+
+```gitconfig
+[commit]
+	gpgsign = true
+```
+
+To sign only in specific directories instead, leave the global default off and use [Per-Organization (Conditional) Signing](#per-organization-conditional-signing) below — those configs enable signing automatically.
 
 ### 5. Export Your Public Key
 
@@ -92,6 +99,51 @@ Copy the entire output (including the `-----BEGIN PGP PUBLIC KEY BLOCK-----` and
 1. Go to: https://gitlab.com/-/profile/gpg_keys
 2. Paste your public key
 3. Click "Add key"
+
+## Per-Organization (Conditional) Signing
+
+The committed `gitconfig` can select a different identity and signing key automatically based on which directory a repository lives in, using Git's `includeIf` directives. This is useful when you contribute to multiple organizations that each require a different email and signed commits.
+
+### Organize repositories by organization
+
+```
+~/Code/
+├── work1/      # Organization 1 — auto-signs with org 1 email + key
+├── work2/      # Organization 2 — auto-signs with org 2 email + key
+└── personal/   # Personal projects
+```
+
+### How it works
+
+The main `gitconfig` pulls in an organization-specific config when you work under the matching directory:
+
+```gitconfig
+[includeIf "gitdir:~/Code/work1/"]
+    path = ~/.config/git/work1.gitconfig
+
+[includeIf "gitdir:~/Code/work2/"]
+    path = ~/.config/git/work2.gitconfig
+```
+
+Each organization config overrides `user.email` and `user.signingkey`, and sets `commit.gpgsign = true`, so commits made anywhere under that directory are signed with the right key.
+
+### Set up an organization
+
+1. Generate a key for the organization and upload its public key to that org's Git host (see [Manual Setup](#manual-setup) above).
+2. Create the organization config from the template (it is never committed):
+   ```bash
+   cp ~/dotfiles/templates/config/git/work.gitconfig.template ~/.config/git/work1.gitconfig
+   # Edit ~/.config/git/work1.gitconfig: set the organization email and signing key ID
+   ```
+   Repeat for `work2`, etc. The directories matched by `includeIf` (`~/Code/work1/`, `~/Code/work2/`) are defined in `gitconfig` — adjust them there if your layout differs.
+
+### Verify
+
+```bash
+bash ~/dotfiles/scripts/verify_git_signing.sh
+```
+
+This checks that repositories under each configured organization directory resolve to the expected email, signing key, and `commit.gpgsign = true`, reading the per-organization `~/.config/git/*.gitconfig` files. It prints a `PASS` / `FAIL` line per organization and exits non-zero if any are misconfigured.
 
 ## Verify Signing
 
@@ -131,6 +183,23 @@ If this fails, restart the GPG agent:
 ```bash
 gpgconf --kill gpg-agent
 gpg-agent --daemon
+```
+
+### Commits are not signed at all
+
+The committed `gitconfig` ships with `commit.gpgsign = false`. Confirm signing is enabled and see which config provides each value:
+
+```bash
+git config --show-origin --get commit.gpgsign
+git config --show-origin --list | grep -E 'user\.(email|signingkey)|commit\.gpgsign'
+```
+
+Enable it globally in `~/.config/git/local.gitconfig` (`[commit] gpgsign = true`), or rely on the per-organization configs described above.
+
+### Disable signing globally (emergency rollback)
+
+```bash
+git config --global commit.gpgsign false
 ```
 
 ### Wrong key being used


### PR DESCRIPTION
## Summary
- Add `CONTRIBUTING.md` — a maintainer/architecture overview: the `bootstrap.sh` → `install.sh` → `update.sh` → `verify.sh` lifecycle, where the helpers live (`scripts/bootstrap_helpers.sh`, `verify_helpers.sh`, `dryrun_helpers.sh`, `preflight.sh`), the dry-run/preflight model, the hand-rolled `scripts/test_*.sh` convention and how to run them, and step-by-steps for adding a managed dotfile or a config template safely (placeholders only).
- Consolidate GPG/commit-signing docs so `docs/GPG_SIGNING.md` is the single canonical guide. Folded in the per-organization (`includeIf`) conditional-signing content that previously lived only in the README, corrected the `commit.gpgsign` default (the committed `gitconfig` ships `false`), and added "commits not signed" / "disable globally" troubleshooting.
- Trim the README **Git Commit Signing** section to a short summary plus a link to `docs/GPG_SIGNING.md`; the step-by-step instructions are no longer duplicated across both files.

## Scope
Only `CONTRIBUTING.md` (new), `docs/GPG_SIGNING.md`, and the Git-commit-signing section of `README.md` were changed. No scripts were modified.

## Validation
- All relative markdown links in the three files resolve to real files (checked programmatically).
- Anchor targets exist: `#git-commit-signing` (README security note), and `#manual-setup` / `#per-organization-conditional-signing` (intra-doc links in `docs/GPG_SIGNING.md`).
- No duplicated GPG setup steps: tokens `full-generate-key`, `list-secret-keys`, `armor --export`, `work.gitconfig.template`, `clearsign`, and `settings/gpg` now appear 0× in `README.md` and 1× in `docs/GPG_SIGNING.md`.
- Content cross-checked for accuracy against `gitconfig`, `install.sh`, `bootstrap.sh`, `update.sh`, `verify.sh`, the `scripts/` helpers and tests, `.github/workflows/*.yml`, and `templates/`.

---
_Conversation: https://app.warp.dev/conversation/af755c30-037c-4999-af38-ad8da5800c5c_

_Run: https://oz.warp.dev/runs/019ec40d-03de-7a5a-a4e9-f7733b99ddea_

_This PR was generated with [Oz](https://warp.dev/oz)._
