### PR TITLE
Make config/mise.toml the single source of truth for runtimes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Four entry-point scripts form the pipeline; everything in `scripts/` exists to s
 1. **`bootstrap.sh`** (bash) — one-time setup on a fresh Mac. Runs `scripts/preflight.sh` first (unless `--skip-preflight` or `--dry-run`), installs Homebrew and the `Brewfile`, language runtimes via `mise`, Yarn via Corepack (from the mise-managed Node), Rust via `rustup`, and `git-lfs`, then hands off to `install.sh` for symlinks, and finally prompts for work configs (`scripts/setup_work_configs.sh`) and macOS defaults (`scripts/macos.sh`). Supports `--dry-run` and `--skip-preflight`.
 2. **`install.sh`** (zsh) — the symlinker. Links every tracked dotfile into `$HOME`, backing up any pre-existing real file to `~/.dotfiles_backup/<timestamp>/`. It also seeds `~/.config/git/local.gitconfig` from `home/examples/gitconfig.local.example` and installs a global pre-commit hook at `~/.config/git/hooks/pre-commit`. Idempotent: a second run relinks nothing already correct and reports `linked / current / backed up`.
 3. **`update.sh`** (bash) — keep-current. `git pull --rebase --autostash`, re-runs `install.sh` to pick up new symlinks, upgrades Homebrew / `mise` / `rustup` / gems / `uv` tools, then runs `verify.sh`. Schedulable via `scripts/setup-scheduler.sh` (launchd, daily at 9 AM).
