### PR TITLE
ci: comprehensive shellcheck, install idempotency check, auto-discovered tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,34 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
 
-      - name: shellcheck bootstrap.sh
-        run: shellcheck -S warning bootstrap.sh
-
-      - name: shellcheck macos.sh
-        run: shellcheck -S warning macos.sh
-
-      - name: shellcheck update.sh
-        run: shellcheck -S warning update.sh
-
-      - name: shellcheck setup-scheduler.sh
-        run: shellcheck -S warning setup-scheduler.sh
-
-      - name: shellcheck verify.sh
-        run: shellcheck -S warning verify.sh
+      # Lint every top-level *.sh and scripts/*.sh in one pass so new scripts are
+      # covered automatically. zsh files (install.sh, scripts/setup_gpg_signing.sh)
+      # are detected by shebang and routed to the zsh-syntax job instead, since
+      # shellcheck only understands sh/bash/dash/ksh.
+      - name: shellcheck all bash scripts
+        run: |
+          fail=0
+          shopt -s nullglob
+          for script in *.sh scripts/*.sh; do
+            # scripts/preflight.sh is excluded until feature/core-hygiene makes it
+            # shellcheck-clean.
+            # TODO(core-hygiene): drop this exclusion once scripts/preflight.sh is clean.
+            if [[ "$script" == "scripts/preflight.sh" ]]; then
+              echo "SKIP (excluded, see TODO): $script"
+              continue
+            fi
+            if head -1 "$script" | grep -q 'zsh'; then
+              echo "SKIP (zsh, see zsh-syntax job): $script"
+              continue
+            fi
+            echo "==> shellcheck -S warning $script"
+            shellcheck -S warning "$script" || fail=1
+          done
+          if [[ "$fail" -ne 0 ]]; then
+            echo "shellcheck reported problems"
+            exit 1
+          fi
+          echo "All bash scripts passed shellcheck."
 
   # ------------------------------------------------------------------
   # 2. zsh-syntax — syntax-check every shell file + parse the Brewfile
@@ -52,8 +66,10 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Syntax-check all shell files
+        # install.sh and scripts/setup_gpg_signing.sh are zsh (skipped by the
+        # shellcheck job), so they are syntax-checked here with a real zsh.
         run: |
-          for f in zshrc zprofile install.sh bootstrap.sh macos.sh; do
+          for f in zshrc zprofile install.sh bootstrap.sh macos.sh scripts/setup_gpg_signing.sh; do
             echo "zsh -n $f"
             zsh -n "$f"
           done
@@ -116,3 +132,28 @@ jobs:
 
           echo ""
           echo "All symlinks verified."
+
+          echo ""
+          echo "--- Idempotency: a second run must back up nothing ---"
+          # Re-run against the SAME temp HOME. Every dotfile is already linked, so
+          # the summary must report "0 backed up".
+          second_output=$(zsh install.sh)
+          echo "$second_output"
+          if echo "$second_output" | grep -q "0 backed up"; then
+            echo "OK  second run reports 0 backed up"
+          else
+            echo "FAIL  second run did not report '0 backed up'" && exit 1
+          fi
+
+          echo ""
+          echo "--- Residue: no publisher.extension files created in the repo dir ---"
+          # The original bug left empty VS Code extension-id files (e.g.
+          # ms-python.python) at the repo root. install.sh must not create or modify
+          # anything tracked here, so the working tree must stay clean after running.
+          residue=$(git status --porcelain --untracked-files=all)
+          if [[ -n "$residue" ]]; then
+            echo "FAIL  install.sh created/modified files in the repo dir:"
+            echo "$residue"
+            exit 1
+          fi
+          echo "OK  no residue files created in the repo dir"

--- a/.github/workflows/test-bootstrap.yml
+++ b/.github/workflows/test-bootstrap.yml
@@ -1,52 +1,67 @@
 name: Test shell scripts
 
+# Auto-discovers and runs every hand-rolled unit test (scripts/test_*.sh).
+# New test files are picked up without editing this workflow, so the trigger
+# watches the whole scripts/ directory plus the scripts under test.
 on:
   push:
     paths:
       - 'bootstrap.sh'
       - 'update.sh'
       - 'verify.sh'
-      - 'scripts/bootstrap_helpers.sh'
-      - 'scripts/test_bootstrap_helpers.sh'
-      - 'scripts/verify_helpers.sh'
-      - 'scripts/test_verify_helpers.sh'
+      - 'scripts/**'
       - '.github/workflows/test-bootstrap.yml'
   pull_request:
     paths:
       - 'bootstrap.sh'
       - 'update.sh'
       - 'verify.sh'
-      - 'scripts/bootstrap_helpers.sh'
-      - 'scripts/test_bootstrap_helpers.sh'
-      - 'scripts/verify_helpers.sh'
-      - 'scripts/test_verify_helpers.sh'
+      - 'scripts/**'
       - '.github/workflows/test-bootstrap.yml'
 
 jobs:
-  test-bootstrap:
+  unit-tests:
+    name: Run hand-rolled unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - name: Syntax check
+        # Syntax-check the scripts under test, their helpers, and every test file.
+        # Test files are globbed so new scripts/test_*.sh are covered automatically.
         run: |
-          bash -n bootstrap.sh
-          bash -n scripts/bootstrap_helpers.sh
-          bash -n scripts/test_bootstrap_helpers.sh
+          for f in bootstrap.sh verify.sh \
+                   scripts/bootstrap_helpers.sh \
+                   scripts/verify_helpers.sh \
+                   scripts/dryrun_helpers.sh; do
+            echo "bash -n $f"
+            bash -n "$f"
+          done
+          shopt -s nullglob
+          for t in scripts/test_*.sh; do
+            echo "bash -n $t"
+            bash -n "$t"
+          done
+          echo "All scripts pass syntax check."
 
       - name: Run tests
-        run: bash scripts/test_bootstrap_helpers.sh
-
-  test-verify:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-
-      - name: Syntax check
+        # Auto-discover and run every unit-test script. New scripts/test_*.sh files
+        # are picked up without naming them here.
         run: |
-          bash -n verify.sh
-          bash -n scripts/verify_helpers.sh
-          bash -n scripts/test_verify_helpers.sh
-
-      - name: Run tests
-        run: bash scripts/test_verify_helpers.sh
+          shopt -s nullglob
+          tests=(scripts/test_*.sh)
+          if [[ ${#tests[@]} -eq 0 ]]; then
+            echo "No test scripts found (scripts/test_*.sh)" && exit 1
+          fi
+          fail=0
+          for t in "${tests[@]}"; do
+            echo ""
+            echo "=============================================="
+            echo "Running $t"
+            echo "=============================================="
+            bash "$t" || fail=1
+          done
+          if [[ "$fail" -ne 0 ]]; then
+            echo "One or more test scripts failed." && exit 1
+          fi
+          echo "All unit-test scripts passed."

--- a/quick-fix.sh
+++ b/quick-fix.sh
@@ -19,7 +19,7 @@ fi
 
 # 1. Symlink dotfiles (the most critical part)
 echo "Step 1: Symlinking dotfiles..."
-cd ~/dotfiles
+cd ~/dotfiles || exit 1
 zsh install.sh
 echo "✓ Dotfiles symlinked"
 echo ""
@@ -36,6 +36,7 @@ echo ""
 
 # 3. Source the new zshrc
 echo "Step 3: Reloading shell configuration..."
+# shellcheck source=/dev/null
 source ~/.zshrc 2>/dev/null || true
 echo "✓ Done"
 echo ""

--- a/scripts/dryrun_helpers.sh
+++ b/scripts/dryrun_helpers.sh
@@ -60,7 +60,8 @@ check_brew_bundle() {
 
   if ! command -v brew &>/dev/null; then
     info "Would install packages from Brewfile (Homebrew not yet installed)"
-    local entry_count=$(grep -cE "^(brew|cask|tap|mas)" "$brewfile" || echo "0")
+    local entry_count
+    entry_count=$(grep -cE "^(brew|cask|tap|mas)" "$brewfile" || echo "0")
     info "Brewfile contains: $entry_count total entries"
     return
   fi
@@ -76,7 +77,8 @@ check_brew_bundle() {
     success "All Brewfile packages already installed — skip"
   else
     # Count missing packages from the output
-    local missing_count=$(echo "$check_output" | grep -c "needs to be installed" || echo "0")
+    local missing_count
+    missing_count=$(echo "$check_output" | grep -c "needs to be installed" || echo "0")
     if (( missing_count > 0 )); then
       info "Would install: $missing_count package(s)"
     else
@@ -133,7 +135,8 @@ check_mise_runtimes() {
   fi
 
   local -a runtimes=("ruby@3.3.6" "node@22" "java@temurin-21" "python@3.12" "go@1.24")
-  local installed=$(mise list 2>/dev/null || echo "")
+  local installed
+  installed=$(mise list 2>/dev/null || echo "")
   local -a missing=()
 
   for runtime in "${runtimes[@]}"; do
@@ -169,7 +172,8 @@ check_rust() {
       info "Would skip Rust (rustup not installed)"
     fi
   else
-    local rust_version=$(rustc --version 2>/dev/null | awk '{print $2}')
+    local rust_version
+    rust_version=$(rustc --version 2>/dev/null | awk '{print $2}' || true)
     success "rustup already installed (rustc $rust_version) — skip"
   fi
 }

--- a/scripts/install_claude_code.sh
+++ b/scripts/install_claude_code.sh
@@ -76,7 +76,8 @@ install_claude_code() {
 
       # Verify installation
       if command -v claude &>/dev/null; then
-        local installed_version=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+        local installed_version
+        installed_version=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
         success "Verified: claude command available (version $installed_version)"
       else
         warn "Installation completed but 'claude' not found in PATH"
@@ -109,7 +110,8 @@ install_claude_code() {
 
     # Verify installation
     if command -v claude &>/dev/null; then
-      local installed_version=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+      local installed_version
+      installed_version=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
       success "Verified: claude command available (version $installed_version)"
     else
       warn "Installation completed but 'claude' not found in PATH"

--- a/scripts/install_vscode_work_extensions.sh
+++ b/scripts/install_vscode_work_extensions.sh
@@ -80,7 +80,8 @@ install_work_vscode_extensions() {
   local failed=0
 
   for vsix in "${vsix_files[@]}"; do
-    local ext_name=$(basename "$vsix")
+    local ext_name
+    ext_name=$(basename "$vsix")
     info "Installing $ext_name..."
 
     if code --install-extension "$vsix" --force 2>/dev/null; then

--- a/scripts/install_zscaler_cert.sh
+++ b/scripts/install_zscaler_cert.sh
@@ -18,10 +18,6 @@ else
   error() { echo "❌ $*" >&2; }
 fi
 
-# Color codes
-CYAN='\033[0;36m'
-RESET='\033[0m'
-
 CERT_NAME="ZscalerRootCertificate-2048-SHA256"
 CERT_FILE="${CERT_NAME}.crt"
 

--- a/scripts/setup_work_configs.sh
+++ b/scripts/setup_work_configs.sh
@@ -2,6 +2,10 @@
 # Setup work-specific configurations from templates
 # Part of Phase 2: Installation Scripts
 
+# Note: the ~/… strings in the user-facing messages below are intentional
+# display text, not paths meant to expand, so suppress SC2088 file-wide.
+# shellcheck disable=SC2088
+
 set -e
 
 # Get the dotfiles directory
@@ -199,7 +203,8 @@ setup_claude_cli() {
   info "Checking Claude Code CLI installation..."
 
   if command -v claude &>/dev/null; then
-    local version=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
+    local version
+    version=$(claude --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' || echo "unknown")
     success "Claude Code CLI already installed (version: $version)"
     return 0
   fi

--- a/scripts/test_dryrun_helpers.sh
+++ b/scripts/test_dryrun_helpers.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# test_dryrun_helpers.sh — unit tests for dryrun_helpers.sh
+# Usage: bash scripts/test_dryrun_helpers.sh
+# shellcheck disable=SC1091,SC2030,SC2031,SC2034  # dynamic source; intentional subshell scoping; vars used by sourced fns
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+  TESTS_PASSED=$(( TESTS_PASSED + 1 ))
+  TESTS_RUN=$(( TESTS_RUN + 1 ))
+  printf "  PASS  %s\n" "$1"
+}
+
+fail() {
+  TESTS_FAILED=$(( TESTS_FAILED + 1 ))
+  TESTS_RUN=$(( TESTS_RUN + 1 ))
+  printf "  FAIL  %s — %s\n" "$1" "$2"
+}
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+# Source the bootstrap output helpers (info/success/warn + colors) and the
+# dry-run helpers under test ONCE, here at the script's top level. This mirrors
+# how bootstrap.sh sources them at top level, and — crucially — keeps the
+# `typeset -a DRY_RUN_ACTIONS=()` declaration in a non-function scope so the
+# array stays a real (empty) variable instead of becoming unbound under `set -u`.
+# Each test runs in its own subshell, which inherits this empty array and these
+# functions but cannot leak mutations back to the parent, so every test starts
+# from a clean slate.
+source "$SCRIPT_DIR/bootstrap_helpers.sh"
+setup_colors
+STEP=0
+TOTAL_STEPS=13
+source "$SCRIPT_DIR/dryrun_helpers.sh"
+
+# ── Shared fake dotfiles checkout ─────────────────────────────────────────────
+# check_dotfile_symlinks reads $DOTFILES_DIR/<src> only for the readlink compare,
+# so the files do not need to exist for the symlink-target match to succeed.
+FAKE_DOTFILES="$TMPDIR_BASE/dotfiles"
+mkdir -p "$FAKE_DOTFILES/config/git"
+
+# The destination/source pairs check_dotfile_symlinks iterates over (16 entries).
+DOTFILE_PAIRS=(
+  ".zshrc:zshrc"
+  ".zprofile:zprofile"
+  ".gitconfig:gitconfig"
+  ".tmux.conf:tmux.conf"
+  ".hyper.js:hyper.js"
+  ".gitignore_global:gitignore_global"
+  ".gemrc:gemrc"
+  ".irbrc:irbrc"
+  ".pryrc:pryrc"
+  ".psqlrc:psqlrc"
+  ".npmrc:npmrc"
+  ".editorconfig:editorconfig"
+  ".config/starship.toml:config/starship.toml"
+  ".config/direnv/direnvrc:config/direnvrc"
+  ".config/mise/config.toml:config/mise.toml"
+  ".ssh/config:ssh_config"
+)
+
+# ── dry_run_log ───────────────────────────────────────────────────────────────
+echo ""
+echo "=== dry_run_log ==="
+
+# Case 1: appends a single entry
+if (
+  dry_run_log "first action"
+  [[ "${#DRY_RUN_ACTIONS[@]}" -eq 1 ]] || { printf "  FAIL  count: expected 1, got %s\n" "${#DRY_RUN_ACTIONS[@]}"; exit 1; }
+  [[ "${DRY_RUN_ACTIONS[0]}" == "first action" ]] || { printf "  FAIL  content: got %s\n" "${DRY_RUN_ACTIONS[0]}"; exit 1; }
+); then
+  pass "dry_run_log: single call → 1 entry with matching text"
+else
+  fail "dry_run_log: single call" "subshell exited non-zero"
+fi
+
+# Case 2: appends multiple entries in order
+if (
+  dry_run_log "a"
+  dry_run_log "b"
+  dry_run_log "c"
+  [[ "${#DRY_RUN_ACTIONS[@]}" -eq 3 ]] || { printf "  FAIL  count: expected 3, got %s\n" "${#DRY_RUN_ACTIONS[@]}"; exit 1; }
+  [[ "${DRY_RUN_ACTIONS[2]}" == "c" ]] || { printf "  FAIL  order: last entry got %s\n" "${DRY_RUN_ACTIONS[2]}"; exit 1; }
+); then
+  pass "dry_run_log: three calls → 3 ordered entries"
+else
+  fail "dry_run_log: three calls" "subshell exited non-zero"
+fi
+
+# Case 3: fresh subshell starts with an empty action list
+if (
+  [[ "${#DRY_RUN_ACTIONS[@]}" -eq 0 ]] || { printf "  FAIL  expected empty, got %s\n" "${#DRY_RUN_ACTIONS[@]}"; exit 1; }
+); then
+  pass "dry_run_log: DRY_RUN_ACTIONS empty at start of each test"
+else
+  fail "dry_run_log: empty at start" "subshell exited non-zero"
+fi
+
+# ── dry_run_step ──────────────────────────────────────────────────────────────
+echo ""
+echo "=== dry_run_step ==="
+
+# Case 1: increments STEP
+if (
+  dry_run_step "first"  >/dev/null
+  [[ "$STEP" -eq 1 ]] || { printf "  FAIL  STEP after 1 call: expected 1, got %s\n" "$STEP"; exit 1; }
+  dry_run_step "second" >/dev/null
+  [[ "$STEP" -eq 2 ]] || { printf "  FAIL  STEP after 2 calls: expected 2, got %s\n" "$STEP"; exit 1; }
+); then
+  pass "dry_run_step: increments STEP (1, 2)"
+else
+  fail "dry_run_step: increments STEP" "subshell exited non-zero"
+fi
+
+# Case 2: output contains the [STEP/TOTAL] counter and the title
+output=$( dry_run_step "Install widgets" )
+if echo "$output" | grep -q "1/13"; then
+  pass "dry_run_step: output contains counter [1/13]"
+else
+  fail "dry_run_step: counter" "got: $output"
+fi
+if echo "$output" | grep -q "Install widgets"; then
+  pass "dry_run_step: output contains title text"
+else
+  fail "dry_run_step: title" "got: $output"
+fi
+
+# Case 3: output marks the step as a dry run
+if echo "$output" | grep -q "dry-run"; then
+  pass "dry_run_step: output marked '(dry-run)'"
+else
+  fail "dry_run_step: dry-run marker" "got: $output"
+fi
+
+# ── check_dotfile_symlinks ────────────────────────────────────────────────────
+echo ""
+echo "=== check_dotfile_symlinks ==="
+
+# Case 1: nothing linked yet → logs install action + would-symlink all 16 files
+FAKE_HOME1="$TMPDIR_BASE/home1"
+mkdir -p "$FAKE_HOME1"
+out1=$(
+  export HOME="$FAKE_HOME1"
+  DOTFILES_DIR="$FAKE_DOTFILES"
+  check_dotfile_symlinks
+  printf '\n--ACTIONS--\n'
+  printf '%s\n' "${DRY_RUN_ACTIONS[@]}"
+)
+if echo "$out1" | grep -q "Would symlink: 16 file(s)"; then
+  pass "check_dotfile_symlinks: empty HOME → would symlink all 16"
+else
+  fail "check_dotfile_symlinks: empty HOME would-symlink count" "got: $out1"
+fi
+if echo "$out1" | grep -q "Run: install.sh (symlink dotfiles)"; then
+  pass "check_dotfile_symlinks: logs install.sh action"
+else
+  fail "check_dotfile_symlinks: install.sh action logged" "got: $out1"
+fi
+
+# Case 2: all destinations already correctly linked → would symlink 0
+FAKE_HOME2="$TMPDIR_BASE/home2"
+for pair in "${DOTFILE_PAIRS[@]}"; do
+  dest_rel="${pair%%:*}"
+  src_rel="${pair##*:}"
+  mkdir -p "$FAKE_HOME2/$(dirname "$dest_rel")"
+  ln -sf "$FAKE_DOTFILES/$src_rel" "$FAKE_HOME2/$dest_rel"
+done
+out2=$(
+  export HOME="$FAKE_HOME2"
+  DOTFILES_DIR="$FAKE_DOTFILES"
+  check_dotfile_symlinks
+)
+if echo "$out2" | grep -q "Would symlink: 0 file(s)"; then
+  pass "check_dotfile_symlinks: all linked → would symlink 0"
+else
+  fail "check_dotfile_symlinks: all-linked would-symlink count" "got: $out2"
+fi
+if echo "$out2" | grep -q "Already linked: 16 file(s)"; then
+  pass "check_dotfile_symlinks: all linked → already linked 16"
+else
+  fail "check_dotfile_symlinks: already-linked count" "got: $out2"
+fi
+
+# Case 3: an existing plain file at a destination → reported as a backup
+FAKE_HOME3="$TMPDIR_BASE/home3"
+mkdir -p "$FAKE_HOME3"
+echo "pre-existing" > "$FAKE_HOME3/.zshrc"
+out3=$(
+  export HOME="$FAKE_HOME3"
+  DOTFILES_DIR="$FAKE_DOTFILES"
+  check_dotfile_symlinks
+)
+if echo "$out3" | grep -qE "Would backup: 1 existing file"; then
+  pass "check_dotfile_symlinks: plain file at dest → would backup 1"
+else
+  fail "check_dotfile_symlinks: backup detection" "got: $out3"
+fi
+
+# Case 4: missing local configs are logged as create actions
+if (
+  export HOME="$FAKE_HOME1"
+  DOTFILES_DIR="$FAKE_DOTFILES"
+  check_dotfile_symlinks >/dev/null
+  printf '%s\n' "${DRY_RUN_ACTIONS[@]}" | grep -q "Create ~/.zshrc.local from template" \
+    || { printf "  FAIL  missing zshrc.local not logged\n"; exit 1; }
+  printf '%s\n' "${DRY_RUN_ACTIONS[@]}" | grep -q "Create ~/.config/git/local.gitconfig from template" \
+    || { printf "  FAIL  missing local.gitconfig not logged\n"; exit 1; }
+); then
+  pass "check_dotfile_symlinks: logs create actions for missing local configs"
+else
+  fail "check_dotfile_symlinks: local config create actions" "subshell exited non-zero"
+fi
+
+# ── check_ssh_key ─────────────────────────────────────────────────────────────
+echo ""
+echo "=== check_ssh_key ==="
+
+# Case 1: no key present → logs a generate action
+if (
+  export HOME="$TMPDIR_BASE/ssh_none"
+  mkdir -p "$HOME"
+  check_ssh_key >/dev/null
+  printf '%s\n' "${DRY_RUN_ACTIONS[@]}" | grep -q "Generate SSH key" \
+    || { printf "  FAIL  generate action not logged\n"; exit 1; }
+); then
+  pass "check_ssh_key: missing key → logs generate action"
+else
+  fail "check_ssh_key: missing key" "subshell exited non-zero"
+fi
+
+# Case 2: key already present → no generate action, reports skip
+out_key=$(
+  export HOME="$TMPDIR_BASE/ssh_have"
+  mkdir -p "$HOME/.ssh"
+  : > "$HOME/.ssh/id_ed25519"
+  check_ssh_key
+  printf '\n--ACTIONS--\n'
+  printf '%s\n' "${DRY_RUN_ACTIONS[@]}"
+)
+if echo "$out_key" | grep -q "already exists"; then
+  pass "check_ssh_key: existing key → reports skip"
+else
+  fail "check_ssh_key: existing key skip message" "got: $out_key"
+fi
+if echo "$out_key" | sed -n '/--ACTIONS--/,$p' | grep -q "Generate SSH key"; then
+  fail "check_ssh_key: existing key should not log generate" "got: $out_key"
+else
+  pass "check_ssh_key: existing key → no generate action logged"
+fi
+
+# ── check_brew_bundle (missing Brewfile branch) ───────────────────────────────
+echo ""
+echo "=== check_brew_bundle ==="
+
+# Case 1: Brewfile path does not exist → warns and logs nothing
+out_brew=$(
+  check_brew_bundle "$TMPDIR_BASE/no_such_brewfile"
+  printf '\n--ACTIONS--\n'
+  printf '%s\n' "${DRY_RUN_ACTIONS[@]}"
+)
+if echo "$out_brew" | grep -q "Brewfile not found"; then
+  pass "check_brew_bundle: missing Brewfile → warns"
+else
+  fail "check_brew_bundle: missing Brewfile warning" "got: $out_brew"
+fi
+if echo "$out_brew" | sed -n '/--ACTIONS--/,$p' | grep -q "brew bundle"; then
+  fail "check_brew_bundle: missing Brewfile should log nothing" "got: $out_brew"
+else
+  pass "check_brew_bundle: missing Brewfile → no action logged"
+fi
+
+# ── check_work_configs ────────────────────────────────────────────────────────
+echo ""
+echo "=== check_work_configs ==="
+
+# Case 1: setup script present → reports it would prompt
+WORK_DOTFILES="$TMPDIR_BASE/work_dotfiles"
+mkdir -p "$WORK_DOTFILES/scripts"
+: > "$WORK_DOTFILES/scripts/setup_work_configs.sh"
+out_work=$(
+  DOTFILES_DIR="$WORK_DOTFILES"
+  check_work_configs
+)
+if echo "$out_work" | grep -q "work configuration setup"; then
+  pass "check_work_configs: script present → reports prompt"
+else
+  fail "check_work_configs: script present" "got: $out_work"
+fi
+
+# Case 2: setup script absent → no output
+out_work_none=$(
+  DOTFILES_DIR="$TMPDIR_BASE/work_none"
+  mkdir -p "$DOTFILES_DIR"
+  check_work_configs
+)
+if [[ -z "$out_work_none" ]]; then
+  pass "check_work_configs: script absent → silent"
+else
+  fail "check_work_configs: script absent" "expected no output, got: $out_work_none"
+fi
+
+# ── show_dry_run_summary ──────────────────────────────────────────────────────
+echo ""
+echo "=== show_dry_run_summary ==="
+
+# Case 1: no actions → reports already bootstrapped
+out_sum_empty=$( show_dry_run_summary )
+if echo "$out_sum_empty" | grep -q "0 actions planned"; then
+  pass "show_dry_run_summary: empty → '0 actions planned'"
+else
+  fail "show_dry_run_summary: empty count" "got: $out_sum_empty"
+fi
+if echo "$out_sum_empty" | grep -q "already bootstrapped"; then
+  pass "show_dry_run_summary: empty → 'already bootstrapped' message"
+else
+  fail "show_dry_run_summary: empty message" "got: $out_sum_empty"
+fi
+
+# Case 2: with actions → reports count and enumerates each action
+out_sum=$(
+  dry_run_log "Install Homebrew"
+  dry_run_log "Generate SSH key"
+  show_dry_run_summary
+)
+if echo "$out_sum" | grep -q "2 actions planned"; then
+  pass "show_dry_run_summary: 2 logged → '2 actions planned'"
+else
+  fail "show_dry_run_summary: action count" "got: $out_sum"
+fi
+if echo "$out_sum" | grep -q "Install Homebrew" && echo "$out_sum" | grep -q "Generate SSH key"; then
+  pass "show_dry_run_summary: enumerates logged actions"
+else
+  fail "show_dry_run_summary: action enumeration" "got: $out_sum"
+fi
+
+# ── check_macos_defaults ──────────────────────────────────────────────────────
+echo ""
+echo "=== check_macos_defaults ==="
+
+# Always informational; logs nothing but mentions the defaults it would apply.
+out_macos=$(
+  check_macos_defaults
+  printf '\n--ACTIONS--\n'
+  printf '%s\n' "${DRY_RUN_ACTIONS[@]}"
+)
+if echo "$out_macos" | grep -q "macOS developer defaults"; then
+  pass "check_macos_defaults: reports it would prompt"
+else
+  fail "check_macos_defaults: prompt message" "got: $out_macos"
+fi
+macos_actions=$(echo "$out_macos" | awk 'p; /--ACTIONS--/{p=1}' | tr -d '[:space:]')
+if [[ -n "$macos_actions" ]]; then
+  fail "check_macos_defaults: should not log actions" "got: $out_macos"
+else
+  pass "check_macos_defaults: logs no actions"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────"
+printf "  %d tests: %d passed, %d failed\n" "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+echo "─────────────────────────────────────"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/verify_git_signing.sh
+++ b/scripts/verify_git_signing.sh
@@ -29,9 +29,10 @@ test_repo() {
     fi
 
     cd "$repo_path"
-    local actual_email=$(git config user.email)
-    local actual_key=$(git config user.signingkey 2>/dev/null || echo "NONE")
-    local actual_sign=$(git config commit.gpgsign)
+    local actual_email actual_key actual_sign
+    actual_email=$(git config user.email || true)
+    actual_key=$(git config user.signingkey 2>/dev/null || echo "NONE")
+    actual_sign=$(git config commit.gpgsign || true)
 
     local status="✅ PASS"
     local color=$GREEN


### PR DESCRIPTION
## Summary
CI + test-coverage workstream of the dotfiles roadmap. Makes shellcheck coverage comprehensive, asserts `install.sh` idempotency in CI, auto-discovers unit tests, and adds tests for the dry-run helpers.

### `.github/workflows/ci.yml`
- Replaced the five hard-coded `shellcheck` steps with a single step that lints **every** top-level `*.sh` and `scripts/*.sh` at `-S warning`. New scripts are covered automatically.
- zsh files are detected by shebang and skipped (routed to the `zsh-syntax` job): `install.sh` and `scripts/setup_gpg_signing.sh`. The `zsh-syntax` job now also `zsh -n`'s `scripts/setup_gpg_signing.sh`.
- `scripts/preflight.sh` is **temporarily excluded** from the lint glob with a `TODO(core-hygiene)` marker — it becomes shellcheck-clean on `feature/core-hygiene`; remove the exclusion once both land.
- `install-smoke` job: after symlink verification, runs `install.sh` a **second time** against the same temp `HOME` and asserts the summary reports `0 backed up`; also asserts the repo working tree stays clean (no `publisher.extension` residue files).

### `.github/workflows/test-bootstrap.yml`
- Auto-discovers and runs **every** `scripts/test_*.sh` (glob/loop) instead of naming individual files, so new test files are picked up without editing the workflow. Syntax-check steps retained (and generalized to glob the test files); path triggers widened to `scripts/**`.

### `scripts/test_dryrun_helpers.sh` (new)
- Unit tests for `scripts/dryrun_helpers.sh` in the existing hand-rolled harness style: `dry_run_log`, `dry_run_step`, `check_dotfile_symlinks`, `check_ssh_key`, `check_brew_bundle`, `check_work_configs`, `show_dry_run_summary`, `check_macos_defaults` (26 assertions).

## Pre-existing shellcheck fixes (separate commit)
Enabling the repo-wide glob surfaced real warnings in scripts no longer named individually. To keep CI green, this PR includes a separate, mechanical, behavior-preserving commit fixing 7 scripts (authorized by the orchestrator; `scripts/preflight.sh` left untouched — owned by `feature/core-hygiene`):
- `quick-fix.sh` — SC2164 (`cd ... || exit`), SC1090 (`# shellcheck source=/dev/null`)
- `scripts/dryrun_helpers.sh`, `scripts/install_claude_code.sh`, `scripts/install_vscode_work_extensions.sh`, `scripts/setup_work_configs.sh`, `scripts/verify_git_signing.sh` — SC2155 (split `local` decl/assignment)
- `scripts/install_zscaler_cert.sh` — SC2034 (drop unused `CYAN`/`RESET`)
- `scripts/setup_work_configs.sh` — SC2088 (file-level disable for intentional `~/` display strings)

## Validation (run locally)
- `shellcheck -S warning scripts/test_dryrun_helpers.sh` — clean
- `bash scripts/test_*.sh` — all pass (bootstrap 14, dryrun 26, verify 26)
- Simulated the ci.yml lint glob: all bash scripts pass; `install.sh`, `scripts/setup_gpg_signing.sh` skipped (zsh); `scripts/preflight.sh` skipped (excluded); `fail=0`
- `install.sh` run twice against a temp `HOME`: 2nd run reports `0 backed up`
- `bash -n` on all workflow-referenced scripts; both workflow YAMLs parse cleanly

_Conversation: https://app.warp.dev/conversation/ec5b8536-789c-4eb2-abdd-1398b6df41c1_
_Run: https://oz.warp.dev/runs/019ec40d-03d3-75c1-a30c-4b7f11ec43a4_
_Plans_:
- _[Dotfiles roadmap execution (orchestrated)](https://app.warp.dev/conversation/ec5b8536-789c-4eb2-abdd-1398b6df41c1)_

_This PR was generated with [Oz](https://warp.dev/oz)._
