### PR TITLE
Make ~/.gitconfig a thin include so global writes don't pollute the repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,17 @@ jobs:
           echo "All symlinks verified."
 
           echo ""
+          echo "--- Verifying ~/.gitconfig is a thin include (not a symlink) ---"
+          if [[ -L "$HOME/.gitconfig" ]]; then
+            echo "FAIL  ~/.gitconfig is a symlink (should be a thin include file)" && exit 1
+          fi
+          if [[ -f "$HOME/.gitconfig" ]] && grep -q "home/gitconfig" "$HOME/.gitconfig"; then
+            echo "OK  ~/.gitconfig includes the tracked config"
+          else
+            echo "FAIL  ~/.gitconfig missing or does not include home/gitconfig" && exit 1
+          fi
+
+          echo ""
           echo "--- Idempotency: a second run must back up nothing ---"
           # Re-run against the SAME temp HOME. Every dotfile is already linked, so
           # the summary must report "0 backed up".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ A maintainer-facing guide to how this repository is wired together and the conve
 Four entry-point scripts form the pipeline; everything in `scripts/` exists to support them.
 
 1. **`bootstrap.sh`** (bash) — one-time setup on a fresh Mac. Runs `scripts/preflight.sh` first (unless `--skip-preflight` or `--dry-run`), installs Homebrew and the `Brewfile`, language runtimes via `mise`, Yarn via Corepack (from the mise-managed Node), Rust via `rustup`, and `git-lfs`, then hands off to `install.sh` for symlinks, and finally prompts for work configs (`scripts/setup_work_configs.sh`) and macOS defaults (`scripts/macos.sh`). Supports `--dry-run` and `--skip-preflight`.
-2. **`install.sh`** (zsh) — the symlinker. Links every tracked dotfile into `$HOME`, backing up any pre-existing real file to `~/.dotfiles_backup/<timestamp>/`. It also seeds `~/.config/git/local.gitconfig` from `home/examples/gitconfig.local.example` and installs a global pre-commit hook at `~/.config/git/hooks/pre-commit`. Idempotent: a second run relinks nothing already correct and reports `linked / current / backed up`.
+2. **`install.sh`** (zsh) — the symlinker. Links every tracked dotfile (per `config/symlinks.map`) into `$HOME`, backing up any pre-existing real file to `~/.dotfiles_backup/<timestamp>/`. It also writes a thin `~/.gitconfig` that *includes* the tracked `home/gitconfig` (a real file, not a symlink, so `git config --global` and tools like `gh auth setup-git` never write into the repo), seeds `~/.config/git/local.gitconfig` from `home/examples/gitconfig.local.example`, and installs a global pre-commit hook at `~/.config/git/hooks/pre-commit`. Idempotent: a second run relinks nothing already correct and reports `linked / current / backed up`.
 3. **`update.sh`** (bash) — keep-current. `git pull --rebase --autostash`, re-runs `install.sh` to pick up new symlinks, upgrades Homebrew / `mise` / `rustup` / gems / `uv` tools, then runs `verify.sh`. Schedulable via `scripts/setup-scheduler.sh` (launchd, daily at 9 AM).