-4. **`verify.sh`** (bash) — health check. Seven checks: symlinks, `mise.toml` vs `bootstrap.sh` version drift, required tools, stale backups, SSH key, global git-lfs init, and mise-installed runtimes. Broken symlinks are the only hard error (exit 1); everything else is a warning (exit 0).
+4. **`verify.sh`** (bash) — health check. Eight checks: symlinks, required tools, stale backups, SSH key, global git-lfs init, mise-installed runtimes, dotfiles git health, and Brewfile drift. Broken symlinks are the only hard error (exit 1); everything else is a warning (exit 0).
 
 ```
 bootstrap.sh ──▶ install.sh ──▶ update.sh ──▶ verify.sh
@@ -29,8 +29,8 @@ bootstrap.sh ──▶ install.sh ──▶ update.sh ──▶ verify.sh
 
 ## Helpers
 
-- **`scripts/lib/bootstrap_helpers.sh`** — sourced by `bootstrap.sh`, `update.sh`, and `verify.sh`. Side-effect-free output helpers: `setup_colors`, `step`, `info`, `success`, `warn`. Call `setup_colors` once after sourcing.
-- **`scripts/lib/verify_helpers.sh`** — sourced by `verify.sh`. Pure check functions (`check_symlinks`, `check_mise_version_drift`, `check_required_tools`, `check_ssh_key`, `check_git_lfs_global`, `check_mise_installed`, `check_stale_backups`). Each sets result globals (e.g. `SYMLINK_BROKEN_COUNT`, `SYMLINK_BROKEN_LIST`) rather than printing or exiting, which makes them unit-testable. The canonical symlink map lives here as the `DOTFILES_SYMLINKS` array.
+- **`scripts/lib/bootstrap_helpers.sh`** — sourced by `bootstrap.sh`, `update.sh`, and `verify.sh`. Side-effect-free output helpers (`setup_colors`, `step`, `info`, `success`, `warn`; call `setup_colors` once after sourcing) plus `parse_mise_runtimes`, which reads the `[tools]` table of `config/mise.toml` — the single source of truth for runtime versions.
+- **`scripts/lib/verify_helpers.sh`** — sourced by `verify.sh`. Pure check functions (`check_symlinks`, `check_required_tools`, `check_ssh_key`, `check_git_lfs_global`, `check_mise_installed`, `check_stale_backups`, `check_dotfiles_git_health`, `check_brewfile_drift`). Each sets result globals (e.g. `SYMLINK_BROKEN_COUNT`, `SYMLINK_BROKEN_LIST`) rather than printing or exiting, which makes them unit-testable. The canonical symlink map lives here as the `DOTFILES_SYMLINKS` array.
 - **`scripts/lib/dryrun_helpers.sh`** — sourced by `bootstrap.sh` only when `--dry-run` is set. Provides `dry_run_step`, per-step `check_*` previews (including `check_corepack`) that record intended actions via `dry_run_log`, and `show_dry_run_summary`.
 - **`scripts/preflight.sh`** — standalone (defines its own colors and `error`/`warn`/`success`/`info`). Validates the system before bootstrap.
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
 | `Brewfile` | _(used by bootstrap)_ | All Homebrew packages and casks |
 | `home/npmrc` | `~/.npmrc` | npm defaults — `save-exact`, no fund/update noise |
 | `update.sh` | _(run to update)_ | Upgrade all packages, runtimes, and gems; runs health check at end |
-| `verify.sh` | _(run to verify)_ | Health check — symlinks, version drift, missing tools, stale backups |
+| `verify.sh` | _(run to verify)_ | Health check — symlinks, missing tools, installed runtimes, stale backups |
 | `scripts/setup-scheduler.sh` | _(run once)_ | Install launchd job to run `update.sh` daily at 9 AM |
 | `scripts/macos.sh` | _(run once)_ | macOS developer defaults |
 | `home/examples/zshrc.local.example` | _(template)_ | Template for machine-specific overrides |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -245,60 +245,71 @@ if [[ "$DRY_RUN" == true ]]; then
   check_mise_runtimes
 elif command -v mise &>/dev/null; then
   step "⚡  Runtimes via mise  (Ruby · Node · Java · Python · Go)"
-  # Check what's already installed
-  _installed=$(mise list 2>/dev/null || echo "")
+  # Read the runtime list from config/mise.toml — the single source of truth.
+  declare -a runtimes=()
+  while IFS= read -r _rt; do
+    [[ -n "$_rt" ]] && runtimes+=("$_rt")
+  done < <(parse_mise_runtimes "$DOTFILES_DIR/config/mise.toml")
 
-  # Define runtimes to install
-  declare -a runtimes=("ruby@3.3.6" "node@22" "java@temurin-21" "python@3.12" "go@1.24")
-  declare -a to_install=()
-
-  # Check which runtimes need installation
-  for runtime in "${runtimes[@]}"; do
-    if echo "$_installed" | grep -q "$runtime"; then
-      success "$runtime already installed"
-    else
-      to_install+=("$runtime")
-    fi
-  done
-
-  # If nothing to install, skip the prompt
-  if [[ ${#to_install[@]} -eq 0 ]]; then
-    mise use --global ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24 2>/dev/null || true
-    success "All runtimes already configured: Ruby 3.3.6 · Node 22 · Java 21 · Python 3.12 · Go 1.24"
+  if [[ ${#runtimes[@]} -eq 0 ]]; then
+    warn "No runtimes declared in config/mise.toml — skipping mise setup"
   else
-    echo ""
-    printf "  ${DIM}Installing ${#to_install[@]} runtime(s) can take 5-10 minutes (compiling from source).${RESET}\n"
-    echo ""
-    read -t 10 -rp "  Install missing runtimes now? [Y/n] (auto-yes in 10s) " install_runtimes || install_runtimes="y"
-    if [[ "$install_runtimes" =~ ^[Nn]$ ]]; then
-      info "Skipped. Install later with: mise install"
+    # Check what's already installed
+    _installed=$(mise list 2>/dev/null || echo "")
+    declare -a to_install=()
+
+    # Check which runtimes need installation
+    for runtime in "${runtimes[@]}"; do
+      if echo "$_installed" | grep -q "$runtime"; then
+        success "$runtime already installed"
+      else
+        to_install+=("$runtime")
+      fi
+    done
+
+    # Human-readable summary derived from the parsed list ("ruby@3.3.6 · …")
+    printf -v _rt_summary '%s · ' "${runtimes[@]}"
+    _rt_summary="${_rt_summary% · }"
+
+    # If nothing to install, skip the prompt
+    if [[ ${#to_install[@]} -eq 0 ]]; then
+      mise use --global "${runtimes[@]}" 2>/dev/null || true
+      success "All runtimes already configured: ${_rt_summary}"
     else
-      # Install only missing runtimes with progress feedback
-      declare -i total=${#to_install[@]}
-      declare -i current=0
+      echo ""
+      printf "  ${DIM}Installing ${#to_install[@]} runtime(s) can take 5-10 minutes (compiling from source).${RESET}\n"
+      echo ""
+      read -t 10 -rp "  Install missing runtimes now? [Y/n] (auto-yes in 10s) " install_runtimes || install_runtimes="y"
+      if [[ "$install_runtimes" =~ ^[Nn]$ ]]; then
+        info "Skipped. Install later with: mise install"
+      else
+        # Install only missing runtimes with progress feedback
+        declare -i total=${#to_install[@]}
+        declare -i current=0
 
-      # Disable exit-on-error for runtime installations
-      set +e
+        # Disable exit-on-error for runtime installations
+        set +e
 
-      for runtime in "${to_install[@]}"; do
-        (( current++ ))
-        percentage=$(( current * 100 / total ))
-        echo ""
-        printf "${CYAN}  → [$current/$total - ${percentage}%%] Installing $runtime...${RESET}\n"
-        echo ""
-        # Show full output so user can see progress
-        if mise install "$runtime" 2>&1; then
-          printf "${GREEN}  ✓ [$current/$total - ${percentage}%%] $runtime installed${RESET}\n"
-        else
-          warn "Failed to install $runtime (continuing anyway)"
-        fi
-      done
+        for runtime in "${to_install[@]}"; do
+          (( current++ ))
+          percentage=$(( current * 100 / total ))
+          echo ""
+          printf "${CYAN}  → [$current/$total - ${percentage}%%] Installing $runtime...${RESET}\n"
+          echo ""
+          # Show full output so user can see progress
+          if mise install "$runtime" 2>&1; then
+            printf "${GREEN}  ✓ [$current/$total - ${percentage}%%] $runtime installed${RESET}\n"
+          else
+            warn "Failed to install $runtime (continuing anyway)"
+          fi
+        done
 
-      # Re-enable exit-on-error
-      set -e
+        # Re-enable exit-on-error
+        set -e
 
-      mise use --global ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24 2>/dev/null || true
-      success "Runtime installation complete (some may have failed - check above)"
+        mise use --global "${runtimes[@]}" 2>/dev/null || true
+        success "Runtime installation complete (some may have failed - check above)"
+      fi
     fi
   fi
 else

--- a/scripts/lib/bootstrap_helpers.sh
+++ b/scripts/lib/bootstrap_helpers.sh
@@ -24,3 +24,28 @@ step() {
   echo ""
   printf "${BOLD}${BLUE}  ▸ [%d/%d]  %s${RESET}\n" "$STEP" "$TOTAL_STEPS" "$*"
 }
+
+# ── mise runtime parsing ──────────────────────────────────────────────────────
+# parse_mise_runtimes TOML_FILE
+# Prints one "tool@version" per line for every entry in the [tools] table of a
+# mise config (e.g. config/mise.toml), making that file the single source of
+# truth for runtime versions. Pure Bash (portable to macOS Bash 3.2): tracks the
+# [tools] table, skips blanks/comments and other tables, and takes the first
+# double-quoted value. A missing file prints nothing.
+parse_mise_runtimes() {
+  local toml_file="$1" line key val in_tools=0
+  [[ -f "$toml_file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # strip leading whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    case "$line" in
+      ''|'#'*)    continue ;;              # blank or comment
+      '[tools]'*) in_tools=1; continue ;;  # enter the [tools] table
+      '['*)       in_tools=0; continue ;;  # any other table ends it
+    esac
+    [[ "$in_tools" -eq 1 && "$line" == *=* ]] || continue
+    key="${line%%=*}"; key="${key//[[:space:]]/}"
+    val="${line#*=}"; val="${val#*\"}"; val="${val%%\"*}"
+    [[ -n "$key" && -n "$val" ]] && printf '%s@%s\n' "$key" "$val"
+  done < "$toml_file"
+}

--- a/scripts/lib/dryrun_helpers.sh
+++ b/scripts/lib/dryrun_helpers.sh
@@ -134,7 +134,17 @@ check_mise_runtimes() {
     return
   fi
 
-  local -a runtimes=("ruby@3.3.6" "node@22" "java@temurin-21" "python@3.12" "go@1.24")
+  # Read the runtime list from config/mise.toml — the single source of truth.
+  local _rt
+  local -a runtimes=()
+  while IFS= read -r _rt; do
+    [[ -n "$_rt" ]] && runtimes+=("$_rt")
+  done < <(parse_mise_runtimes "$DOTFILES_DIR/config/mise.toml")
+  if [[ ${#runtimes[@]} -eq 0 ]]; then
+    info "No runtimes declared in config/mise.toml"
+    return
+  fi
+
   local installed
   installed=$(mise list 2>/dev/null || echo "")
   local -a missing=()

--- a/scripts/lib/verify_helpers.sh
+++ b/scripts/lib/verify_helpers.sh
@@ -72,56 +72,6 @@ check_symlinks() {
   done
 }
 
-# check_mise_version_drift TOML_FILE BOOTSTRAP_FILE
-# Compares runtime versions in config/mise.toml against the pinned versions in bootstrap.sh.
-# Detects drift introduced by editing one file without updating the other.
-# Sets:
-#   DRIFT_COUNT — number of mismatches
-#   DRIFT_LIST  — array of "tool: mise.toml=X  bootstrap.sh=Y" descriptions
-check_mise_version_drift() {
-  local toml_file="$1"
-  local bootstrap_file="$2"
-  DRIFT_COUNT=0
-  DRIFT_LIST=()
-
-  local tools=(ruby node java python go)
-
-  for tool in "${tools[@]}"; do
-    # Extract from mise.toml: tool = "version"
-    local toml_ver
-    toml_ver=$(grep -E "^${tool}[[:space:]]*=" "$toml_file" 2>/dev/null \
-      | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/' | tr -d '[:space:]')
-
-    # Extract from bootstrap.sh: mise install ...tool@version...
-    local bootstrap_ver
-    # Match only version characters so surrounding shell syntax in bootstrap.sh
-    # (quoted array elements like "ruby@3.3.6" and the closing paren on "go@1.24")
-    # is never captured as part of the version.
-    bootstrap_ver=$(grep -oE "${tool}@[A-Za-z0-9._-]+" "$bootstrap_file" 2>/dev/null \
-      | head -1 | sed "s/${tool}@//")
-
-    # Skip tools not tracked in either file
-    [[ -z "$toml_ver" && -z "$bootstrap_ver" ]] && continue
-
-    if [[ -z "$toml_ver" ]]; then
-      DRIFT_COUNT=$(( DRIFT_COUNT + 1 ))
-      DRIFT_LIST+=("$tool: present in bootstrap.sh ($bootstrap_ver) but missing from mise.toml")
-      continue
-    fi
-
-    if [[ -z "$bootstrap_ver" ]]; then
-      DRIFT_COUNT=$(( DRIFT_COUNT + 1 ))
-      DRIFT_LIST+=("$tool: present in mise.toml ($toml_ver) but not found in bootstrap.sh")
-      continue
-    fi
-
-    if [[ "$toml_ver" != "$bootstrap_ver" ]]; then
-      DRIFT_COUNT=$(( DRIFT_COUNT + 1 ))
-      DRIFT_LIST+=("$tool: mise.toml=$toml_ver  bootstrap.sh=$bootstrap_ver")
-    fi
-  done
-}
-
 # check_required_tools TOOL [TOOL ...]
 # Checks each named tool is available on PATH via command -v.
 # Sets:
@@ -211,18 +161,20 @@ check_mise_installed() {
 
   command -v mise &>/dev/null || return 0
 
-  local tools=(ruby node java python go)
-  for tool in "${tools[@]}"; do
-    local toml_ver
-    toml_ver=$(grep -E "^${tool}[[:space:]]*=" "$toml_file" 2>/dev/null \
-      | sed 's/.*=[[:space:]]*"\(.*\)".*/\1/' | tr -d '[:space:]')
-    [[ -z "$toml_ver" ]] && continue
-
+  # Derive the runtime list from mise.toml (the single source of truth) via
+  # parse_mise_runtimes (from bootstrap_helpers.sh, which verify.sh sources
+  # before this file), so a tool added to or removed from mise.toml is
+  # reflected here automatically.
+  local entry tool toml_ver
+  while IFS= read -r entry; do
+    [[ -n "$entry" ]] || continue
+    tool="${entry%@*}"
+    toml_ver="${entry#*@}"
     if ! mise where "$tool" &>/dev/null 2>&1; then
       MISE_UNINSTALLED_COUNT=$(( MISE_UNINSTALLED_COUNT + 1 ))
       MISE_UNINSTALLED_LIST+=("$tool@$toml_ver not installed — run: mise install")
     fi
-  done
+  done < <(parse_mise_runtimes "$toml_file")
 }
 
 # check_dotfiles_git_health DOTFILES_DIR

--- a/scripts/tests/test_bootstrap_helpers.sh
+++ b/scripts/tests/test_bootstrap_helpers.sh
@@ -184,6 +184,52 @@ else
   fail "output helpers" "subshell exited non-zero"
 fi
 
+# ── parse_mise_runtimes ───────────────────────────────────────────────────────
+echo ""
+echo "=== parse_mise_runtimes ==="
+
+PMR_TMP=$(mktemp -d)
+trap 'rm -rf "$PMR_TMP"' EXIT
+
+# Fixture: a representative mise config with a comment, blank lines, and a
+# trailing table that must be ignored.
+PMR_TOML="$PMR_TMP/mise.toml"
+cat > "$PMR_TOML" << 'EOF'
+# managed runtimes
+
+[tools]
+ruby = "3.3.6"
+node = "22"
+java = "temurin-21"
+python = "3.12"
+go = "1.24"
+
+[settings]
+experimental = true
+EOF
+
+# Case 1: emits one tool@version line per [tools] entry, preserving order
+pmr_out=$(
+  source "$SCRIPT_DIR/../lib/bootstrap_helpers.sh"
+  parse_mise_runtimes "$PMR_TOML"
+)
+pmr_expected=$'ruby@3.3.6\nnode@22\njava@temurin-21\npython@3.12\ngo@1.24'
+assert_eq "parse_mise_runtimes: parses [tools] into tool@version lines" "$pmr_expected" "$pmr_out"
+
+# Case 2: ignores comments, blank lines, and non-[tools] tables (exactly 5 entries)
+pmr_count=$(
+  source "$SCRIPT_DIR/../lib/bootstrap_helpers.sh"
+  parse_mise_runtimes "$PMR_TOML" | grep -c '@'
+)
+assert_eq "parse_mise_runtimes: ignores comments/blanks/other tables" "5" "$pmr_count"
+
+# Case 3: a missing file prints nothing and exits 0
+pmr_missing=$(
+  source "$SCRIPT_DIR/../lib/bootstrap_helpers.sh"
+  parse_mise_runtimes "$PMR_TMP/does_not_exist.toml"
+)
+assert_eq "parse_mise_runtimes: missing file → empty output" "" "$pmr_missing"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────"

--- a/scripts/tests/test_verify_helpers.sh
+++ b/scripts/tests/test_verify_helpers.sh
@@ -137,96 +137,6 @@ else
   fail "check_symlinks: empty list" "subshell exited non-zero"
 fi
 
-# ── check_mise_version_drift ──────────────────────────────────────────────────
-echo ""
-echo "=== check_mise_version_drift ==="
-
-TOML_MATCH="$TMPDIR_BASE/mise_match.toml"
-TOML_DRIFT="$TMPDIR_BASE/mise_drift.toml"
-TOML_MISSING_RUBY="$TMPDIR_BASE/mise_missing_ruby.toml"
-BOOTSTRAP_REF="$TMPDIR_BASE/bootstrap_ref.sh"
-
-cat > "$TOML_MATCH" << 'EOF'
-[tools]
-ruby = "3.3.6"
-node = "22"
-java = "temurin-21"
-python = "3.12"
-go = "1.24"
-EOF
-
-cat > "$TOML_DRIFT" << 'EOF'
-[tools]
-ruby = "3.3.0"
-node = "20"
-java = "temurin-21"
-python = "3.12"
-go = "1.24"
-EOF
-
-cat > "$TOML_MISSING_RUBY" << 'EOF'
-[tools]
-node = "22"
-java = "temurin-21"
-python = "3.12"
-go = "1.24"
-EOF
-
-cat > "$BOOTSTRAP_REF" << 'EOF'
-mise install ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
-mise use --global ruby@3.3.6 node@22 java@temurin-21 python@3.12 go@1.24
-EOF
-
-# Case 1: no drift
-if (
-  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
-  check_mise_version_drift "$TOML_MATCH" "$BOOTSTRAP_REF"
-  [[ "$DRIFT_COUNT" -eq 0 ]] || { printf "  FAIL  drift: expected 0, got %s\n" "$DRIFT_COUNT"; exit 1; }
-); then
-  pass "check_mise_version_drift: matching versions → DRIFT=0"
-else
-  fail "check_mise_version_drift: matching versions" "subshell exited non-zero"
-fi
-
-# Case 2: 2 drifted tools (ruby 3.3.0 vs 3.3.6, node 20 vs 22)
-if (
-  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
-  check_mise_version_drift "$TOML_DRIFT" "$BOOTSTRAP_REF"
-  [[ "$DRIFT_COUNT" -eq 2 ]] || { printf "  FAIL  drift: expected 2, got %s\n" "$DRIFT_COUNT"; exit 1; }
-); then
-  pass "check_mise_version_drift: ruby+node drifted → DRIFT=2"
-else
-  fail "check_mise_version_drift: 2 drifted tools" "subshell exited non-zero"
-fi
-
-# Case 3: drift list names the correct tools
-drift_items=$(
-  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
-  check_mise_version_drift "$TOML_DRIFT" "$BOOTSTRAP_REF"
-  printf '%s\n' "${DRIFT_LIST[@]}"
-)
-if echo "$drift_items" | grep -q "^ruby:"; then
-  pass "check_mise_version_drift: DRIFT_LIST contains ruby entry"
-else
-  fail "check_mise_version_drift: DRIFT_LIST contains ruby entry" "got: $drift_items"
-fi
-if echo "$drift_items" | grep -q "^node:"; then
-  pass "check_mise_version_drift: DRIFT_LIST contains node entry"
-else
-  fail "check_mise_version_drift: DRIFT_LIST contains node entry" "got: $drift_items"
-fi
-
-# Case 4: ruby absent from toml → detected as drift
-if (
-  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
-  check_mise_version_drift "$TOML_MISSING_RUBY" "$BOOTSTRAP_REF"
-  [[ "$DRIFT_COUNT" -ge 1 ]] || { printf "  FAIL  drift: expected >= 1, got %s\n" "$DRIFT_COUNT"; exit 1; }
-); then
-  pass "check_mise_version_drift: ruby missing from toml → DRIFT>=1"
-else
-  fail "check_mise_version_drift: ruby missing from toml" "subshell exited non-zero"
-fi
-
 # ── check_required_tools ──────────────────────────────────────────────────────
 echo ""
 echo "=== check_required_tools ==="
@@ -431,9 +341,20 @@ else
   fail "check_git_lfs_global: lfs config present" "subshell exited non-zero"
 fi
 
-# ── check_mise_installed ──────────────────────────────────────────────────
+# ── check_mise_installed ───────────────────────────
 echo ""
 echo "=== check_mise_installed ==="
+
+# Fixture: a mise config whose [tools] table lists the expected runtimes.
+TOML_MATCH="$TMPDIR_BASE/mise_match.toml"
+cat > "$TOML_MATCH" << 'EOF'
+[tools]
+ruby = "3.3.6"
+node = "22"
+java = "temurin-21"
+python = "3.12"
+go = "1.24"
+EOF
 
 # Case 1: mise not on PATH → silently returns count=0 (no-op)
 mkdir -p "$TMPDIR_BASE/empty_bin"
@@ -448,9 +369,12 @@ else
   fail "check_mise_installed: mise not on PATH" "subshell exited non-zero"
 fi
 
-# Case 2: all tools installed (reuse TOML_MATCH from earlier; only runs if mise is present)
+# Case 2: tool list derived from mise.toml; only runs if mise is present.
+# check_mise_installed uses parse_mise_runtimes, so source bootstrap_helpers.sh
+# too (verify.sh sources both, in this order, at runtime).
 if command -v mise &>/dev/null; then
   if (
+    source "$SCRIPT_DIR/../lib/bootstrap_helpers.sh"
     source "$SCRIPT_DIR/../lib/verify_helpers.sh"
     check_mise_installed "$TOML_MATCH"
     # We can't assert count=0 since tools may not be installed in CI,

--- a/verify.sh
+++ b/verify.sh
@@ -3,14 +3,13 @@
 #
 # Reports:
 #   1. Broken symlinks        (errors   — exit 1)
-#   2. Version drift          (warnings — exit 0)
-#   3. Missing required tools (warnings — exit 0)
-#   4. Stale backups          (warnings — exit 0)
-#   5. SSH key                (warnings — exit 0)
-#   6. git-lfs global init    (warnings — exit 0)
-#   7. mise tools installed   (warnings — exit 0)
-#   8. dotfiles git health    (warnings — exit 0)
-#   9. Brewfile drift         (warnings — exit 0)
+#   2. Required tools         (warnings — exit 0)
+#   3. Stale backups          (warnings — exit 0)
+#   4. SSH key                (warnings — exit 0)
+#   5. git-lfs global init    (warnings — exit 0)
+#   6. mise tools installed   (warnings — exit 0)
+#   7. dotfiles git health    (warnings — exit 0)
+#   8. Brewfile drift         (warnings — exit 0)
 #
 # Usage:   bash ~/dotfiles/verify.sh
 # Called by update.sh automatically after each update cycle.
@@ -24,7 +23,7 @@ WARNINGS=0
 # shellcheck disable=SC2034  # used by step() in helpers
 STEP=0
 # shellcheck disable=SC2034
-TOTAL_STEPS=9
+TOTAL_STEPS=8
 
 # shellcheck source=scripts/lib/bootstrap_helpers.sh
 source "$DOTFILES_DIR/scripts/lib/bootstrap_helpers.sh"
@@ -63,21 +62,7 @@ else
   ERRORS=$(( ERRORS + SYMLINK_BROKEN_COUNT ))
 fi
 
-# ── 2. Version drift ──────────────────────────────────────────────────────────
-step "📌  Version drift (mise.toml vs bootstrap.sh)"
-check_mise_version_drift "$DOTFILES_DIR/config/mise.toml" "$DOTFILES_DIR/bootstrap.sh"
-
-if [[ "$DRIFT_COUNT" -eq 0 ]]; then
-  success "mise.toml and bootstrap.sh agree on all runtime versions"
-else
-  for drift in "${DRIFT_LIST[@]}"; do
-    warn "$drift"
-  done
-  warn "$DRIFT_COUNT version(s) out of sync — update mise.toml or bootstrap.sh"
-  WARNINGS=$(( WARNINGS + DRIFT_COUNT ))
-fi
-
-# ── 3. Required tools ─────────────────────────────────────────────────────────
+# ── 2. Required tools ─────────────────────────────────────────────────────────
 step "🧰  Required tools"
 check_required_tools "${REQUIRED_TOOLS[@]}"
 
@@ -91,7 +76,7 @@ else
   WARNINGS=$(( WARNINGS + TOOLS_MISSING_COUNT ))
 fi
 
-# ── 4. Stale backups ──────────────────────────────────────────────────────────
+# ── 3. Stale backups ──────────────────────────────────────────────────────────
 step "🗂️   Stale backups"
 check_stale_backups "$HOME/.dotfiles_backup"
 
@@ -105,7 +90,7 @@ else
   WARNINGS=$(( WARNINGS + STALE_BACKUP_COUNT ))
 fi
 
-# ── 5. SSH key ─────────────────────────────────────────────────────────
+# ── 4. SSH key ─────────────────────────────────────────────────────────
 step "🔑  SSH key"
 check_ssh_key
 
@@ -116,7 +101,7 @@ else
   WARNINGS=$(( WARNINGS + 1 ))
 fi
 
-# ── 6. git-lfs ──────────────────────────────────────────────────────
+# ── 5. git-lfs ──────────────────────────────────────────────────────
 step "📁  git-lfs"
 check_git_lfs_global
 
@@ -127,7 +112,7 @@ else
   WARNINGS=$(( WARNINGS + 1 ))
 fi
 
-# ── 7. mise tools installed ──────────────────────────────────────────────
+# ── 6. mise tools installed ──────────────────────────────────────────────
 step "⚡  mise tools installed"
 check_mise_installed "$DOTFILES_DIR/config/mise.toml"
 
@@ -141,7 +126,7 @@ else
   WARNINGS=$(( WARNINGS + MISE_UNINSTALLED_COUNT ))
 fi
 
-# ── 8. Dotfiles git health ───────────────────────────────────────────────
+# ── 7. Dotfiles git health ───────────────────────────────────────────────
 step "🩺  Dotfiles git health"
 check_dotfiles_git_health "$DOTFILES_DIR"
 
@@ -154,7 +139,7 @@ else
   WARNINGS=$(( WARNINGS + ${#DOTFILES_GIT_HEALTH_ISSUES[@]} ))
 fi
 
-# ── 9. Brewfile drift ────────────────────────────────────────────────────
+# ── 8. Brewfile drift ────────────────────────────────────────────────────
 step "🍺  Brewfile drift"
 check_brewfile_drift "$DOTFILES_DIR/Brewfile"
 


### PR DESCRIPTION
## Summary
Runtime versions (Ruby, Node, Java, Python, Go) are now read from `config/mise.toml` everywhere instead of being duplicated across shell scripts. This eliminates version drift between the mise config and the install/verify logic.

## What changed
- **`scripts/lib/bootstrap_helpers.sh`** — add `parse_mise_runtimes()`, a pure-Bash parser (portable to macOS Bash 3.2) that emits `tool@version` for each entry in the `[tools]` table.
- **`bootstrap.sh`** / **`scripts/lib/dryrun_helpers.sh`** — install and dry-run-preview the runtimes parsed from `config/mise.toml` rather than a hardcoded list.
- **`verify.sh`** / **`scripts/lib/verify_helpers.sh`** — remove the now-obsolete `mise.toml`-vs-`bootstrap.sh` drift check (with SSOT there is no second source to drift against; it had begun emitting false-positive warnings), and make `check_mise_installed` derive its tool list from `config/mise.toml`. Verify drops from 9 to 8 checks.
- **Tests** — add `parse_mise_runtimes` unit tests; remove the drift-check tests (preserving the shared `TOML_MATCH` fixture).
- **Docs** — sync `CONTRIBUTING.md` and `README.md` to the new check set.

## Validation
- Unit tests: bootstrap 17/17, verify 29/29, dryrun 26/26, templates 8/8.
- `shellcheck -S warning`: clean on all touched scripts.
- `bash -n`: clean.
- `bash verify.sh`: runs 8 steps with no drift step and no spurious drift warnings.

## Artifacts
- Plan: https://app.warp.dev/drive/notebook/SijKIwknyFwUa5G7qume8Y
- Conversation: https://app.warp.dev/conversation/94f35ae1-447f-4850-a05e-d6957c64aafb

Co-Authored-By: Oz <oz-agent@warp.dev>
