### PR TITLE
observability: update.sh failure notifications + log rotation + uninstall.sh

### DIFF
--- a/setup-scheduler.sh
+++ b/setup-scheduler.sh
@@ -7,6 +7,12 @@
 #
 # Logs are written to ~/dotfiles/logs/update.log
 # Edit LaunchAgents/com.dotfiles.update.plist to change the schedule.
+#
+# update.log is rotated automatically by update.sh (copytruncate-style) once it
+# exceeds DOTFILES_LOG_MAX_BYTES (default 1 MiB), keeping DOTFILES_LOG_KEEP
+# (default 5) rotated copies — so the launchd log can't grow unbounded.
+# update.sh also writes ~/dotfiles/logs/update.status after every run with the
+# last-run timestamp, overall success/failure, and any failed steps.
 
 set -euo pipefail
 
@@ -52,7 +58,8 @@ launchctl bootstrap "gui/$(id -u)" "$PLIST_DEST"
 
 echo ""
 success "update.sh scheduled — runs daily at 9 AM"
-info "Log:       $LOG_DIR/update.log"
+info "Log:       $LOG_DIR/update.log (auto-rotated; keeps ${DOTFILES_LOG_KEEP:-5} copies)"
+info "Status:    $LOG_DIR/update.status"
 info "Plist:     $PLIST_DEST"
 info "Uninstall: bash ~/dotfiles/setup-scheduler.sh --uninstall"
 echo ""

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# uninstall.sh — reverse install.sh: remove dotfiles symlinks and restore backups
+#
+# Usage:
+#   bash ~/dotfiles/uninstall.sh            # interactive (asks for confirmation)
+#   bash ~/dotfiles/uninstall.sh --dry-run  # print what would happen, change nothing
+#   bash ~/dotfiles/uninstall.sh --yes      # skip the confirmation prompt
+#   bash ~/dotfiles/uninstall.sh --help
+#
+# What it does:
+#   1. Removes the symlinks install.sh creates — but ONLY the ones that actually
+#      point INTO this dotfiles repo. Each managed path is resolved; if it is a
+#      symlink whose target lives under this repo it is removed, otherwise it is
+#      left untouched. Regular files and unrelated symlinks are never touched.
+#   2. Restores the most recent ~/.dotfiles_backup/<timestamp> snapshot (the
+#      files install.sh moved aside) back into $HOME.
+#
+# It deliberately does NOT remove user data that install.sh merely seeds and
+# never owns: ~/.config/git/local.gitconfig and the global pre-commit hook at
+# ~/.config/git/hooks/pre-commit.
+
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKUP_ROOT="$HOME/.dotfiles_backup"
+
+# shellcheck source=scripts/bootstrap_helpers.sh
+source "$DOTFILES_DIR/scripts/bootstrap_helpers.sh"
+setup_colors
+
+DRY_RUN=0
+ASSUME_YES=0
+
+usage() {
+  sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run|-n) DRY_RUN=1 ;;
+    --yes|-y)     ASSUME_YES=1 ;;
+    --help|-h)    usage; exit 0 ;;
+    *) printf "Unknown option: %s\n" "$1" >&2; usage; exit 2 ;;
+  esac
+  shift
+done
+
+# The exact set of links install.sh manages, in "<dest>" form.
+VSCODE_DIR="$HOME/Library/Application Support/Code/User"
+MANAGED_LINKS=(
+  "$HOME/.zshrc"
+  "$HOME/.zprofile"
+  "$HOME/.gitconfig"
+  "$HOME/.tmux.conf"
+  "$HOME/.hyper.js"
+  "$HOME/.gitignore_global"
+  "$HOME/.gemrc"
+  "$HOME/.irbrc"
+  "$HOME/.pryrc"
+  "$HOME/.psqlrc"
+  "$HOME/.npmrc"
+  "$HOME/.editorconfig"
+  "$HOME/.config/starship.toml"
+  "$HOME/.config/direnv/direnvrc"
+  "$HOME/.config/mise/config.toml"
+  "$HOME/.ssh/config"
+  "$VSCODE_DIR/settings.json"
+)
+
+# Counters
+_removed=0
+_skipped=0
+_restored=0
+
+# Pretty action line; prefixes [dry-run] when not actually doing the work.
+action() {
+  if (( DRY_RUN )); then
+    printf "${CYAN}  → [dry-run] %s${RESET}\n" "$*"
+  else
+    printf "${CYAN}  → %s${RESET}\n" "$*"
+  fi
+}
+
+# Resolve a symlink target to an absolute path (without requiring realpath).
+resolve_target() {
+  local link="$1" target
+  target="$(readlink "$link")"
+  case "$target" in
+    /*) printf '%s\n' "$target" ;;
+    *)  printf '%s\n' "$(cd "$(dirname "$link")" && pwd)/$target" ;;
+  esac
+}
+
+# True when $1 is equal to or nested under $2.
+is_under() {
+  local path="$1" dir="$2"
+  [[ "$path" == "$dir" || "$path" == "$dir/"* ]]
+}
+
+short() { printf '%s\n' "${1/$HOME/\~}"; }
+
+echo ""
+printf "${BOLD}  🧹  dotfiles uninstall${RESET}  —  reversing install.sh\n"
+echo "  ─────────────────────────────────────────────────"
+printf "  Repo:   %s\n" "$(short "$DOTFILES_DIR")"
+if (( DRY_RUN )); then
+  printf "  Mode:   dry-run (nothing will be changed)\n"
+fi
+echo "  ─────────────────────────────────────────────────"
+
+# ── Confirmation ──────────────────────────────────────────────────────────────
+if (( ! DRY_RUN && ! ASSUME_YES )); then
+  printf "\n  This removes dotfiles symlinks pointing into the repo and restores\n"
+  printf "  the most recent ~/.dotfiles_backup snapshot. Continue? [y/N] "
+  read -r reply
+  case "$reply" in
+    [yY]|[yY][eE][sS]) ;;
+    *) echo ""; info "Aborted — nothing changed"; echo ""; exit 0 ;;
+  esac
+fi
+
+# ── 1. Remove repo-owned symlinks ─────────────────────────────────────────────
+# shellcheck disable=SC2034  # STEP/TOTAL_STEPS are read by step() from helpers
+STEP=0
+# shellcheck disable=SC2034
+TOTAL_STEPS=2
+
+step "🔗  Remove symlinks"
+for dest in "${MANAGED_LINKS[@]}"; do
+  short_dest="$(short "$dest")"
+
+  if [[ ! -L "$dest" ]]; then
+    if [[ -e "$dest" ]]; then
+      warn "skip      $short_dest (not a symlink — leaving as-is)"
+      (( _skipped++ )) || true
+    fi
+    continue
+  fi
+
+  target="$(resolve_target "$dest")"
+  if ! is_under "$target" "$DOTFILES_DIR"; then
+    warn "skip      $short_dest → $(short "$target") (not in this repo)"
+    (( _skipped++ )) || true
+    continue
+  fi
+
+  action "remove    $short_dest"
+  if (( ! DRY_RUN )); then
+    rm -f "$dest"
+  fi
+  (( _removed++ )) || true
+done
+
+# ── 2. Restore most recent backup ─────────────────────────────────────────────
+step "♻️   Restore backup"
+latest_backup=""
+if [[ -d "$BACKUP_ROOT" ]]; then
+  # Timestamp dir names sort chronologically; take the last one.
+  while IFS= read -r dir; do
+    [[ -n "$dir" ]] && latest_backup="$dir"
+  done < <(find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 -type d | sort)
+fi
+
+if [[ -z "$latest_backup" ]]; then
+  info "No backups found in $(short "$BACKUP_ROOT") — nothing to restore"
+else
+  info "Restoring from $(short "$latest_backup")"
+  shopt -s dotglob nullglob
+  for item in "$latest_backup"/*; do
+    name="$(basename "$item")"
+    target="$HOME/$name"
+    action "restore   $(short "$target")"
+    if (( ! DRY_RUN )); then
+      # Clear any leftover (e.g. a symlink we didn't own) then move the file back.
+      [[ -e "$target" || -L "$target" ]] && rm -rf "$target"
+      mv "$item" "$target"
+    fi
+    (( _restored++ )) || true
+  done
+  shopt -u dotglob nullglob
+
+  # If we emptied the snapshot, drop the now-empty directory (real run only).
+  if (( ! DRY_RUN )) && [[ -d "$latest_backup" ]]; then
+    rmdir "$latest_backup" 2>/dev/null || true
+  fi
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "  ─────────────────────────────────────────────────"
+if (( DRY_RUN )); then
+  success "${_removed} would remove  ·  ${_skipped} skipped  ·  ${_restored} would restore"
+  info "Dry run — no changes were made"
+else
+  success "${_removed} removed  ·  ${_skipped} skipped  ·  ${_restored} restored"
+fi
+echo "  ─────────────────────────────────────────────────"
+echo ""

--- a/update.sh
+++ b/update.sh
@@ -14,6 +14,25 @@
 #   5. Updates the Rust toolchain via rustup
 #   6. Updates global Ruby gems
 #   7. Runs verify.sh health check
+#
+# Self-healing / observability:
+#   * Individual step failures no longer abort the run — every step is attempted
+#     and any that fail are collected and reported at the end.
+#   * On completion a status file is written to logs/update.status capturing the
+#     last-run timestamp, overall success/failure, which step(s) failed, and the
+#     run duration. This makes failures of the daily launchd job visible.
+#   * On failure a macOS notification is posted (osascript). This is skipped in
+#     CI and non-GUI/headless contexts so it is always safe to run.
+#
+# Log rotation:
+#   The launchd job appends stdout/stderr to logs/update.log. To keep it from
+#   growing unbounded, update.log is rotated (copytruncate-style, so launchd's
+#   open file descriptor keeps appending) at the start of each run once it
+#   exceeds a size threshold. Tunable via environment variables:
+#     DOTFILES_LOG_MAX_BYTES  rotate when update.log exceeds this size
+#                             (default: 1048576 = 1 MiB)
+#     DOTFILES_LOG_KEEP       number of rotated copies to keep
+#                             (default: 5 -> update.log.1 .. update.log.5)
 
 set -euo pipefail
 
@@ -24,9 +43,118 @@ STEP=0
 # shellcheck disable=SC2034
 TOTAL_STEPS=7
 
+LOG_DIR="$DOTFILES_DIR/logs"
+LOG_FILE="$LOG_DIR/update.log"
+STATUS_FILE="$LOG_DIR/update.status"
+LOG_MAX_BYTES="${DOTFILES_LOG_MAX_BYTES:-1048576}"  # 1 MiB
+LOG_KEEP="${DOTFILES_LOG_KEEP:-5}"
+
+# Steps whose work failed during this run (reported in the summary + status file)
+FAILED_STEPS=()
+
 # shellcheck source=scripts/bootstrap_helpers.sh
 source "$(dirname "$0")/scripts/bootstrap_helpers.sh"
 setup_colors
+
+# ── Observability helpers ─────────────────────────────────────────────────────
+mark_failure() { FAILED_STEPS+=("$1"); }
+
+# rotate_log — copytruncate-style rotation of logs/update.log.
+# Runs before any of this run's output is produced so the current run lands in a
+# freshly truncated file. Truncating in place (rather than mv) keeps launchd's
+# already-open file descriptor valid so it continues appending to the same inode.
+rotate_log() {
+  [[ -f "$LOG_FILE" ]] || return 0
+  [[ "$LOG_MAX_BYTES" =~ ^[0-9]+$ ]] || return 0
+  [[ "$LOG_KEEP" =~ ^[0-9]+$ ]] && (( LOG_KEEP >= 1 )) || return 0
+
+  local size
+  size=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
+  size=${size//[[:space:]]/}
+  [[ "$size" =~ ^[0-9]+$ ]] || return 0
+  (( size > LOG_MAX_BYTES )) || return 0
+
+  # Shift existing rotations: .(KEEP-1) -> .KEEP, ... , .1 -> .2 (oldest dropped)
+  local i
+  for (( i = LOG_KEEP - 1; i >= 1; i-- )); do
+    [[ -f "$LOG_FILE.$i" ]] && mv -f "$LOG_FILE.$i" "$LOG_FILE.$((i + 1))"
+  done
+  cp "$LOG_FILE" "$LOG_FILE.1" 2>/dev/null || return 0
+  : > "$LOG_FILE"
+  rm -f "$LOG_FILE.$((LOG_KEEP + 1))" 2>/dev/null || true
+}
+
+# can_notify — true only in an interactive macOS GUI (Aqua) session, never in CI
+# or headless/ssh contexts, so notifications are always safe to attempt.
+can_notify() {
+  [[ -z "${CI:-}" ]] || return 1
+  command -v osascript &>/dev/null || return 1
+  [[ "$(launchctl managername 2>/dev/null || true)" == "Aqua" ]] || return 1
+  return 0
+}
+
+notify() {
+  local title="$1" msg="$2"
+  can_notify || return 0
+  osascript -e "display notification \"$msg\" with title \"$title\"" &>/dev/null || true
+}
+
+write_status() {
+  local ts="$1" run_status="$2" failed="$3" elapsed="$4"
+  mkdir -p "$LOG_DIR" 2>/dev/null || true
+  {
+    echo "last_run=$ts"
+    echo "status=$run_status"
+    echo "failed_steps=$failed"
+    echo "duration_seconds=$elapsed"
+  } > "$STATUS_FILE" 2>/dev/null || true
+}
+
+# finalize — runs on EXIT (normal or aborted). Writes the status file, prints the
+# summary banner, and notifies on failure. Always runs so failures of the daily
+# launchd job are recorded even if a step aborts the script unexpectedly.
+finalize() {
+  local code=$?
+  trap - EXIT
+
+  local elapsed=$(( SECONDS - UPDATE_START ))
+  local mins=$(( elapsed / 60 ))
+  local secs=$(( elapsed % 60 ))
+
+  # An unexpected abort (nonzero exit) with no recorded step counts as a failure.
+  if (( code != 0 )) && (( ${#FAILED_STEPS[@]} == 0 )); then
+    FAILED_STEPS+=("aborted (exit $code)")
+  fi
+
+  local failed_list=""
+  if (( ${#FAILED_STEPS[@]} > 0 )); then
+    failed_list=$(printf '%s, ' "${FAILED_STEPS[@]}")
+    failed_list=${failed_list%, }
+  fi
+
+  local run_status="success"
+  (( ${#FAILED_STEPS[@]} > 0 )) && run_status="failure"
+
+  write_status "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$run_status" "$failed_list" "$elapsed"
+
+  echo ""
+  echo "  ─────────────────────────────────────────────────"
+  if [[ "$run_status" == "success" ]]; then
+    printf "${GREEN}${BOLD}  ✅  Update complete${RESET}  in %dm %ds\n" "$mins" "$secs"
+  else
+    printf "${YELLOW}${BOLD}  ⚠️  Update finished with issues${RESET}  in %dm %ds\n" "$mins" "$secs"
+    printf "${YELLOW}  Failed: %s${RESET}\n" "$failed_list"
+    notify "dotfiles update failed" "Steps with issues: $failed_list"
+    (( code == 0 )) && code=1
+  fi
+  echo "  ─────────────────────────────────────────────────"
+  echo ""
+
+  exit "$code"
+}
+trap finalize EXIT
+
+rotate_log
 
 # ── Banner ────────────────────────────────────────────────────────────────────
 echo ""
@@ -39,18 +167,29 @@ echo "  ────────────────────────
 # ── Steps ─────────────────────────────────────────────────────────────────────
 
 step "🔃  Dotfiles"
-git -C "$DOTFILES_DIR" pull --rebase --autostash
-success "Dotfiles pulled"
+if git -C "$DOTFILES_DIR" pull --rebase --autostash; then
+  success "Dotfiles pulled"
+else
+  warn "Dotfiles pull failed — continuing"
+  mark_failure "Dotfiles"
+fi
 
 step "🔗  Symlinks"
-zsh "$DOTFILES_DIR/install.sh"
+if ! zsh "$DOTFILES_DIR/install.sh"; then
+  warn "Symlink install failed — continuing"
+  mark_failure "Symlinks"
+fi
 
 step "🍺  Homebrew"
-brew update
+if ! brew update; then
+  warn "brew update failed — continuing"
+  mark_failure "Homebrew"
+fi
 if brew upgrade; then
   success "All Homebrew packages upgraded"
 else
   warn "Some Homebrew packages failed to upgrade — continuing anyway"
+  mark_failure "Homebrew"
 fi
 brew autoremove 2>/dev/null || true
 brew cleanup --prune=7 2>/dev/null || true  # remove downloads older than 7 days
@@ -58,24 +197,36 @@ success "Homebrew update complete"
 
 step "⚡  Runtimes (mise)"
 if command -v mise &>/dev/null; then
-  mise upgrade
-  success "Runtimes upgraded: $(mise current | tr '\n' ' ')"
+  if mise upgrade; then
+    success "Runtimes upgraded: $(mise current 2>/dev/null | tr '\n' ' ' || true)"
+  else
+    warn "mise upgrade failed — continuing"
+    mark_failure "Runtimes (mise)"
+  fi
 else
   warn "mise not installed — skipping runtime upgrades"
 fi
 
 step "🦀  Rust"
 if command -v rustup &>/dev/null; then
-  rustup update
-  success "Rust toolchain updated: $(rustc --version 2>/dev/null)"
+  if rustup update; then
+    success "Rust toolchain updated: $(rustc --version 2>/dev/null || true)"
+  else
+    warn "rustup update failed — continuing"
+    mark_failure "Rust"
+  fi
 else
   warn "rustup not installed — skipping"
 fi
 
 step "💎  Ruby gems"
 if command -v gem &>/dev/null; then
-  gem update --system --no-document 2>/dev/null
-  success "Global gems updated"
+  if gem update --system --no-document 2>/dev/null; then
+    success "Global gems updated"
+  else
+    warn "gem update failed — continuing"
+    mark_failure "Ruby gems"
+  fi
 else
   warn "gem not found — skipping (mise Ruby may not be active)"
 fi
@@ -87,15 +238,10 @@ if command -v uv &>/dev/null; then
 fi
 
 step "🔍  Health check"
-bash "$DOTFILES_DIR/verify.sh" || warn "Some checks need attention — see output above"
+if ! bash "$DOTFILES_DIR/verify.sh"; then
+  warn "Some checks need attention — see output above"
+  mark_failure "Health check"
+fi
 
-# ── Summary ───────────────────────────────────────────────────────────────────
-_elapsed=$(( SECONDS - UPDATE_START ))
-_mins=$(( _elapsed / 60 ))
-_secs=$(( _elapsed % 60 ))
-
-echo ""
-echo "  ─────────────────────────────────────────────────"
-printf "${GREEN}${BOLD}  ✅  Update complete${RESET}  in %dm %ds\n" "$_mins" "$_secs"
-echo "  ─────────────────────────────────────────────────"
-echo ""
+# Summary banner + status file + failure notification are emitted by finalize()
+# via the EXIT trap installed near the top of this script.


### PR DESCRIPTION
## Summary
Observability / self-healing workstream of the dotfiles roadmap. Scoped to `update.sh`, `setup-scheduler.sh`, and a new `uninstall.sh` (plus header docs). No changes to `install.sh`/`verify.sh` or the plist's `__DOTFILES_DIR__` mechanism.

### 1. Failure notifications + status file (`update.sh`)
- Daily-update steps no longer abort the run on failure — each step is attempted and any failures are collected.
- An `EXIT`-trap `finalize()` writes `logs/update.status` after every run (last-run timestamp, overall `success`/`failure`, which step(s) failed, duration), making failures of the launchd job visible.
- On failure a macOS notification is posted via `osascript`. `can_notify()` guards it to only fire in an interactive GUI (Aqua) session — it no-ops in CI/headless/SSH, so it's always safe.
- Existing banner UX preserved (now emitted by `finalize()`); bash 3.2-safe (the plist runs `/bin/bash`).

### 2. Log rotation (`update.sh`, documented in `setup-scheduler.sh`)
- The launchd job appends to `logs/update.log`. Added copytruncate-style rotation that runs before any output is produced and truncates the file in place, so launchd's already-open fd keeps appending to the same inode.
- Tunable via `DOTFILES_LOG_MAX_BYTES` (default 1 MiB) and `DOTFILES_LOG_KEEP` (default 5). Plist left untouched.

### 3. `uninstall.sh` (new)
- Reverses `install.sh`: removes only managed symlinks whose resolved target lives **under this repo** (never touches real files or unrelated symlinks), then restores the most recent `~/.dotfiles_backup/<timestamp>`.
- Covers the same link set `install.sh` manages. Deliberately leaves user-owned seeds (`~/.config/git/local.gitconfig`, global pre-commit hook).
- Supports `--dry-run`, `--yes`, `--help`, with a confirmation prompt on real runs.

## Validation
- `shellcheck -S warning update.sh setup-scheduler.sh uninstall.sh` — clean.
- `bash -n` on all three — clean.
- `uninstall.sh --dry-run` against a temp `$HOME` with fake symlinks (into the repo + one outside) and a fake `~/.dotfiles_backup`: removes nothing, reports correct actions, skips outside-repo link and the real file.
- Real `uninstall.sh --yes` run: removed in-repo symlink, restored newest backup, preserved outside-repo symlink and real file.
- `rotate_log` (threshold + keep-N + in-place truncate) and `write_status` exercised under bash.


---
_Conversation: https://app.warp.dev/conversation/850e91ef-1bd8-4322-be83-e676b485ba9a_
_Run: https://oz.warp.dev/runs/019ec40d-03df-7b10-9da1-b72f7053e8f9_
_Plans_:
- _[Dotfiles roadmap execution (orchestrated)](https://app.warp.dev/conversation/850e91ef-1bd8-4322-be83-e676b485ba9a)_

_This PR was generated with [Oz](https://warp.dev/oz)._
