### PR TITLE
core-hygiene: harden VS Code install, gitconfig guard, Brewfile drift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,25 @@ streetsidesoftware.*/
 usernamehw.*/
 visualstudioexptteam.*/
 
+# VS Code extension residue — FILE form (no trailing slash), e.g.
+# `eamodio.gitlens`, `continue.continue`, `docker.docker`. `code
+# --install-extension` can leave these empty files in the cwd. install.sh now
+# runs that from a temp dir, but these patterns guard against any stragglers.
+# Scoped to known extension publishers (see vscode/extensions.txt) so real
+# tracked files (gitconfig, gitignore_global, Brewfile.work, *.local.example)
+# are NOT ignored.
+continue.*
+dbaeumer.*
+docker.*
+eamodio.*
+github.*
+mhutchie.*
+streetsidesoftware.*
+stylelint.*
+usernamehw.*
+visualstudioexptteam.*
+vivaxy.*
+
 # Git configs with actual keys/emails (only templates are tracked)
 config/git/*.gitconfig
 !config/git/*.template

--- a/install.sh
+++ b/install.sh
@@ -116,7 +116,14 @@ if [[ -d "$VSCODE_DIR" ]]; then
   success "VS Code settings linked"
   if command -v code &>/dev/null; then
     info "Installing VS Code extensions..."
-    grep -v '^#' "$DOTFILES_DIR/vscode/extensions.txt" | xargs -L1 code --install-extension --force 2>/dev/null
+    # Run the install loop inside a subshell rooted at a throwaway temp dir.
+    # `code --install-extension` drops empty `publisher.extension` residue
+    # files into the cwd; isolating cwd here guarantees that residue never
+    # lands in the dotfiles repo (the root cause of past stray files).
+    (
+      cd "$(mktemp -d)" || exit 1
+      grep -v '^#' "$DOTFILES_DIR/vscode/extensions.txt" | xargs -L1 code --install-extension --force 2>/dev/null
+    )
     success "VS Code extensions installed"
   fi
 else

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 # Colors
 BOLD="\033[1m"
+# shellcheck disable=SC2034  # DIM kept for palette parity with other scripts
 DIM="\033[2m"
 RESET="\033[0m"
 RED="\033[31m"
@@ -219,6 +220,39 @@ if command -v git &>/dev/null; then
   else
     success "Git configured as: $_git_name <$_git_email>"
   fi
+fi
+
+# ── 13. Dotfiles Repository Integrity ────────────────────────────────────────
+# Catches a corrupted gitconfig (e.g. leftover merge-conflict markers) BEFORE
+# bootstrap symlinks it over ~/.gitconfig and breaks git globally.
+info "Checking dotfiles repository integrity..."
+_dotfiles_dir=$(cd "$(dirname "$0")/.." && pwd)
+
+# Build conflict-marker patterns at runtime so this script never contains a
+# literal 7-character marker that would match itself during the scan.
+_cm_begin=$(printf '<%.0s' {1..7})
+_cm_sep=$(printf '=%.0s' {1..7})
+_cm_end=$(printf '>%.0s' {1..7})
+_cm_re="^${_cm_begin}|^${_cm_end}|^${_cm_sep}\$"
+
+if git -C "$_dotfiles_dir" rev-parse --is-inside-work-tree &>/dev/null; then
+  _cm_hits=$(git -C "$_dotfiles_dir" grep -lE "$_cm_re" -- . 2>/dev/null || true)
+  if [[ -n "$_cm_hits" ]]; then
+    error "Merge-conflict markers found in tracked dotfiles:"
+    while IFS= read -r _f; do
+      [[ -n "$_f" ]] && error "    $_f"
+    done <<< "$_cm_hits"
+  else
+    success "No merge-conflict markers in tracked dotfiles"
+  fi
+else
+  warn "Not inside the dotfiles git work tree — skipping conflict-marker scan"
+fi
+
+if git config --list &>/dev/null; then
+  success "git config --list parses cleanly"
+else
+  error "git config --list failed — ~/.gitconfig may be broken (fix before symlinking)"
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/test_verify_helpers.sh
+++ b/scripts/test_verify_helpers.sh
@@ -465,6 +465,179 @@ else
   pass "check_mise_installed: mise not installed — skipped"
 fi
 
+# ── check_dotfiles_git_health ─────────────────────────────────────────────
+echo ""
+echo "=== check_dotfiles_git_health ==="
+
+# Build conflict markers at runtime so this test file never contains a literal
+# 7-character marker (which would trip the very check it exercises).
+CM_BEGIN=$(printf '<%.0s' {1..7})
+CM_SEP=$(printf '=%.0s' {1..7})
+CM_END=$(printf '>%.0s' {1..7})
+
+# Clean global config so git operations succeed in the scan cases.
+CLEAN_GITCONFIG="$TMPDIR_BASE/gitconfig_clean"
+touch "$CLEAN_GITCONFIG"
+
+# Case 1: clean tracked files + clean config → OK=true
+GITREPO_CLEAN="$TMPDIR_BASE/gitrepo_clean"
+mkdir -p "$GITREPO_CLEAN"
+git -C "$GITREPO_CLEAN" init -q
+echo "hello world" > "$GITREPO_CLEAN/file.txt"
+git -C "$GITREPO_CLEAN" add file.txt
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export GIT_CONFIG_GLOBAL="$CLEAN_GITCONFIG"
+  check_dotfiles_git_health "$GITREPO_CLEAN"
+  [[ "$DOTFILES_GIT_HEALTH_OK" == "true" ]] || { printf "  FAIL  expected OK=true, got %s\n" "$DOTFILES_GIT_HEALTH_OK"; exit 1; }
+  [[ "${#DOTFILES_CONFLICT_FILES[@]}" -eq 0 ]] || { printf "  FAIL  expected 0 conflict files\n"; exit 1; }
+); then
+  pass "check_dotfiles_git_health: clean repo + clean config → OK=true"
+else
+  fail "check_dotfiles_git_health: clean repo" "subshell exited non-zero"
+fi
+
+# Case 2: a tracked file containing conflict markers → OK=false, file listed
+GITREPO_CONFLICT="$TMPDIR_BASE/gitrepo_conflict"
+mkdir -p "$GITREPO_CONFLICT"
+git -C "$GITREPO_CONFLICT" init -q
+{
+  echo "$CM_BEGIN HEAD"
+  echo "ours"
+  echo "$CM_SEP"
+  echo "theirs"
+  echo "$CM_END branch"
+} > "$GITREPO_CONFLICT/conflicted.txt"
+git -C "$GITREPO_CONFLICT" add conflicted.txt
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export GIT_CONFIG_GLOBAL="$CLEAN_GITCONFIG"
+  check_dotfiles_git_health "$GITREPO_CONFLICT"
+  [[ "$DOTFILES_GIT_HEALTH_OK" == "false" ]] || { printf "  FAIL  expected OK=false\n"; exit 1; }
+  printf '%s\n' "${DOTFILES_CONFLICT_FILES[@]}" | grep -q "conflicted.txt" || { printf "  FAIL  conflicted.txt not in DOTFILES_CONFLICT_FILES\n"; exit 1; }
+); then
+  pass "check_dotfiles_git_health: tracked file with markers → OK=false, file listed"
+else
+  fail "check_dotfiles_git_health: conflict markers" "subshell exited non-zero"
+fi
+
+# Case 3: broken global config (contains a conflict marker) → git config fails → OK=false
+BROKEN_GITCONFIG="$TMPDIR_BASE/gitconfig_broken"
+{
+  echo "[user]"
+  echo "  name = test"
+  echo "$CM_BEGIN HEAD"
+} > "$BROKEN_GITCONFIG"
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export GIT_CONFIG_GLOBAL="$BROKEN_GITCONFIG"
+  check_dotfiles_git_health "$GITREPO_CLEAN"
+  [[ "$DOTFILES_GIT_HEALTH_OK" == "false" ]] || { printf "  FAIL  expected OK=false with broken config\n"; exit 1; }
+  [[ "${#DOTFILES_GIT_HEALTH_ISSUES[@]}" -ge 1 ]] || { printf "  FAIL  expected at least one issue\n"; exit 1; }
+); then
+  pass "check_dotfiles_git_health: broken global config → OK=false"
+else
+  fail "check_dotfiles_git_health: broken global config" "subshell exited non-zero"
+fi
+
+# Case 4: path that is not a git work tree → OK=false with an issue
+NOT_A_REPO="$TMPDIR_BASE/not_a_repo"
+mkdir -p "$NOT_A_REPO"
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export GIT_CONFIG_GLOBAL="$CLEAN_GITCONFIG"
+  check_dotfiles_git_health "$NOT_A_REPO"
+  [[ "$DOTFILES_GIT_HEALTH_OK" == "false" ]] || { printf "  FAIL  expected OK=false for non-repo\n"; exit 1; }
+); then
+  pass "check_dotfiles_git_health: non-git directory → OK=false"
+else
+  fail "check_dotfiles_git_health: non-git directory" "subshell exited non-zero"
+fi
+
+# ── check_brewfile_drift ──────────────────────────────────────────────────
+echo ""
+echo "=== check_brewfile_drift ==="
+
+# Fake brew stub: `brew bundle check --file=F` exits 0 iff F contains IN_SYNC.
+FAKE_BIN="$TMPDIR_BASE/fakebin"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/brew" << 'EOF'
+#!/usr/bin/env bash
+f=""
+for a in "$@"; do
+  case "$a" in
+    --file=*) f="${a#--file=}" ;;
+  esac
+done
+if [[ "${1:-}" == "bundle" ]]; then
+  if [[ -f "$f" ]] && grep -q IN_SYNC "$f"; then exit 0; else exit 1; fi
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/brew"
+
+# Case 1: brew not on PATH → skipped, OK=true
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export PATH="$TMPDIR_BASE/empty_bin"
+  check_brewfile_drift "$TMPDIR_BASE/whatever_Brewfile"
+  [[ "$BREWFILE_DRIFT_SKIPPED" == "true" ]] || { printf "  FAIL  expected SKIPPED=true\n"; exit 1; }
+  [[ "$BREWFILE_DRIFT_OK" == "true" ]] || { printf "  FAIL  expected OK=true when skipped\n"; exit 1; }
+); then
+  pass "check_brewfile_drift: brew absent → skipped, OK=true"
+else
+  fail "check_brewfile_drift: brew absent" "subshell exited non-zero"
+fi
+
+# Case 2: brew present, Brewfile in sync → OK=true, not skipped
+BREWFILE_SYNC="$TMPDIR_BASE/Brewfile_sync"
+echo "# IN_SYNC marker" > "$BREWFILE_SYNC"
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export PATH="$FAKE_BIN:$PATH"
+  check_brewfile_drift "$BREWFILE_SYNC"
+  [[ "$BREWFILE_DRIFT_SKIPPED" == "false" ]] || { printf "  FAIL  expected SKIPPED=false\n"; exit 1; }
+  [[ "$BREWFILE_DRIFT_OK" == "true" ]] || { printf "  FAIL  expected OK=true in sync\n"; exit 1; }
+); then
+  pass "check_brewfile_drift: in sync → OK=true"
+else
+  fail "check_brewfile_drift: in sync" "subshell exited non-zero"
+fi
+
+# Case 3: brew present, Brewfile drifted → OK=false, issue set
+BREWFILE_DRIFTED="$TMPDIR_BASE/Brewfile_drift"
+echo "brew \"git\"" > "$BREWFILE_DRIFTED"
+
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export PATH="$FAKE_BIN:$PATH"
+  check_brewfile_drift "$BREWFILE_DRIFTED"
+  [[ "$BREWFILE_DRIFT_OK" == "false" ]] || { printf "  FAIL  expected OK=false on drift\n"; exit 1; }
+  [[ -n "$BREWFILE_DRIFT_ISSUE" ]] || { printf "  FAIL  expected non-empty issue\n"; exit 1; }
+); then
+  pass "check_brewfile_drift: drift detected → OK=false, issue set"
+else
+  fail "check_brewfile_drift: drift detected" "subshell exited non-zero"
+fi
+
+# Case 4: brew present but Brewfile missing → OK=false, issue mentions not found
+if (
+  source "$SCRIPT_DIR/verify_helpers.sh"
+  export PATH="$FAKE_BIN:$PATH"
+  check_brewfile_drift "$TMPDIR_BASE/does_not_exist_Brewfile"
+  [[ "$BREWFILE_DRIFT_OK" == "false" ]] || { printf "  FAIL  expected OK=false for missing Brewfile\n"; exit 1; }
+  echo "$BREWFILE_DRIFT_ISSUE" | grep -q "not found" || { printf "  FAIL  issue should mention 'not found'\n"; exit 1; }
+); then
+  pass "check_brewfile_drift: missing Brewfile → OK=false, 'not found' issue"
+else
+  fail "check_brewfile_drift: missing Brewfile" "subshell exited non-zero"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────"

--- a/scripts/verify_helpers.sh
+++ b/scripts/verify_helpers.sh
@@ -222,6 +222,84 @@ check_mise_installed() {
   done
 }
 
+# check_dotfiles_git_health DOTFILES_DIR
+# Repository/config integrity guard:
+#   1. No tracked dotfile contains git merge-conflict markers.
+#   2. `git config --list` parses cleanly (catches a broken ~/.gitconfig before
+#      install.sh symlinks gitconfig over it).
+# Sets:
+#   DOTFILES_GIT_HEALTH_OK     — true when both checks pass
+#   DOTFILES_GIT_HEALTH_ISSUES — array of human-readable problems (empty when OK)
+#   DOTFILES_CONFLICT_FILES    — array of tracked files containing markers
+check_dotfiles_git_health() {
+  local dotfiles_dir="$1"
+  DOTFILES_GIT_HEALTH_OK=true
+  DOTFILES_GIT_HEALTH_ISSUES=()
+  DOTFILES_CONFLICT_FILES=()
+
+  # Build conflict-marker patterns at runtime so this source file never
+  # contains a literal 7-character marker that would match itself.
+  local _b _s _e marker_re
+  _b=$(printf '<%.0s' {1..7})
+  _s=$(printf '=%.0s' {1..7})
+  _e=$(printf '>%.0s' {1..7})
+  marker_re="^${_b}|^${_e}|^${_s}\$"
+
+  if git -C "$dotfiles_dir" rev-parse --is-inside-work-tree &>/dev/null; then
+    local matches
+    matches=$(git -C "$dotfiles_dir" grep -lE "$marker_re" -- . 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+      while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        DOTFILES_CONFLICT_FILES+=("$f")
+        DOTFILES_GIT_HEALTH_ISSUES+=("conflict markers in tracked file: $f")
+      done <<< "$matches"
+      DOTFILES_GIT_HEALTH_OK=false
+    fi
+  else
+    DOTFILES_GIT_HEALTH_ISSUES+=("$dotfiles_dir is not a git work tree — cannot scan tracked files")
+    DOTFILES_GIT_HEALTH_OK=false
+  fi
+
+  if ! git config --list &>/dev/null; then
+    DOTFILES_GIT_HEALTH_ISSUES+=("git config --list failed — ~/.gitconfig may be broken")
+    DOTFILES_GIT_HEALTH_OK=false
+  fi
+}
+
+# check_brewfile_drift BREWFILE
+# Detects divergence between installed Homebrew packages and the Brewfile via
+# `brew bundle check`. Silently skips when brew is not on PATH (check_required_tools
+# already reports a missing brew).
+# Sets:
+#   BREWFILE_DRIFT_OK      — true when packages match the Brewfile (or skipped)
+#   BREWFILE_DRIFT_SKIPPED — true when brew is unavailable
+#   BREWFILE_DRIFT_ISSUE   — human-readable problem description (empty when OK)
+check_brewfile_drift() {
+  local brewfile="$1"
+  BREWFILE_DRIFT_OK=true
+  BREWFILE_DRIFT_SKIPPED=false
+  BREWFILE_DRIFT_ISSUE=""
+
+  if ! command -v brew &>/dev/null; then
+    BREWFILE_DRIFT_SKIPPED=true
+    return 0
+  fi
+
+  if [[ ! -f "$brewfile" ]]; then
+    BREWFILE_DRIFT_OK=false
+    BREWFILE_DRIFT_ISSUE="Brewfile not found at $brewfile"
+    return 0
+  fi
+
+  if brew bundle check --file="$brewfile" &>/dev/null; then
+    BREWFILE_DRIFT_OK=true
+  else
+    BREWFILE_DRIFT_OK=false
+    BREWFILE_DRIFT_ISSUE="installed packages diverge from Brewfile — run: brew bundle install --file=$brewfile"
+  fi
+}
+
 # check_stale_backups BACKUP_DIR [DAYS]
 # Finds backup directories inside BACKUP_DIR that are older than DAYS (default: 30).
 # Sets:

--- a/verify.sh
+++ b/verify.sh
@@ -9,6 +9,8 @@
 #   5. SSH key                (warnings — exit 0)
 #   6. git-lfs global init    (warnings — exit 0)
 #   7. mise tools installed   (warnings — exit 0)
+#   8. dotfiles git health    (warnings — exit 0)
+#   9. Brewfile drift         (warnings — exit 0)
 #
 # Usage:   bash ~/dotfiles/verify.sh
 # Called by update.sh automatically after each update cycle.
@@ -22,7 +24,7 @@ WARNINGS=0
 # shellcheck disable=SC2034  # used by step() in helpers
 STEP=0
 # shellcheck disable=SC2034
-TOTAL_STEPS=7
+TOTAL_STEPS=9
 
 # shellcheck source=scripts/bootstrap_helpers.sh
 source "$DOTFILES_DIR/scripts/bootstrap_helpers.sh"
@@ -136,6 +138,32 @@ else
   done
   warn "$MISE_UNINSTALLED_COUNT runtime(s) not installed — run: mise install"
   WARNINGS=$(( WARNINGS + MISE_UNINSTALLED_COUNT ))
+fi
+
+# ── 8. Dotfiles git health ───────────────────────────────────────────────
+step "🩺  Dotfiles git health"
+check_dotfiles_git_health "$DOTFILES_DIR"
+
+if [[ "$DOTFILES_GIT_HEALTH_OK" == "true" ]]; then
+  success "No conflict markers in tracked dotfiles; git config parses cleanly"
+else
+  for issue in "${DOTFILES_GIT_HEALTH_ISSUES[@]}"; do
+    warn "$issue"
+  done
+  WARNINGS=$(( WARNINGS + ${#DOTFILES_GIT_HEALTH_ISSUES[@]} ))
+fi
+
+# ── 9. Brewfile drift ────────────────────────────────────────────────────
+step "🍺  Brewfile drift"
+check_brewfile_drift "$DOTFILES_DIR/Brewfile"
+
+if [[ "$BREWFILE_DRIFT_SKIPPED" == "true" ]]; then
+  info "brew not installed — skipping Brewfile drift check"
+elif [[ "$BREWFILE_DRIFT_OK" == "true" ]]; then
+  success "Brewfile in sync with installed packages"
+else
+  warn "$BREWFILE_DRIFT_ISSUE"
+  WARNINGS=$(( WARNINGS + 1 ))
 fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Core hygiene + validation + drift detection for the dotfiles repo.

- **install.sh** — `code --install-extension` now runs inside a subshell rooted at a throwaway temp dir (`cd "$(mktemp -d)"`), so the empty `publisher.extension` residue files VS Code drops into the cwd can never land in the dotfiles repo. Existing behavior preserved (skips cleanly when `code` is absent; installs from `vscode/extensions.txt`; same success/info output).
- **.gitignore** — added the FILE form of extension residue (`publisher.*` with no trailing slash, e.g. `eamodio.gitlens`, `continue.continue`, `docker.docker`) alongside the existing directory patterns. Scoped to the known publishers in `vscode/extensions.txt` so real tracked files (`gitconfig`, `gitignore_global`, `Brewfile.work`, `*.local.example`) are NOT ignored.
- **scripts/preflight.sh** — new CRITICAL "Dotfiles Repository Integrity" check: scans tracked dotfiles for merge-conflict markers and confirms `git config --list` parses cleanly, catching a broken `~/.gitconfig` before bootstrap symlinks it. Also made the script `shellcheck -S warning` clean (SC2034 on `DIM`).
- **verify.sh + scripts/verify_helpers.sh** — two new WARNING health checks: `check_dotfiles_git_health` (same conflict-marker + `git config --list` scan) and `check_brewfile_drift` (`brew bundle check`, skipped when brew is absent). `TOTAL_STEPS` bumped 7 → 9.
- **scripts/test_verify_helpers.sh** — added unit tests covering both new helpers (clean/conflict/broken-config/non-repo; brew absent/in-sync/drift/missing-file).

Conflict-marker patterns are built at runtime via `printf` so the scripts/tests never contain a literal 7-character marker that would self-trigger the scan.

## Validation
- `shellcheck -S warning verify.sh scripts/preflight.sh scripts/verify_helpers.sh scripts/test_verify_helpers.sh` — clean.
- `install.sh` is zsh; `zsh -n install.sh` passes (shellcheck only lints sh/bash).
- `bash scripts/test_verify_helpers.sh` — 34/34 pass (8 new).
- `install.sh` run twice against a temp `$HOME` → 2nd run reports `0 backed up` (16 current); `git status --porcelain` shows no residue/untracked files.
- `verify.sh` against a temp `$HOME` runs all 9 steps; step 8 (git health) passes on this very branch.

Scope: only `install.sh`, `.gitignore`, `scripts/preflight.sh`, `verify.sh`, `scripts/verify_helpers.sh`, and `scripts/test_verify_helpers.sh`.

_Conversation: https://app.warp.dev/conversation/fdea79ad-98ef-48b5-a506-8356296a1269_

_Run: https://oz.warp.dev/runs/019ec40d-03d9-74cb-aa07-be56edb09410_

_Plans_:
- _[Dotfiles roadmap execution (orchestrated)](https://app.warp.dev/plan/c7e2410e-5036-419c-82d6-a99c8e5f4c4b)_

_This PR was generated with [Oz](https://warp.dev/oz)._
