### PR TITLE
ci: lint preflight.sh (drop temporary shellcheck exclusion)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,6 @@ jobs:
           fail=0
           shopt -s nullglob
           for script in *.sh scripts/*.sh; do
-            # scripts/preflight.sh is excluded until feature/core-hygiene makes it
-            # shellcheck-clean.
-            # TODO(core-hygiene): drop this exclusion once scripts/preflight.sh is clean.
-            if [[ "$script" == "scripts/preflight.sh" ]]; then
-              echo "SKIP (excluded, see TODO): $script"
-              continue
-            fi
             if head -1 "$script" | grep -q 'zsh'; then
               echo "SKIP (zsh, see zsh-syntax job): $script"
               continue


### PR DESCRIPTION
## What
Removes the temporary `scripts/preflight.sh` exclusion from the repo-wide shellcheck job in `ci.yml`.
## Why
`preflight.sh` is now `shellcheck -S warning` clean on `main` (fixed in core-hygiene, #31). The exclusion was a cross-branch stopgap added with the repo-wide shellcheck glob (#33), whose branch predated #31.
## Validation
- `shellcheck -S warning scripts/preflight.sh` exits 0 on current main.
- The glob now lints preflight.sh alongside every other bash script.

Conversation: https://app.warp.dev/conversation/39a0ce65-f3ba-4985-b1f5-38b02031602c
Plan: https://app.warp.dev/drive/notebook/eImxwvHmNQBkcbcX11uFKh

Co-Authored-By: Oz <oz-agent@warp.dev>