-4. **`verify.sh`** (bash) — health check. Eight checks: symlinks, required tools, stale backups, SSH key, global git-lfs init, mise-installed runtimes, dotfiles git health, and Brewfile drift. Broken symlinks are the only hard error (exit 1); everything else is a warning (exit 0).
+4. **`verify.sh`** (bash) — health check. Nine checks: symlinks, required tools, stale backups, SSH key, global git-lfs init, mise-installed runtimes, dotfiles git health, Brewfile drift, and git config include. Broken symlinks are the only hard error (exit 1); everything else is a warning (exit 0).
 
 ```
 bootstrap.sh ──▶ install.sh ──▶ update.sh ──▶ verify.sh
@@ -20,7 +20,7 @@ bootstrap.sh ──▶ install.sh ──▶ update.sh ──▶ verify.sh
 ## Layout
 
 - **Root** — the four entry-point scripts (`bootstrap.sh`, `install.sh`, `update.sh`, `verify.sh`), package manifests (`Brewfile`, `Brewfile.work`), and repo meta (`README.md`, `CONTRIBUTING.md`).
-- **`home/`** — the tracked dotfiles symlinked into `$HOME` (`zshrc`, `zprofile`, `gitconfig`, `tmux.conf`, …); `home/examples/` holds the `*.local.example` templates.
+- **`home/`** — the tracked dotfiles symlinked into `$HOME` (`zshrc`, `zprofile`, `tmux.conf`, …); `home/examples/` holds the `*.local.example` templates. (`gitconfig` lives here too but is loaded via a thin `~/.gitconfig` include rather than symlinked, so global writes never touch the repo.)
 - **`scripts/`** — the secondary entry scripts (`macos.sh`, `setup-scheduler.sh`, `uninstall.sh`, `quick-fix.sh`) and supporting/work-setup scripts. Sourced helper libraries live in **`scripts/lib/`** and unit tests in **`scripts/tests/`** (see below). Has its own [README](scripts/README.md).
 - **`config/`** — XDG configs symlinked under `~/.config` (`starship.toml`, `mise.toml`, `direnvrc`).
 - **`templates/`** — work / secret-bearing configs shipped as `*.template` placeholders (see [templates/README.md](templates/README.md)).
@@ -30,7 +30,7 @@ bootstrap.sh ──▶ install.sh ──▶ update.sh ──▶ verify.sh
 ## Helpers
 
 - **`scripts/lib/bootstrap_helpers.sh`** — sourced by `bootstrap.sh`, `update.sh`, and `verify.sh`. Side-effect-free output helpers (`setup_colors`, `step`, `info`, `success`, `warn`; call `setup_colors` once after sourcing) plus `parse_mise_runtimes`, which reads the `[tools]` table of `config/mise.toml` — the single source of truth for runtime versions.
-- **`scripts/lib/verify_helpers.sh`** — sourced by `verify.sh`. Pure check functions (`check_symlinks`, `check_required_tools`, `check_ssh_key`, `check_git_lfs_global`, `check_mise_installed`, `check_stale_backups`, `check_dotfiles_git_health`, `check_brewfile_drift`). Each sets result globals (e.g. `SYMLINK_BROKEN_COUNT`, `SYMLINK_BROKEN_LIST`) rather than printing or exiting, which makes them unit-testable. `load_symlink_map` populates the `DOTFILES_SYMLINKS` array from `config/symlinks.map`, the canonical symlink manifest (see below).
+- **`scripts/lib/verify_helpers.sh`** — sourced by `verify.sh`. Pure check functions (`check_symlinks`, `check_required_tools`, `check_ssh_key`, `check_git_lfs_global`, `check_mise_installed`, `check_stale_backups`, `check_dotfiles_git_health`, `check_brewfile_drift`, `check_gitconfig_include`). Each sets result globals (e.g. `SYMLINK_BROKEN_COUNT`, `SYMLINK_BROKEN_LIST`) rather than printing or exiting, which makes them unit-testable. `load_symlink_map` populates the `DOTFILES_SYMLINKS` array from `config/symlinks.map`, the canonical symlink manifest (see below).
 - **`scripts/lib/dryrun_helpers.sh`** — sourced by `bootstrap.sh` only when `--dry-run` is set. Provides `dry_run_step`, per-step `check_*` previews (including `check_corepack`) that record intended actions via `dry_run_log`, and `show_dry_run_summary`.
 - **`scripts/preflight.sh`** — standalone (defines its own colors and `error`/`warn`/`success`/`info`). Validates the system before bootstrap.
 
@@ -74,7 +74,7 @@ The dotfile→destination mapping is a single source of truth in `config/symlink
 2. **`config/symlinks.map`** — add one `src  dest` line (src relative to the repo root, dest relative to `$HOME`). Every consumer picks it up automatically — no other script or workflow needs editing.
 3. **`README.md`** — add a row to the Dotfiles table (human-readable reference).
 
-Non-symlink setup (the `~/.config/git/local.gitconfig` seed, the global pre-commit hook, and VS Code settings/extensions) is intentionally bespoke in `install.sh` and is deliberately not part of the manifest.
+Non-symlink setup (the thin `~/.gitconfig` include, the `~/.config/git/local.gitconfig` seed, the global pre-commit hook, and VS Code settings/extensions) is intentionally bespoke in `install.sh` and is deliberately not part of the manifest.
 
 ### Add a configuration template
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
 |------|-------------|--------------|
 | `home/zshrc` | `~/.zshrc` | Shell config — mise, PATH, aliases, plugins |
 | `home/zprofile` | `~/.zprofile` | Login profile — Homebrew PATH setup |
