### PR TITLE
Symlink-map SSOT, update.sh helper tests, and doc fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,37 +92,17 @@ jobs:
           echo ""
           echo "--- Verifying symlinks ---"
 
-          # Home-level dotfiles
-          for link in \
-            .zshrc .zprofile \
-            .gitconfig .gitignore_global \
-            .tmux.conf .hyper.js \
-            .gemrc .psqlrc .editorconfig \
-            .irbrc .pryrc .npmrc; do
-            if [[ -L "$HOME/$link" ]]; then
-              echo "OK  $link"
+          # Verify every destination in the manifest is a symlink. The manifest
+          # (config/symlinks.map) is the single source of truth install.sh links
+          # from, so this list can never drift from what install.sh creates.
+          while read -r src dest; do
+            [[ -z "$src" || "$src" == \#* ]] && continue
+            if [[ -L "$HOME/$dest" ]]; then
+              echo "OK  $dest"
             else
-              echo "MISSING  $link" && exit 1
+              echo "MISSING  $dest" && exit 1
             fi
-          done
-
-          # XDG config files
-          for cfg in \
-            .config/starship.toml \
-            .config/mise/config.toml; do
-            if [[ -L "$HOME/$cfg" ]]; then
-              echo "OK  $cfg"
-            else
-              echo "MISSING  $cfg" && exit 1
-            fi
-          done
-
-          # SSH config
-          if [[ -L "$HOME/.ssh/config" ]]; then
-            echo "OK  .ssh/config"
-          else
-            echo "MISSING  .ssh/config" && exit 1
-          fi
+          done < config/symlinks.map
 
           echo ""
           echo "All symlinks verified."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ bootstrap.sh ──▶ install.sh ──▶ update.sh ──▶ verify.sh
 ## Helpers
 
 - **`scripts/lib/bootstrap_helpers.sh`** — sourced by `bootstrap.sh`, `update.sh`, and `verify.sh`. Side-effect-free output helpers (`setup_colors`, `step`, `info`, `success`, `warn`; call `setup_colors` once after sourcing) plus `parse_mise_runtimes`, which reads the `[tools]` table of `config/mise.toml` — the single source of truth for runtime versions.
-- **`scripts/lib/verify_helpers.sh`** — sourced by `verify.sh`. Pure check functions (`check_symlinks`, `check_required_tools`, `check_ssh_key`, `check_git_lfs_global`, `check_mise_installed`, `check_stale_backups`, `check_dotfiles_git_health`, `check_brewfile_drift`). Each sets result globals (e.g. `SYMLINK_BROKEN_COUNT`, `SYMLINK_BROKEN_LIST`) rather than printing or exiting, which makes them unit-testable. The canonical symlink map lives here as the `DOTFILES_SYMLINKS` array.
+- **`scripts/lib/verify_helpers.sh`** — sourced by `verify.sh`. Pure check functions (`check_symlinks`, `check_required_tools`, `check_ssh_key`, `check_git_lfs_global`, `check_mise_installed`, `check_stale_backups`, `check_dotfiles_git_health`, `check_brewfile_drift`). Each sets result globals (e.g. `SYMLINK_BROKEN_COUNT`, `SYMLINK_BROKEN_LIST`) rather than printing or exiting, which makes them unit-testable. `load_symlink_map` populates the `DOTFILES_SYMLINKS` array from `config/symlinks.map`, the canonical symlink manifest (see below).
 - **`scripts/lib/dryrun_helpers.sh`** — sourced by `bootstrap.sh` only when `--dry-run` is set. Provides `dry_run_step`, per-step `check_*` previews (including `check_corepack`) that record intended actions via `dry_run_log`, and `show_dry_run_summary`.
 - **`scripts/preflight.sh`** — standalone (defines its own colors and `error`/`warn`/`success`/`info`). Validates the system before bootstrap.
 
@@ -62,20 +62,19 @@ Because the helpers are side-effect-free, tests exercise them directly against t
 ## CI
 
 - **`.github/workflows/ci.yml`** — three jobs: `shellcheck` (bash scripts, `-S warning`), `zsh-syntax` (`zsh -n` on the zsh files plus a `Brewfile` parse check), and `install-smoke` (runs `zsh install.sh` against a throwaway `$HOME` and asserts every expected symlink exists).
-- **`.github/workflows/test-bootstrap.yml`** — runs the `scripts/tests/test_*.sh` unit tests (currently `test_bootstrap_helpers.sh`, `test_dryrun_helpers.sh`, `test_verify_helpers.sh`, and `test_validate_templates.sh`) plus `bash -n` syntax checks when the relevant scripts change.
+- **`.github/workflows/test-bootstrap.yml`** — runs the `scripts/tests/test_*.sh` unit tests (currently `test_bootstrap_helpers.sh`, `test_dryrun_helpers.sh`, `test_verify_helpers.sh`, `test_update_helpers.sh`, and `test_validate_templates.sh`) plus `bash -n` syntax checks when the relevant scripts change.
 
 ## Common tasks
 
 ### Add a managed dotfile
 
-A tracked dotfile is represented in several independent lists. Update all of them so install, verify, dry-run, CI, and the docs stay in agreement:
+The dotfile→destination mapping is a single source of truth in `config/symlinks.map`; `install.sh`, `verify.sh`, `bootstrap.sh --dry-run`, and the CI install-smoke job all read it. To track a new dotfile:
 
 1. Add the file to the repo (`home/`, or `config/` for XDG configs).
-2. **`install.sh`** — add a `symlink "$DOTFILES_DIR/home/<src>" "$HOME/<dest>"` line.
-3. **`scripts/lib/verify_helpers.sh`** — add `"home/<src>:<dest>"` to the `DOTFILES_SYMLINKS` array so `verify.sh` checks it.
-4. **`scripts/lib/dryrun_helpers.sh`** — add the same pair to the list in `check_dotfile_symlinks` so `--dry-run` previews it.
-5. **`README.md`** — add a row to the Dotfiles table.
-6. **`.github/workflows/ci.yml`** — add the destination to the install-smoke symlink list so the smoke test verifies it.
+2. **`config/symlinks.map`** — add one `src  dest` line (src relative to the repo root, dest relative to `$HOME`). Every consumer picks it up automatically — no other script or workflow needs editing.
+3. **`README.md`** — add a row to the Dotfiles table (human-readable reference).
+
+Non-symlink setup (the `~/.config/git/local.gitconfig` seed, the global pre-commit hook, and VS Code settings/extensions) is intentionally bespoke in `install.sh` and is deliberately not part of the manifest.
 
 ### Add a configuration template
 

--- a/config/symlinks.map
+++ b/config/symlinks.map
@@ -1,0 +1,34 @@
+# symlinks.map — single source of truth for tracked dotfile symlinks.
+#
+# One record per line:  <src>  <dest>
+#   src   path relative to the dotfiles repo root (DOTFILES_DIR)
+#   dest  path relative to $HOME
+# Columns are whitespace-separated; blank lines and # comments are ignored.
+#
+# Consumed by install.sh (creates the links), verify.sh (checks them),
+# bootstrap.sh --dry-run (previews them), and the CI install-smoke job.
+# Add a tracked dotfile by adding one line here — every consumer picks it up.
+#
+# Non-symlink setup (local.gitconfig seed, global pre-commit hook, VS Code
+# settings/extensions) stays bespoke in install.sh and is intentionally not
+# listed here.
+
+# Home-directory dotfiles
+home/zshrc             .zshrc
+home/zprofile          .zprofile
+home/gitconfig         .gitconfig
+home/tmux.conf         .tmux.conf
+home/hyper.js          .hyper.js
+home/gitignore_global  .gitignore_global
+home/gemrc             .gemrc
+home/irbrc             .irbrc
+home/pryrc             .pryrc
+home/psqlrc            .psqlrc
+home/npmrc             .npmrc
+home/editorconfig      .editorconfig
+home/ssh_config        .ssh/config
+
+# XDG configs under ~/.config
+config/starship.toml   .config/starship.toml
+config/direnvrc        .config/direnv/direnvrc
+config/mise.toml       .config/mise/config.toml

--- a/install.sh
+++ b/install.sh
@@ -41,31 +41,23 @@ echo ""
 print -P "%F{cyan}  🔗  dotfiles%f  ─  symlinking from ${DOTFILES_DIR/$HOME/\~}"
 echo "  ─────────────────────────────────────────────────"
 
-# Home directory symlinks
-symlink "$DOTFILES_DIR/home/zshrc"    "$HOME/.zshrc"
-symlink "$DOTFILES_DIR/home/zprofile" "$HOME/.zprofile"
-symlink "$DOTFILES_DIR/home/gitconfig" "$HOME/.gitconfig"
-symlink "$DOTFILES_DIR/home/tmux.conf" "$HOME/.tmux.conf"
-symlink "$DOTFILES_DIR/home/hyper.js"  "$HOME/.hyper.js"
+# Tracked dotfile symlinks — single source of truth: config/symlinks.map
+# (install.sh creates them; verify.sh, bootstrap --dry-run, and CI read the
+# same file, so the mapping lives in exactly one place.)
+SYMLINK_MAP="$DOTFILES_DIR/config/symlinks.map"
+if [[ -r "$SYMLINK_MAP" ]]; then
+  while read -r src_rel dest_rel; do
+    [[ -z "$src_rel" || "$src_rel" == \#* ]] && continue
+    dest="$HOME/$dest_rel"
+    mkdir -p "$(dirname "$dest")"
+    symlink "$DOTFILES_DIR/$src_rel" "$dest"
+  done < "$SYMLINK_MAP"
+else
+  backup "symlink manifest not found: $SYMLINK_MAP"
+fi
 
-# Git global ignore
-symlink "$DOTFILES_DIR/home/gitignore_global" "$HOME/.gitignore_global"
-
-# Ruby — skip docs on every gem install
-symlink "$DOTFILES_DIR/home/gemrc" "$HOME/.gemrc"
-
-# Ruby REPL defaults (IRB + Pry)
-symlink "$DOTFILES_DIR/home/irbrc" "$HOME/.irbrc"
-symlink "$DOTFILES_DIR/home/pryrc" "$HOME/.pryrc"
-
-# PostgreSQL client defaults (pairs with Postgres.app)
-symlink "$DOTFILES_DIR/home/psqlrc" "$HOME/.psqlrc"
-
-# npm client defaults (save-exact, no fund noise)
-symlink "$DOTFILES_DIR/home/npmrc" "$HOME/.npmrc"
-
-# EditorConfig global fallback (project-level .editorconfig overrides this)
-symlink "$DOTFILES_DIR/home/editorconfig" "$HOME/.editorconfig"
+# Harden ~/.ssh perms (the directory is created above when linking ssh_config)
+[[ -d "$HOME/.ssh" ]] && chmod 700 "$HOME/.ssh"
 
 # Local git config (signing key, work email overrides — not committed)
 mkdir -p "$HOME/.config/git"
@@ -91,23 +83,6 @@ EOF
 else
   success "Already exists: global pre-commit hook"
 fi
-
-# ~/.config symlinks
-mkdir -p "$HOME/.config"
-symlink "$DOTFILES_DIR/config/starship.toml" "$HOME/.config/starship.toml"
-
-# direnv global helpers (layout_python, layout_node)
-mkdir -p "$HOME/.config/direnv"
-symlink "$DOTFILES_DIR/config/direnvrc" "$HOME/.config/direnv/direnvrc"
-
-# mise global config (pinned Ruby + Node versions)
-mkdir -p "$HOME/.config/mise"
-symlink "$DOTFILES_DIR/config/mise.toml" "$HOME/.config/mise/config.toml"
-
-# SSH config
-mkdir -p "$HOME/.ssh"
-chmod 700 "$HOME/.ssh"
-symlink "$DOTFILES_DIR/home/ssh_config" "$HOME/.ssh/config"
 
 # VS Code settings
 VSCODE_DIR="$HOME/Library/Application Support/Code/User"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,7 @@ Automation scripts for system setup, configuration, and maintenance.
 ## Layout
 
 - **`scripts/`** — runnable scripts (work setup, installers, `macos.sh`, `uninstall.sh`, `validate_templates.sh`, …).
-- **`scripts/lib/`** — sourced helper libraries (no side effects): `bootstrap_helpers.sh`, `verify_helpers.sh`, `dryrun_helpers.sh`.
+- **`scripts/lib/`** — sourced helper libraries (no side effects): `bootstrap_helpers.sh`, `verify_helpers.sh`, `dryrun_helpers.sh`, `update_helpers.sh`.
 - **`scripts/tests/`** — hand-rolled unit tests (`test_*.sh`) for the helpers and validators.
 
 ---
@@ -14,12 +14,12 @@ Automation scripts for system setup, configuration, and maintenance.
 
 ### `lib/bootstrap_helpers.sh`
 
-Shell functions used by `bootstrap.sh` and other scripts:
+Shell functions sourced by `bootstrap.sh`, `update.sh`, and `verify.sh`:
 
+- **`setup_colors()`** — Initialize color codes (call once after sourcing)
 - **`step()`** — Display numbered progress steps
-- **`info()`**, **`success()`**, **`warn()`**, **`error()`** — Colored output
-- **`setup_colors()`** — Initialize color codes
-- **`check_internet()`** — Verify network connectivity
+- **`info()`**, **`success()`**, **`warn()`** — Colored output
+- **`parse_mise_runtimes()`** — Read the `[tools]` table of `config/mise.toml`, the single source of truth for runtime versions
 
 **Usage:**
 ```bash
@@ -195,15 +195,17 @@ code --list-extensions
 
 ## Tests (`tests/`)
 
+Hand-rolled unit tests (no framework), auto-discovered and run by `.github/workflows/test-bootstrap.yml`: `test_bootstrap_helpers.sh`, `test_verify_helpers.sh`, `test_dryrun_helpers.sh`, `test_update_helpers.sh`, and `test_validate_templates.sh`. Run one directly with `bash scripts/tests/<file>`.
+
 ### `tests/test_bootstrap_helpers.sh`
 
 **Unit tests for bootstrap helper functions**
 
 Tests the shell functions in `lib/bootstrap_helpers.sh`:
-- Color code initialization
-- Output functions (info, success, warn, error)
-- Step counter
-- Helper utilities
+- Color code initialization (`setup_colors`)
+- Output functions (`info`, `success`, `warn`)
+- Step counter (`step`)
+- mise runtime parsing (`parse_mise_runtimes`)
 
 **Usage:**
 ```bash
@@ -221,19 +223,21 @@ bash ~/dotfiles/scripts/tests/test_bootstrap_helpers.sh
 
 ### `lib/verify_helpers.sh`
 
-**Helper functions for verify.sh**
+**Pure check functions for verify.sh**
 
-Utility functions used by the verification script:
-- Check if command exists
-- Verify file symlinks
-- Check version strings
-- Report findings
+Each sets result globals (counts + lists) instead of printing or exiting, which makes them unit-testable:
+- **`check_symlinks`** / **`load_symlink_map`** — validate tracked symlinks loaded from `config/symlinks.map`
+- **`check_required_tools`** — report tools missing from `PATH`
+- **`check_ssh_key`** / **`check_git_lfs_global`** — signing key + global git-lfs init
+- **`check_mise_installed`** — runtimes declared in `config/mise.toml` are actually installed
+- **`check_stale_backups`** / **`check_dotfiles_git_health`** / **`check_brewfile_drift`**
 
 **Usage:**
 ```bash
 source "$(dirname "$0")/scripts/lib/verify_helpers.sh"
-check_command git
-verify_symlink ~/.zshrc
+load_symlink_map "$DOTFILES_DIR/config/symlinks.map"
+check_symlinks "$DOTFILES_DIR" "$HOME"
+echo "$SYMLINK_BROKEN_COUNT broken"
 ```
 
 ---
@@ -389,4 +393,4 @@ source ~/dotfiles/scripts/my_script.sh
 
 ---
 
-*Last updated: June 1, 2026*
+*Last updated: June 14, 2026*

--- a/scripts/lib/dryrun_helpers.sh
+++ b/scripts/lib/dryrun_helpers.sh
@@ -215,30 +215,24 @@ check_git_lfs() {
 check_dotfile_symlinks() {
   dry_run_log "Run: install.sh (symlink dotfiles)"
 
-  local -a files=(
-    "$HOME/.zshrc:zshrc"
-    "$HOME/.zprofile:zprofile"
-    "$HOME/.gitconfig:gitconfig"
-    "$HOME/.tmux.conf:tmux.conf"
-    "$HOME/.hyper.js:hyper.js"
-    "$HOME/.gitignore_global:gitignore_global"
-    "$HOME/.gemrc:gemrc"
-    "$HOME/.irbrc:irbrc"
-    "$HOME/.pryrc:pryrc"
-    "$HOME/.psqlrc:psqlrc"
-    "$HOME/.npmrc:npmrc"
-    "$HOME/.editorconfig:editorconfig"
-    "$HOME/.config/starship.toml:config/starship.toml"
-    "$HOME/.config/direnv/direnvrc:config/direnvrc"
-    "$HOME/.config/mise/config.toml:config/mise.toml"
-    "$HOME/.ssh/config:ssh_config"
-  )
+  # Read tracked symlinks from config/symlinks.map (single source of truth) as
+  # "dest_abs:src_rel" entries so the comparison loop below is unchanged. Using
+  # the same manifest install.sh and verify.sh read means this preview can never
+  # drift from what is actually linked.
+  local -a files=()
+  local manifest="$DOTFILES_DIR/config/symlinks.map" _src _dest
+  if [[ -r "$manifest" ]]; then
+    while read -r _src _dest; do
+      [[ -z "$_src" || "$_src" == \#* ]] && continue
+      files+=("$HOME/$_dest:$_src")
+    done < "$manifest"
+  fi
 
   local to_link=0
   local already_linked=0
   local to_backup=0
 
-  for entry in "${files[@]}"; do
+  for entry in ${files[@]+"${files[@]}"}; do
     local dest="${entry%%:*}"
     local src_rel="${entry##*:}"
     local src="$DOTFILES_DIR/$src_rel"

--- a/scripts/lib/update_helpers.sh
+++ b/scripts/lib/update_helpers.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# update_helpers.sh — observability/maintenance helpers sourced by update.sh.
+#
+# Side-effect-light and unit-testable: each reads its configuration from globals
+# that update.sh defines before sourcing this file:
+#   LOG_FILE, LOG_MAX_BYTES, LOG_KEEP   (rotate_log)
+#   LOG_DIR, STATUS_FILE                (write_status)
+# No function here calls `exit` or installs traps; the run flow (mark_failure,
+# finalize, the EXIT trap) stays in update.sh.
+# shellcheck disable=SC2034  # globals are provided by the sourcing script
+
+# rotate_log — copytruncate-style rotation of logs/update.log.
+# Runs before any of this run's output is produced so the current run lands in a
+# freshly truncated file. Truncating in place (rather than mv) keeps launchd's
+# already-open file descriptor valid so it continues appending to the same inode.
+rotate_log() {
+  [[ -f "$LOG_FILE" ]] || return 0
+  [[ "$LOG_MAX_BYTES" =~ ^[0-9]+$ ]] || return 0
+  [[ "$LOG_KEEP" =~ ^[0-9]+$ ]] && (( LOG_KEEP >= 1 )) || return 0
+
+  local size
+  size=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
+  size=${size//[[:space:]]/}
+  [[ "$size" =~ ^[0-9]+$ ]] || return 0
+  (( size > LOG_MAX_BYTES )) || return 0
+
+  # Shift existing rotations: .(KEEP-1) -> .KEEP, ... , .1 -> .2 (oldest dropped)
+  local i
+  for (( i = LOG_KEEP - 1; i >= 1; i-- )); do
+    [[ -f "$LOG_FILE.$i" ]] && mv -f "$LOG_FILE.$i" "$LOG_FILE.$((i + 1))"
+  done
+  cp "$LOG_FILE" "$LOG_FILE.1" 2>/dev/null || return 0
+  : > "$LOG_FILE"
+  rm -f "$LOG_FILE.$((LOG_KEEP + 1))" 2>/dev/null || true
+}
+
+# can_notify — true only in an interactive macOS GUI (Aqua) session, never in CI
+# or headless/ssh contexts, so notifications are always safe to attempt.
+can_notify() {
+  [[ -z "${CI:-}" ]] || return 1
+  command -v osascript &>/dev/null || return 1
+  [[ "$(launchctl managername 2>/dev/null || true)" == "Aqua" ]] || return 1
+  return 0
+}
+
+notify() {
+  local title="$1" msg="$2"
+  can_notify || return 0
+  osascript -e "display notification \"$msg\" with title \"$title\"" &>/dev/null || true
+}
+
+# write_status TIMESTAMP STATUS FAILED_STEPS ELAPSED
+# Writes a key=value status file to $STATUS_FILE recording the last run, so a
+# silent failure of the daily launchd job is observable after the fact.
+write_status() {
+  local ts="$1" run_status="$2" failed="$3" elapsed="$4"
+  mkdir -p "$LOG_DIR" 2>/dev/null || true
+  {
+    echo "last_run=$ts"
+    echo "status=$run_status"
+    echo "failed_steps=$failed"
+    echo "duration_seconds=$elapsed"
+  } > "$STATUS_FILE" 2>/dev/null || true
+}

--- a/scripts/lib/verify_helpers.sh
+++ b/scripts/lib/verify_helpers.sh
@@ -3,26 +3,27 @@
 # No side effects, no interactive prompts, no exits.
 # shellcheck disable=SC2034  # variables are used by callers that source this file
 
-# ── Symlink map ───────────────────────────────────────────────────────────────
-# Each entry is "src_relative_to_DOTFILES_DIR:dest_relative_to_HOME"
-DOTFILES_SYMLINKS=(
-  "home/zshrc:.zshrc"
-  "home/zprofile:.zprofile"
-  "home/gitconfig:.gitconfig"
-  "home/tmux.conf:.tmux.conf"
-  "home/hyper.js:.hyper.js"
-  "home/gitignore_global:.gitignore_global"
-  "home/gemrc:.gemrc"
-  "home/irbrc:.irbrc"
-  "home/pryrc:.pryrc"
-  "home/psqlrc:.psqlrc"
-  "home/npmrc:.npmrc"
-  "home/editorconfig:.editorconfig"
-  "config/starship.toml:.config/starship.toml"
-  "config/direnvrc:.config/direnv/direnvrc"
-  "config/mise.toml:.config/mise/config.toml"
-  "home/ssh_config:.ssh/config"
-)
+# ── Symlink map ───────────────────────────────────────────────────────────
+# The canonical dotfile→destination mapping lives in config/symlinks.map (the
+# single source of truth shared with install.sh, bootstrap --dry-run, and CI).
+# load_symlink_map reads it into DOTFILES_SYMLINKS as
+# "src_relative_to_DOTFILES_DIR:dest_relative_to_HOME" entries — the form
+# check_symlinks consumes. Defaults to empty so the array is always set.
+DOTFILES_SYMLINKS=()
+
+# load_symlink_map MANIFEST
+# Populates DOTFILES_SYMLINKS from a symlinks.map manifest of "src dest" records
+# (whitespace-separated; blank lines and # comments ignored). A missing manifest
+# leaves the array empty.
+load_symlink_map() {
+  local manifest="$1" src dest
+  DOTFILES_SYMLINKS=()
+  [[ -f "$manifest" ]] || return 0
+  while read -r src dest; do
+    [[ -z "$src" || "$src" == \#* ]] && continue
+    DOTFILES_SYMLINKS+=("$src:$dest")
+  done < "$manifest"
+}
 
 # check_symlinks DOTFILES_DIR HOME_DIR
 # Validates every entry in DOTFILES_SYMLINKS: source must exist in DOTFILES_DIR

--- a/scripts/tests/test_dryrun_helpers.sh
+++ b/scripts/tests/test_dryrun_helpers.sh
@@ -45,25 +45,35 @@ source "$SCRIPT_DIR/../lib/dryrun_helpers.sh"
 FAKE_DOTFILES="$TMPDIR_BASE/dotfiles"
 mkdir -p "$FAKE_DOTFILES/config/git"
 
-# The destination/source pairs check_dotfile_symlinks iterates over (16 entries).
-DOTFILE_PAIRS=(
-  ".zshrc:zshrc"
-  ".zprofile:zprofile"
-  ".gitconfig:gitconfig"
-  ".tmux.conf:tmux.conf"
-  ".hyper.js:hyper.js"
-  ".gitignore_global:gitignore_global"
-  ".gemrc:gemrc"
-  ".irbrc:irbrc"
-  ".pryrc:pryrc"
-  ".psqlrc:psqlrc"
-  ".npmrc:npmrc"
-  ".editorconfig:editorconfig"
-  ".config/starship.toml:config/starship.toml"
-  ".config/direnv/direnvrc:config/direnvrc"
-  ".config/mise/config.toml:config/mise.toml"
-  ".ssh/config:ssh_config"
-)
+# Fixture manifest — the single source of truth check_dotfile_symlinks reads
+# (mirrors the real config/symlinks.map; src paths keep their home/ or config/
+# prefix). The src files need not exist: only the readlink target is compared.
+cat > "$FAKE_DOTFILES/config/symlinks.map" << 'EOF'
+home/zshrc               .zshrc
+home/zprofile            .zprofile
+home/gitconfig           .gitconfig
+home/tmux.conf           .tmux.conf
+home/hyper.js            .hyper.js
+home/gitignore_global    .gitignore_global
+home/gemrc               .gemrc
+home/irbrc               .irbrc
+home/pryrc               .pryrc
+home/psqlrc              .psqlrc
+home/npmrc               .npmrc
+home/editorconfig        .editorconfig
+home/ssh_config          .ssh/config
+config/starship.toml     .config/starship.toml
+config/direnvrc          .config/direnv/direnvrc
+config/mise.toml         .config/mise/config.toml
+EOF
+
+# Destination/source pairs derived from the manifest (dest:src, 16 entries),
+# used to materialize symlinks in the "all linked" case below.
+DOTFILE_PAIRS=()
+while read -r _s _d; do
+  [[ -z "$_s" || "$_s" == \#* ]] && continue
+  DOTFILE_PAIRS+=("$_d:$_s")
+done < "$FAKE_DOTFILES/config/symlinks.map"
 
 # ── dry_run_log ───────────────────────────────────────────────────────────────
 echo ""

--- a/scripts/tests/test_update_helpers.sh
+++ b/scripts/tests/test_update_helpers.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# test_update_helpers.sh — unit tests for update_helpers.sh
+# Usage: bash scripts/tests/test_update_helpers.sh
+# shellcheck disable=SC1091,SC2030,SC2031,SC2034  # dynamic source; intentional subshell scoping; vars used by sourced fns
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+  TESTS_PASSED=$(( TESTS_PASSED + 1 ))
+  TESTS_RUN=$(( TESTS_RUN + 1 ))
+  printf "  PASS  %s\n" "$1"
+}
+
+fail() {
+  TESTS_FAILED=$(( TESTS_FAILED + 1 ))
+  TESTS_RUN=$(( TESTS_RUN + 1 ))
+  printf "  FAIL  %s — %s\n" "$1" "$2"
+}
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+source "$SCRIPT_DIR/../lib/update_helpers.sh"
+
+# ── rotate_log ────────────────────────────────────────────────────────────────
+echo ""
+echo "=== rotate_log ==="
+
+# Case 1: file under the size threshold → no rotation, file left untouched
+if (
+  LOG_FILE="$TMPDIR_BASE/under.log"
+  LOG_MAX_BYTES=1048576
+  LOG_KEEP=5
+  printf 'small\n' > "$LOG_FILE"
+  rotate_log
+  [[ -f "$LOG_FILE" ]]              || { printf "  FAIL  log removed\n"; exit 1; }
+  [[ "$(cat "$LOG_FILE")" == "small" ]] || { printf "  FAIL  content changed\n"; exit 1; }
+  [[ ! -e "$LOG_FILE.1" ]]         || { printf "  FAIL  .1 should not exist\n"; exit 1; }
+); then
+  pass "rotate_log: under threshold → no rotation"
+else
+  fail "rotate_log: under threshold" "subshell exited non-zero"
+fi
+
+# Case 2: file over threshold → truncated in place, old content copied to .1
+if (
+  LOG_FILE="$TMPDIR_BASE/over.log"
+  LOG_MAX_BYTES=10
+  LOG_KEEP=5
+  printf 'this content exceeds ten bytes\n' > "$LOG_FILE"
+  rotate_log
+  [[ -f "$LOG_FILE" ]]   || { printf "  FAIL  log missing after rotate\n"; exit 1; }
+  [[ ! -s "$LOG_FILE" ]] || { printf "  FAIL  log should be truncated empty\n"; exit 1; }
+  [[ -f "$LOG_FILE.1" ]] || { printf "  FAIL  .1 not created\n"; exit 1; }
+  grep -q "exceeds ten bytes" "$LOG_FILE.1" || { printf "  FAIL  .1 missing old content\n"; exit 1; }
+); then
+  pass "rotate_log: over threshold → truncate in place + copy to .1"
+else
+  fail "rotate_log: over threshold" "subshell exited non-zero"
+fi
+
+# Case 3: existing rotations shift (.1 → .2) and LOG_KEEP caps the oldest
+if (
+  LOG_FILE="$TMPDIR_BASE/shift.log"
+  LOG_MAX_BYTES=10
+  LOG_KEEP=2
+  printf 'NEW oversized current content\n' > "$LOG_FILE"
+  printf 'OLD1\n' > "$LOG_FILE.1"
+  rotate_log
+  grep -q "NEW"  "$LOG_FILE.1" || { printf "  FAIL  current not copied to .1\n"; exit 1; }
+  grep -q "OLD1" "$LOG_FILE.2" || { printf "  FAIL  .1 not shifted to .2\n"; exit 1; }
+  [[ ! -e "$LOG_FILE.3" ]]     || { printf "  FAIL  .3 should not exist (KEEP=2)\n"; exit 1; }
+); then
+  pass "rotate_log: shifts .1→.2 and respects LOG_KEEP"
+else
+  fail "rotate_log: shift + keep-count" "subshell exited non-zero"
+fi
+
+# Case 4: missing log file → no-op, returns success
+if (
+  LOG_FILE="$TMPDIR_BASE/nonexistent.log"
+  LOG_MAX_BYTES=10
+  LOG_KEEP=5
+  rotate_log
+  [[ ! -e "$LOG_FILE.1" ]] || { printf "  FAIL  .1 created for missing log\n"; exit 1; }
+); then
+  pass "rotate_log: missing log file → no-op"
+else
+  fail "rotate_log: missing log file" "subshell exited non-zero"
+fi
+
+# ── write_status ──────────────────────────────────────────────────────────────
+echo ""
+echo "=== write_status ==="
+
+# Case 1: success run → status file has all four keys
+if (
+  LOG_DIR="$TMPDIR_BASE/logs_ok"
+  STATUS_FILE="$LOG_DIR/update.status"
+  write_status "2026-06-14T00:00:00Z" "success" "" "42"
+  [[ -f "$STATUS_FILE" ]] || { printf "  FAIL  status file not written\n"; exit 1; }
+  grep -q "^last_run=2026-06-14T00:00:00Z$" "$STATUS_FILE" || { printf "  FAIL  last_run missing\n"; exit 1; }
+  grep -q "^status=success$"                "$STATUS_FILE" || { printf "  FAIL  status missing\n"; exit 1; }
+  grep -q "^failed_steps=$"                 "$STATUS_FILE" || { printf "  FAIL  failed_steps missing\n"; exit 1; }
+  grep -q "^duration_seconds=42$"           "$STATUS_FILE" || { printf "  FAIL  duration missing\n"; exit 1; }
+); then
+  pass "write_status: success → file contains all four keys"
+else
+  fail "write_status: success" "subshell exited non-zero"
+fi
+
+# Case 2: failure run → records the failed-step list
+if (
+  LOG_DIR="$TMPDIR_BASE/logs_fail"
+  STATUS_FILE="$LOG_DIR/update.status"
+  write_status "2026-06-14T00:00:00Z" "failure" "Homebrew, Rust" "100"
+  grep -q "^status=failure$"               "$STATUS_FILE" || { printf "  FAIL  status not failure\n"; exit 1; }
+  grep -q "^failed_steps=Homebrew, Rust$"  "$STATUS_FILE" || { printf "  FAIL  failed_steps not recorded\n"; exit 1; }
+); then
+  pass "write_status: failure → records failed step list"
+else
+  fail "write_status: failure" "subshell exited non-zero"
+fi
+
+# ── can_notify ────────────────────────────────────────────────────────────────
+echo ""
+echo "=== can_notify ==="
+
+# Case 1: under CI → always false (never posts notifications in CI/headless)
+if (
+  export CI=1
+  if can_notify; then exit 1; else exit 0; fi
+); then
+  pass "can_notify: CI set → returns false"
+else
+  fail "can_notify: CI set" "expected false under CI"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────"
+printf "  %d tests: %d passed, %d failed\n" "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+echo "─────────────────────────────────────"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+  exit 1
+fi

--- a/scripts/tests/test_verify_helpers.sh
+++ b/scripts/tests/test_verify_helpers.sh
@@ -137,7 +137,62 @@ else
   fail "check_symlinks: empty list" "subshell exited non-zero"
 fi
 
-# ── check_required_tools ──────────────────────────────────────────────────────
+# ── load_symlink_map ─────────────────────────────────────────────────────
+echo ""
+echo "=== load_symlink_map ==="
+
+MAP_FIXTURE="$TMPDIR_BASE/symlinks.map"
+cat > "$MAP_FIXTURE" << 'EOF'
+# comment line ignored
+home/zshrc        .zshrc
+
+config/mise.toml  .config/mise/config.toml
+EOF
+
+# Case 1: parses records into src:dest entries, ignoring comments/blank lines
+if (
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  load_symlink_map "$MAP_FIXTURE"
+  [[ "${#DOTFILES_SYMLINKS[@]}" -eq 2 ]] || { printf "  FAIL  count: expected 2, got %s\n" "${#DOTFILES_SYMLINKS[@]}"; exit 1; }
+  [[ "${DOTFILES_SYMLINKS[0]}" == "home/zshrc:.zshrc" ]] || { printf "  FAIL  entry0: got %s\n" "${DOTFILES_SYMLINKS[0]}"; exit 1; }
+  [[ "${DOTFILES_SYMLINKS[1]}" == "config/mise.toml:.config/mise/config.toml" ]] || { printf "  FAIL  entry1: got %s\n" "${DOTFILES_SYMLINKS[1]}"; exit 1; }
+); then
+  pass "load_symlink_map: parses manifest into src:dest, ignores comments/blanks"
+else
+  fail "load_symlink_map: parse" "subshell exited non-zero"
+fi
+
+# Case 2: a missing manifest leaves DOTFILES_SYMLINKS empty
+if (
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  load_symlink_map "$TMPDIR_BASE/does_not_exist.map"
+  [[ "${#DOTFILES_SYMLINKS[@]}" -eq 0 ]] || { printf "  FAIL  expected empty, got %s\n" "${#DOTFILES_SYMLINKS[@]}"; exit 1; }
+); then
+  pass "load_symlink_map: missing manifest → empty array"
+else
+  fail "load_symlink_map: missing manifest" "subshell exited non-zero"
+fi
+
+# Case 3: check_symlinks consumes a manifest-loaded map end-to-end
+MAP_DOTFILES="$TMPDIR_BASE/map_dotfiles"
+MAP_HOME="$TMPDIR_BASE/map_home"
+mkdir -p "$MAP_DOTFILES/home" "$MAP_HOME"
+touch "$MAP_DOTFILES/home/zshrc"
+printf 'home/zshrc  .zshrc\n' > "$MAP_DOTFILES/symlinks.map"
+ln -sf "$MAP_DOTFILES/home/zshrc" "$MAP_HOME/.zshrc"
+if (
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  load_symlink_map "$MAP_DOTFILES/symlinks.map"
+  check_symlinks "$MAP_DOTFILES" "$MAP_HOME"
+  [[ "$SYMLINK_OK_COUNT" -eq 1 ]] || { printf "  FAIL  ok: expected 1, got %s\n" "$SYMLINK_OK_COUNT"; exit 1; }
+  [[ "$SYMLINK_BROKEN_COUNT" -eq 0 ]] || { printf "  FAIL  broken: expected 0, got %s\n" "$SYMLINK_BROKEN_COUNT"; exit 1; }
+); then
+  pass "load_symlink_map + check_symlinks: manifest-driven check passes end-to-end"
+else
+  fail "load_symlink_map + check_symlinks end-to-end" "subshell exited non-zero"
+fi
+
+# ── check_required_tools ────────────────────────────────────────────────────────
 echo ""
 echo "=== check_required_tools ==="
 

--- a/update.sh
+++ b/update.sh
@@ -44,9 +44,13 @@ STEP=0
 TOTAL_STEPS=7
 
 LOG_DIR="$DOTFILES_DIR/logs"
+# shellcheck disable=SC2034  # used by update_helpers.sh (sourced below)
 LOG_FILE="$LOG_DIR/update.log"
+# shellcheck disable=SC2034  # used by update_helpers.sh (sourced below)
 STATUS_FILE="$LOG_DIR/update.status"
+# shellcheck disable=SC2034  # used by update_helpers.sh (sourced below)
 LOG_MAX_BYTES="${DOTFILES_LOG_MAX_BYTES:-1048576}"  # 1 MiB
+# shellcheck disable=SC2034  # used by update_helpers.sh (sourced below)
 LOG_KEEP="${DOTFILES_LOG_KEEP:-5}"
 
 # Steps whose work failed during this run (reported in the summary + status file)

--- a/update.sh
+++ b/update.sh
@@ -54,61 +54,15 @@ FAILED_STEPS=()
 
 # shellcheck source=scripts/lib/bootstrap_helpers.sh
 source "$(dirname "$0")/scripts/lib/bootstrap_helpers.sh"
+# shellcheck source=scripts/lib/update_helpers.sh
+source "$(dirname "$0")/scripts/lib/update_helpers.sh"
 setup_colors
 
 # ── Observability helpers ─────────────────────────────────────────────────────
 mark_failure() { FAILED_STEPS+=("$1"); }
 
-# rotate_log — copytruncate-style rotation of logs/update.log.
-# Runs before any of this run's output is produced so the current run lands in a
-# freshly truncated file. Truncating in place (rather than mv) keeps launchd's
-# already-open file descriptor valid so it continues appending to the same inode.
-rotate_log() {
-  [[ -f "$LOG_FILE" ]] || return 0
-  [[ "$LOG_MAX_BYTES" =~ ^[0-9]+$ ]] || return 0
-  [[ "$LOG_KEEP" =~ ^[0-9]+$ ]] && (( LOG_KEEP >= 1 )) || return 0
-
-  local size
-  size=$(wc -c < "$LOG_FILE" 2>/dev/null || echo 0)
-  size=${size//[[:space:]]/}
-  [[ "$size" =~ ^[0-9]+$ ]] || return 0
-  (( size > LOG_MAX_BYTES )) || return 0
-
-  # Shift existing rotations: .(KEEP-1) -> .KEEP, ... , .1 -> .2 (oldest dropped)
-  local i
-  for (( i = LOG_KEEP - 1; i >= 1; i-- )); do
-    [[ -f "$LOG_FILE.$i" ]] && mv -f "$LOG_FILE.$i" "$LOG_FILE.$((i + 1))"
-  done
-  cp "$LOG_FILE" "$LOG_FILE.1" 2>/dev/null || return 0
-  : > "$LOG_FILE"
-  rm -f "$LOG_FILE.$((LOG_KEEP + 1))" 2>/dev/null || true
-}
-
-# can_notify — true only in an interactive macOS GUI (Aqua) session, never in CI
-# or headless/ssh contexts, so notifications are always safe to attempt.
-can_notify() {
-  [[ -z "${CI:-}" ]] || return 1
-  command -v osascript &>/dev/null || return 1
-  [[ "$(launchctl managername 2>/dev/null || true)" == "Aqua" ]] || return 1
-  return 0
-}
-
-notify() {
-  local title="$1" msg="$2"
-  can_notify || return 0
-  osascript -e "display notification \"$msg\" with title \"$title\"" &>/dev/null || true
-}
-
-write_status() {
-  local ts="$1" run_status="$2" failed="$3" elapsed="$4"
-  mkdir -p "$LOG_DIR" 2>/dev/null || true
-  {
-    echo "last_run=$ts"
-    echo "status=$run_status"
-    echo "failed_steps=$failed"
-    echo "duration_seconds=$elapsed"
-  } > "$STATUS_FILE" 2>/dev/null || true
-}
+# rotate_log, can_notify, notify, and write_status are defined in
+# scripts/lib/update_helpers.sh (sourced above) so they can be unit-tested.
 
 # finalize — runs on EXIT (normal or aborted). Writes the status file, prints the
 # summary banner, and notifies on failure. Always runs so failures of the daily

--- a/verify.sh
+++ b/verify.sh
@@ -48,8 +48,9 @@ printf "  ${DIM}Machine${RESET}  %s\n" "$(scutil --get ComputerName 2>/dev/null 
 printf "  ${DIM}Date${RESET}     %s\n" "$(date '+%a %b %d %Y  %H:%M')"
 echo "  ─────────────────────────────────────────────────"
 
-# ── 1. Symlinks ───────────────────────────────────────────────────────────────
+# ── 1. Symlinks ───────────────────────────────────────────────────────────
 step "🔗  Symlinks"
+load_symlink_map "$DOTFILES_DIR/config/symlinks.map"
 check_symlinks "$DOTFILES_DIR" "$HOME"
 
 if [[ "$SYMLINK_BROKEN_COUNT" -eq 0 ]]; then


### PR DESCRIPTION
## Summary
Three independent repo enhancements, landed on one branch.

### 1. Single source of truth for the symlink map
The dotfile→destination mapping was duplicated across four places that had to be hand-synced. It now lives once in `config/symlinks.map`, read by:
- `install.sh` (creates the links)
- `verify.sh` (via a new `load_symlink_map` helper in `verify_helpers.sh`)
- `bootstrap.sh --dry-run` (`check_dotfile_symlinks`)
- the CI install-smoke job

This also fixed two latent drift bugs the consolidation exposed:
- the dry-run preview compared against the wrong source path (missing the `home/` prefix), so it mis-reported already-linked files;
- the CI smoke test silently omitted `.config/direnv/direnvrc`.

Non-symlink setup (the `local.gitconfig` seed, global pre-commit hook, VS Code settings/extensions) stays bespoke in `install.sh` and is deliberately not in the manifest.

### 2. Test and harden `update.sh` maintenance helpers
Extracted `rotate_log`, `can_notify`, `notify`, and `write_status` into `scripts/lib/update_helpers.sh` and added `scripts/tests/test_update_helpers.sh`, so the daily launchd job's log rotation and status reporting are covered.

### 3. Fix stale `scripts/README.md`
Removed documented helpers that never existed (`error()`, `check_internet()`, `check_command`, `verify_symlink`), documented the real function inventory, listed all test files, and synced the test list in `CONTRIBUTING.md`.

## Validation
- `shellcheck -S warning`: clean on all touched bash; `zsh -n install.sh` and `bash -n` clean.
- Unit tests: bootstrap 17, verify 32, dry-run 26, update 7, templates 8 — **90 passing, 0 failing**.
- Install smoke against an isolated `HOME`: all 16 manifest symlinks created; second run idempotent (`0 backed up`).
- `verify.sh`: `16 symlinks OK`.

## Artifacts
- Plan: https://app.warp.dev/drive/notebook/LSu1NaGlDIutRDY6LGJOlw
- Conversation: https://app.warp.dev/conversation/94f35ae1-447f-4850-a05e-d6957c64aafb

Co-Authored-By: Oz <oz-agent@warp.dev>