-| `home/gitconfig` | `~/.gitconfig` | Git defaults, delta pager, SSH signing |
+| `home/gitconfig` | `~/.gitconfig` _(include)_ | Git defaults, delta pager, SSH signing — loaded via a thin `~/.gitconfig` (not a symlink) so `git config --global` / tool writes stay out of the repo |
 | `home/gitignore_global` | `~/.gitignore_global` | Global ignores — macOS, editors, Java, Go |
 | `home/tmux.conf` | `~/.tmux.conf` | tmux — `C-a` prefix, vim keys, TPM plugins |
 | `home/hyper.js` | `~/.hyper.js` | Hyper — Tokyo Night theme, JetBrains Mono |
@@ -349,7 +349,7 @@ Or for additional work-specific topics: [docs/work-machine.md](docs/work-machine
 
 ## Making changes
 
-Because dotfiles are symlinked, editing `~/.zshrc` edits `~/dotfiles/home/zshrc` directly:
+Because most dotfiles are symlinked, editing `~/.zshrc` edits `~/dotfiles/home/zshrc` directly. (Exception: `~/.gitconfig` is a thin _include_, not a symlink — edit `home/gitconfig` for shared settings; machine-specific or tool-written git config stays in `~/.gitconfig` / `~/.config/git/local.gitconfig`.)
 
 ```sh
 cd ~/dotfiles

--- a/config/symlinks.map
+++ b/config/symlinks.map
@@ -9,15 +9,15 @@
 # bootstrap.sh --dry-run (previews them), and the CI install-smoke job.
 # Add a tracked dotfile by adding one line here — every consumer picks it up.
 #
-# Non-symlink setup (local.gitconfig seed, global pre-commit hook, VS Code
-# settings/extensions) stays bespoke in install.sh and is intentionally not
-# listed here.
+# Non-symlink setup (the ~/.gitconfig thin include, local.gitconfig seed, global
+# pre-commit hook, VS Code settings/extensions) stays bespoke in install.sh and
+# is intentionally not listed here. ~/.gitconfig is a real file (not a symlink)
+# so `git config --global` and tools never write into the tracked repo file.
 
 # Home-directory dotfiles
 home/zshrc             .zshrc
 home/zprofile          .zprofile
-home/gitconfig         .gitconfig
-home/tmux.conf         .tmux.conf
+home/tmux.conf          .tmux.conf
 home/hyper.js          .hyper.js
 home/gitignore_global  .gitignore_global
 home/gemrc             .gemrc

--- a/install.sh
+++ b/install.sh
@@ -59,6 +59,33 @@ fi
 # Harden ~/.ssh perms (the directory is created above when linking ssh_config)
 [[ -d "$HOME/.ssh" ]] && chmod 700 "$HOME/.ssh"
 
+# Git config: a thin, REAL ~/.gitconfig that *includes* the tracked config.
+# Deliberately NOT a symlink — this keeps `git config --global` and tools like
+# `gh auth setup-git` from writing into the tracked dotfile (home/gitconfig).
+# Machine/tool-written settings accumulate here and override the shared defaults.
+GITCONFIG_DEST="$HOME/.gitconfig"
+GITCONFIG_SRC="$DOTFILES_DIR/home/gitconfig"
+GITCONFIG_SHORT="${GITCONFIG_DEST/$HOME/\~}"
+if [[ -f "$GITCONFIG_DEST" && ! -L "$GITCONFIG_DEST" ]] && grep -qF "path = $GITCONFIG_SRC" "$GITCONFIG_DEST"; then
+  success "current   $GITCONFIG_SHORT (thin include of dotfiles gitconfig)"
+else
+  if [[ -e "$GITCONFIG_DEST" || -L "$GITCONFIG_DEST" ]]; then
+    mkdir -p "$BACKUP_DIR"
+    mv "$GITCONFIG_DEST" "$BACKUP_DIR/"
+    backup "backed up  $GITCONFIG_SHORT (was a symlink/real file)"
+  fi
+  cat > "$GITCONFIG_DEST" <<EOF
+# ~/.gitconfig — managed by dotfiles (thin include; intentionally NOT a symlink).
+# Keeping this a real file means 'git config --global ...' and tools such as
+# 'gh auth setup-git' write here instead of into the tracked repo file. Shared
+# config is pulled in from the repo below; anything written after the include
+# (by you or tooling) overrides those defaults on this machine only.
+[include]
+	path = $GITCONFIG_SRC
+EOF
+  success "linked    $GITCONFIG_SHORT (thin include → home/gitconfig)"
+fi
+
 # Local git config (signing key, work email overrides — not committed)
 mkdir -p "$HOME/.config/git"
 if [[ ! -f "$HOME/.config/git/local.gitconfig" ]]; then

--- a/scripts/lib/dryrun_helpers.sh
+++ b/scripts/lib/dryrun_helpers.sh
@@ -263,6 +263,11 @@ check_dotfile_symlinks() {
     dry_run_log "Create ~/.config/git/local.gitconfig from template"
     info "Would create: ~/.config/git/local.gitconfig (git signing key)"
   fi
+
+  if [[ ! -f "$HOME/.gitconfig" ]] || [[ -L "$HOME/.gitconfig" ]]; then
+    dry_run_log "Write ~/.gitconfig thin include (replaces any symlink)"
+    info "Would create: ~/.gitconfig (thin include of home/gitconfig)"
+  fi
 }
 
 # Check work configs

--- a/scripts/lib/verify_helpers.sh
+++ b/scripts/lib/verify_helpers.sh
@@ -73,6 +73,36 @@ check_symlinks() {
   done
 }
 
+# check_gitconfig_include HOME_DIR DOTFILES_DIR
+# Confirms ~/.gitconfig is a real file (not a symlink) that includes the tracked
+# home/gitconfig. This is the structure that keeps `git config --global` and
+# tools like `gh auth setup-git` from writing into the tracked dotfile.
+# Sets:
+#   GITCONFIG_INCLUDE_OK    — true when the include is present and not a symlink
+#   GITCONFIG_INCLUDE_ISSUE — human-readable problem (empty when OK)
+check_gitconfig_include() {
+  local home_dir="$1"
+  local dotfiles_dir="$2"
+  local cfg="$home_dir/.gitconfig"
+  local want="$dotfiles_dir/home/gitconfig"
+  GITCONFIG_INCLUDE_OK=false
+  GITCONFIG_INCLUDE_ISSUE=""
+
+  if [[ -L "$cfg" ]]; then
+    GITCONFIG_INCLUDE_ISSUE="Git config: ~/.gitconfig is a symlink — global writes would pollute the tracked dotfile (run install.sh)"
+    return
+  fi
+  if [[ ! -f "$cfg" ]]; then
+    GITCONFIG_INCLUDE_ISSUE="Git config: ~/.gitconfig missing — run install.sh"
+    return
+  fi
+  if grep -qF "path = $want" "$cfg"; then
+    GITCONFIG_INCLUDE_OK=true
+  else
+    GITCONFIG_INCLUDE_ISSUE="Git config: ~/.gitconfig does not include $want — run install.sh"
+  fi
+}
+
 # check_required_tools TOOL [TOOL ...]
 # Checks each named tool is available on PATH via command -v.
 # Sets:

--- a/scripts/tests/test_dryrun_helpers.sh
+++ b/scripts/tests/test_dryrun_helpers.sh
@@ -221,6 +221,8 @@ if (
     || { printf "  FAIL  missing zshrc.local not logged\n"; exit 1; }
   printf '%s\n' "${DRY_RUN_ACTIONS[@]}" | grep -q "Create ~/.config/git/local.gitconfig from template" \
     || { printf "  FAIL  missing local.gitconfig not logged\n"; exit 1; }
+  printf '%s\n' "${DRY_RUN_ACTIONS[@]}" | grep -q "Write ~/.gitconfig thin include" \
+    || { printf "  FAIL  gitconfig thin-include action not logged\n"; exit 1; }
 ); then
   pass "check_dotfile_symlinks: logs create actions for missing local configs"
 else

--- a/scripts/tests/test_verify_helpers.sh
+++ b/scripts/tests/test_verify_helpers.sh
@@ -537,7 +537,73 @@ else
   fail "check_dotfiles_git_health: non-git directory" "subshell exited non-zero"
 fi
 
-# ── check_brewfile_drift ──────────────────────────────────────────────────
+# ── check_gitconfig_include ─────────────────────────────────
+echo ""
+echo "=== check_gitconfig_include ==="
+
+GCI_DOTFILES="$TMPDIR_BASE/gci_dotfiles"
+mkdir -p "$GCI_DOTFILES/home"
+touch "$GCI_DOTFILES/home/gitconfig"
+
+# Case 1: real file that includes the tracked config → OK=true
+GCI_HOME_OK="$TMPDIR_BASE/gci_home_ok"
+mkdir -p "$GCI_HOME_OK"
+printf '[include]\n\tpath = %s/home/gitconfig\n' "$GCI_DOTFILES" > "$GCI_HOME_OK/.gitconfig"
+if (
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  check_gitconfig_include "$GCI_HOME_OK" "$GCI_DOTFILES"
+  [[ "$GITCONFIG_INCLUDE_OK" == "true" ]] || { printf "  FAIL  expected OK=true, got %s\n" "$GITCONFIG_INCLUDE_OK"; exit 1; }
+  [[ -z "$GITCONFIG_INCLUDE_ISSUE" ]] || { printf "  FAIL  expected empty issue, got %s\n" "$GITCONFIG_INCLUDE_ISSUE"; exit 1; }
+); then
+  pass "check_gitconfig_include: thin include file → OK=true"
+else
+  fail "check_gitconfig_include: thin include" "subshell exited non-zero"
+fi
+
+# Case 2: ~/.gitconfig is a symlink → OK=false, issue mentions symlink
+GCI_HOME_LINK="$TMPDIR_BASE/gci_home_link"
+mkdir -p "$GCI_HOME_LINK"
+ln -sf "$GCI_DOTFILES/home/gitconfig" "$GCI_HOME_LINK/.gitconfig"
+if (
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  check_gitconfig_include "$GCI_HOME_LINK" "$GCI_DOTFILES"
+  [[ "$GITCONFIG_INCLUDE_OK" == "false" ]] || { printf "  FAIL  expected OK=false for symlink\n"; exit 1; }
+  echo "$GITCONFIG_INCLUDE_ISSUE" | grep -q "symlink" || { printf "  FAIL  issue should mention symlink, got %s\n" "$GITCONFIG_INCLUDE_ISSUE"; exit 1; }
+); then
+  pass "check_gitconfig_include: symlink → OK=false, issue mentions symlink"
+else
+  fail "check_gitconfig_include: symlink" "subshell exited non-zero"
+fi
+
+# Case 3: ~/.gitconfig missing → OK=false
+GCI_HOME_MISSING="$TMPDIR_BASE/gci_home_missing"
+mkdir -p "$GCI_HOME_MISSING"
+if (
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  check_gitconfig_include "$GCI_HOME_MISSING" "$GCI_DOTFILES"
+  [[ "$GITCONFIG_INCLUDE_OK" == "false" ]] || { printf "  FAIL  expected OK=false when missing\n"; exit 1; }
+  [[ -n "$GITCONFIG_INCLUDE_ISSUE" ]] || { printf "  FAIL  expected non-empty issue\n"; exit 1; }
+); then
+  pass "check_gitconfig_include: missing ~/.gitconfig → OK=false"
+else
+  fail "check_gitconfig_include: missing" "subshell exited non-zero"
+fi
+
+# Case 4: real file without the include → OK=false
+GCI_HOME_NOINC="$TMPDIR_BASE/gci_home_noinc"
+mkdir -p "$GCI_HOME_NOINC"
+printf '[user]\n\tname = test\n' > "$GCI_HOME_NOINC/.gitconfig"
+if (
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  check_gitconfig_include "$GCI_HOME_NOINC" "$GCI_DOTFILES"
+  [[ "$GITCONFIG_INCLUDE_OK" == "false" ]] || { printf "  FAIL  expected OK=false without include\n"; exit 1; }
+); then
+  pass "check_gitconfig_include: file without include → OK=false"
+else
+  fail "check_gitconfig_include: no include" "subshell exited non-zero"
+fi
+
+# ── check_brewfile_drift ─────────────────────────────────
 echo ""
 echo "=== check_brewfile_drift ==="
 

--- a/verify.sh
+++ b/verify.sh
@@ -10,6 +10,7 @@
 #   6. mise tools installed   (warnings — exit 0)
 #   7. dotfiles git health    (warnings — exit 0)
 #   8. Brewfile drift         (warnings — exit 0)
+#   9. git config include     (warnings — exit 0)
 #
 # Usage:   bash ~/dotfiles/verify.sh
 # Called by update.sh automatically after each update cycle.
@@ -23,7 +24,7 @@ WARNINGS=0
 # shellcheck disable=SC2034  # used by step() in helpers
 STEP=0
 # shellcheck disable=SC2034
-TOTAL_STEPS=8
+TOTAL_STEPS=9
 
 # shellcheck source=scripts/lib/bootstrap_helpers.sh
 source "$DOTFILES_DIR/scripts/lib/bootstrap_helpers.sh"
@@ -150,6 +151,17 @@ elif [[ "$BREWFILE_DRIFT_OK" == "true" ]]; then
   success "Brewfile in sync with installed packages"
 else
   warn "$BREWFILE_DRIFT_ISSUE"
+  WARNINGS=$(( WARNINGS + 1 ))
+fi
+
+# ── 9. Git config include ────────────────────────────────────────────
+step "🔧  Git config include"
+check_gitconfig_include "$HOME" "$DOTFILES_DIR"
+
+if [[ "$GITCONFIG_INCLUDE_OK" == "true" ]]; then
+  success "Git config: ~/.gitconfig includes the tracked config (not a symlink)"
+else
+  warn "$GITCONFIG_INCLUDE_ISSUE"
   WARNINGS=$(( WARNINGS + 1 ))
 fi
 


### PR DESCRIPTION
## Summary
`~/.gitconfig` was symlinked to the tracked `home/gitconfig`, so any `git config --global …` — or tools like `gh auth setup-git` — wrote **into the tracked dotfile**, dirtying the working tree and risking committing machine-specific values (this actually happened earlier in development).

`install.sh` now writes a thin, **real** `~/.gitconfig` that `[include]`s the tracked `home/gitconfig`. Global/tool writes accumulate in the real `~/.gitconfig` (overriding shared defaults for that machine), while the repo file stays clean.

## Changes
- **`config/symlinks.map`** — drop the `gitconfig` symlink entry (now bespoke).
- **`install.sh`** — write the thin include (idempotent; backs up any prior file/symlink to `~/.dotfiles_backup/`).
- **`verify.sh` + `scripts/lib/verify_helpers.sh`** — new `check_gitconfig_include` (step 9) warns if `~/.gitconfig` is a symlink, missing, or lacks the include.
- **`scripts/lib/dryrun_helpers.sh`** — `--dry-run` previews the gitconfig include.
- **`.github/workflows/ci.yml`** — install-smoke asserts `~/.gitconfig` is a non-symlink that includes the tracked config.
- **Tests** — `check_gitconfig_include` cases (verify suite 32 → 36) + a dry-run assertion.
- **Docs** — `README.md` + `CONTRIBUTING.md` document the thin-include structure.

## Why a thin include
`git config --global` always writes to the top-level global file, never to `[include]`d files. Making that top-level file a real (non-symlinked) `~/.gitconfig` is what keeps writes out of the repo. Machine-specific/secret config continues to live in `~/.config/git/local.gitconfig` (included transitively).

## Validation
- `shellcheck --norc -S warning` (CI-equivalent): clean; `zsh -n install.sh` clean.
- Unit suites: bootstrap 17, dry-run 37, update 7, templates 8, **verify 36** — all pass.
- **Isolated-HOME proof:** `install.sh` produced a regular-file `~/.gitconfig`; a `git config --global` write landed in that thin file and the tracked `home/gitconfig` stayed untouched.
- Verified on a real checkout: `~/.gitconfig` converts from symlink → thin include, GitHub auth (`!gh auth git-credential`) and `user.email` still resolve, and `verify.sh` step 9 passes.

## Artifacts
- Conversation: https://app.warp.dev/conversation/94f35ae1-447f-4850-a05e-d6957c64aafb

Co-Authored-By: Oz <oz-agent@warp.dev>
