### PR TITLE
feat(status): read-only dotfiles health snapshot (scripts/status.sh)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,8 @@
 # runs from the dotfiles directory instead of the project root
 *.vscode-*
 ms-*.*
-logs/*.log
+logs/*
+!logs/.gitkeep
 
 # VS Code extension folders (publisher.extension-name format)
 *.*/

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ To schedule daily automatic runs via launchd (9 AM): `bash ~/dotfiles/scripts/se
 
 To run the health check standalone: `bash ~/dotfiles/verify.sh`
 
+For a quick read-only snapshot (repo git state + last `update.sh` result): `bash ~/dotfiles/scripts/status.sh` (aliased as `dotstatus`).
+
 To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
 
 ### Terminal preview
@@ -176,6 +178,7 @@ To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
 | `update.sh` | _(run to update)_ | Upgrade all packages, runtimes, and gems; runs health check at end |
 | `verify.sh` | _(run to verify)_ | Health check — symlinks, missing tools, installed runtimes, stale backups |
 | `scripts/setup-scheduler.sh` | _(run once)_ | Install launchd job to run `update.sh` daily at 9 AM |
+| `scripts/status.sh` | _(run / `dotstatus`)_ | Quick read-only health snapshot — repo git state + last `update.sh` result |
 | `scripts/macos.sh` | _(run once)_ | macOS developer defaults |
 | `home/examples/zshrc.local.example` | _(template)_ | Template for machine-specific overrides |
 

--- a/home/zshrc
+++ b/home/zshrc
@@ -155,6 +155,7 @@ alias gco='git checkout'
 alias glog='git log --oneline --decorate --color --graph'
 
 alias src='source ~/.zshrc'
+alias dotstatus='bash ~/dotfiles/scripts/status.sh'  # dotfiles health: repo git state + last update
 alias c='clear'
 alias edithost='sudo nano /etc/hosts'
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -5,7 +5,7 @@ Automation scripts for system setup, configuration, and maintenance.
 ## Layout
 
 - **`scripts/`** — runnable scripts (work setup, installers, `macos.sh`, `uninstall.sh`, `validate_templates.sh`, …).
-- **`scripts/lib/`** — sourced helper libraries (no side effects): `bootstrap_helpers.sh`, `verify_helpers.sh`, `dryrun_helpers.sh`, `update_helpers.sh`.
+- **`scripts/lib/`** — sourced helper libraries (no side effects): `bootstrap_helpers.sh`, `verify_helpers.sh`, `dryrun_helpers.sh`, `update_helpers.sh`, `status_helpers.sh`.
 - **`scripts/tests/`** — hand-rolled unit tests (`test_*.sh`) for the helpers and validators.
 
 ---
@@ -27,6 +27,24 @@ source "$(dirname "$0")/scripts/lib/bootstrap_helpers.sh"
 setup_colors
 success "Task completed"
 ```
+
+---
+
+## Maintenance
+
+### `status.sh`
+
+**Quick, read-only dotfiles health snapshot.**
+
+Prints the dotfiles repo's git state (branch, clean/dirty, ahead/behind upstream) and the result of the last `update.sh` run (read from `logs/update.status`). Fast and side-effect-free.
+
+**Usage:**
+```bash
+bash ~/dotfiles/scripts/status.sh            # repo + last-update summary
+bash ~/dotfiles/scripts/status.sh --verify   # also run the full verify.sh
+```
+
+Aliased as `dotstatus` in `home/zshrc`. Parsing and git-state helpers live in `lib/status_helpers.sh` (unit-tested by `tests/test_status_helpers.sh`).
 
 ---
 
@@ -195,7 +213,7 @@ code --list-extensions
 
 ## Tests (`tests/`)
 
-Hand-rolled unit tests (no framework), auto-discovered and run by `.github/workflows/test-bootstrap.yml`: `test_bootstrap_helpers.sh`, `test_verify_helpers.sh`, `test_dryrun_helpers.sh`, `test_update_helpers.sh`, and `test_validate_templates.sh`. Run one directly with `bash scripts/tests/<file>`.
+Hand-rolled unit tests (no framework), auto-discovered and run by `.github/workflows/test-bootstrap.yml`: `test_bootstrap_helpers.sh`, `test_verify_helpers.sh`, `test_dryrun_helpers.sh`, `test_update_helpers.sh`, `test_status_helpers.sh`, and `test_validate_templates.sh`. Run one directly with `bash scripts/tests/<file>`.
 
 ### `tests/test_bootstrap_helpers.sh`
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -40,8 +40,9 @@ Prints the dotfiles repo's git state (branch, clean/dirty, ahead/behind upstream
 
 **Usage:**
 ```bash
-bash ~/dotfiles/scripts/status.sh            # repo + last-update summary
-bash ~/dotfiles/scripts/status.sh --verify   # also run the full verify.sh
+bash ~/dotfiles/scripts/status.sh             # repo + last-update summary
+bash ~/dotfiles/scripts/status.sh --verify    # also run the full verify.sh
+bash ~/dotfiles/scripts/status.sh --exit-code # exit non-zero if unhealthy (for scripts/CI)
 ```
 
 Aliased as `dotstatus` in `home/zshrc`. Parsing and git-state helpers live in `lib/status_helpers.sh` (unit-tested by `tests/test_status_helpers.sh`).

--- a/scripts/lib/status_helpers.sh
+++ b/scripts/lib/status_helpers.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# status_helpers.sh — pure, side-effect-free helpers sourced by status.sh.
+#
+# Each function either echoes a value or sets result globals (never prints UI or
+# calls exit), so they are unit-testable against fixtures and temp git repos.
+# shellcheck disable=SC2034  # GIT_STATE_* globals are consumed by the sourcing script
+
+# read_kv_value FILE KEY — echo the raw value of a `KEY=value` line in FILE.
+# Whitespace around the `=` is ignored, trailing whitespace is trimmed, `#`
+# comments are stripped, and the last assignment wins. Echoes nothing when the
+# key is absent or the file is missing. Used to read logs/update.status, whose
+# values (e.g. "Homebrew, Rust") may contain spaces and commas.
+read_kv_value() {
+  local file="$1" key="$2" line val=""
+  [[ -f "$file" ]] || return 0
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line%%#*}"  # strip trailing comment
+    if [[ "$line" =~ ^[[:space:]]*"$key"[[:space:]]*=[[:space:]]*(.*)$ ]]; then
+      val="${BASH_REMATCH[1]}"
+      val="${val%"${val##*[![:space:]]}"}"  # trim trailing whitespace
+    fi
+  done < "$file"
+  printf '%s' "$val"
+}
+
+# git_state DIR — inspect the git work tree at DIR (read-only) and set globals:
+#   GIT_STATE_BRANCH    current branch name ("" if DIR is not a git work tree)
+#   GIT_STATE_DIRTY     true if there are staged/unstaged changes to tracked files
+#   GIT_STATE_UPSTREAM  true if the branch has a configured upstream
+#   GIT_STATE_AHEAD     commits on HEAD not on the upstream
+#   GIT_STATE_BEHIND    commits on the upstream not on HEAD
+# Safe on a non-git directory: leaves the defaults below.
+git_state() {
+  local dir="$1"
+  GIT_STATE_BRANCH=""
+  GIT_STATE_DIRTY=false
+  GIT_STATE_UPSTREAM=false
+  GIT_STATE_AHEAD=0
+  GIT_STATE_BEHIND=0
+
+  git -C "$dir" rev-parse --is-inside-work-tree &>/dev/null || return 0
+  GIT_STATE_BRANCH=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+
+  if ! git -C "$dir" diff --quiet 2>/dev/null || ! git -C "$dir" diff --cached --quiet 2>/dev/null; then
+    GIT_STATE_DIRTY=true
+  fi
+
+  # rev-list --left-right --count UPSTREAM...HEAD → "<behind>\t<ahead>"
+  local counts
+  if counts=$(git -C "$dir" rev-list --left-right --count '@{upstream}...HEAD' 2>/dev/null); then
+    GIT_STATE_UPSTREAM=true
+    GIT_STATE_BEHIND=$(printf '%s' "$counts" | awk '{print $1}')
+    GIT_STATE_AHEAD=$(printf '%s' "$counts" | awk '{print $2}')
+  fi
+}

--- a/scripts/lib/status_helpers.sh
+++ b/scripts/lib/status_helpers.sh
@@ -6,15 +6,16 @@
 # shellcheck disable=SC2034  # GIT_STATE_* globals are consumed by the sourcing script
 
 # read_kv_value FILE KEY — echo the raw value of a `KEY=value` line in FILE.
-# Whitespace around the `=` is ignored, trailing whitespace is trimmed, `#`
-# comments are stripped, and the last assignment wins. Echoes nothing when the
-# key is absent or the file is missing. Used to read logs/update.status, whose
-# values (e.g. "Homebrew, Rust") may contain spaces and commas.
+# Whitespace around the `=` is ignored, trailing whitespace is trimmed, full-line
+# `#` comments are skipped (so `#` is preserved inside values), and the last
+# assignment wins. Echoes nothing when the key is absent or the file is missing.
+# Used to read logs/update.status, whose values (e.g. "Homebrew, Rust") may
+# contain spaces and commas.
 read_kv_value() {
   local file="$1" key="$2" line val=""
   [[ -f "$file" ]] || return 0
   while IFS= read -r line || [[ -n "$line" ]]; do
-    line="${line%%#*}"  # strip trailing comment
+    if [[ "$line" =~ ^[[:space:]]*# ]]; then continue; fi  # skip full-line comments
     if [[ "$line" =~ ^[[:space:]]*"$key"[[:space:]]*=[[:space:]]*(.*)$ ]]; then
       val="${BASH_REMATCH[1]}"
       val="${val%"${val##*[![:space:]]}"}"  # trim trailing whitespace
@@ -24,8 +25,9 @@ read_kv_value() {
 }
 
 # git_state DIR — inspect the git work tree at DIR (read-only) and set globals:
-#   GIT_STATE_BRANCH    current branch name ("" if DIR is not a git work tree)
+#   GIT_STATE_BRANCH    branch name; "detached@<sha>" when detached; "" if not a repo
 #   GIT_STATE_DIRTY     true if there are staged/unstaged changes to tracked files
+#   GIT_STATE_UNTRACKED count of untracked, non-ignored files
 #   GIT_STATE_UPSTREAM  true if the branch has a configured upstream
 #   GIT_STATE_AHEAD     commits on HEAD not on the upstream
 #   GIT_STATE_BEHIND    commits on the upstream not on HEAD
@@ -34,16 +36,28 @@ git_state() {
   local dir="$1"
   GIT_STATE_BRANCH=""
   GIT_STATE_DIRTY=false
+  GIT_STATE_UNTRACKED=0
   GIT_STATE_UPSTREAM=false
   GIT_STATE_AHEAD=0
   GIT_STATE_BEHIND=0
 
   git -C "$dir" rev-parse --is-inside-work-tree &>/dev/null || return 0
+
   GIT_STATE_BRANCH=$(git -C "$dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [[ "$GIT_STATE_BRANCH" == "HEAD" ]]; then
+    # Detached HEAD: show a short SHA instead of the bare "HEAD".
+    local _short
+    _short=$(git -C "$dir" rev-parse --short HEAD 2>/dev/null || true)
+    GIT_STATE_BRANCH="detached@${_short}"
+  fi
 
   if ! git -C "$dir" diff --quiet 2>/dev/null || ! git -C "$dir" diff --cached --quiet 2>/dev/null; then
     GIT_STATE_DIRTY=true
   fi
+
+  local _untracked
+  _untracked=$(git -C "$dir" ls-files --others --exclude-standard 2>/dev/null | wc -l | tr -d '[:space:]')
+  GIT_STATE_UNTRACKED=${_untracked:-0}
 
   # rev-list --left-right --count UPSTREAM...HEAD → "<behind>\t<ahead>"
   local counts

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# status.sh — quick, read-only snapshot of dotfiles health.
+#
+# Shows the dotfiles repo's git state and the result of the last `update.sh`
+# run (read from logs/update.status, which update.sh writes on every run).
+# Read-only and fast — safe to run any time. Handy alias: `dotstatus`.
+#
+# Usage:
+#   bash ~/dotfiles/scripts/status.sh            # repo + last-update summary
+#   bash ~/dotfiles/scripts/status.sh --verify   # also run the full verify.sh
+#   bash ~/dotfiles/scripts/status.sh --help
+
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="$DOTFILES_DIR/logs"
+STATUS_FILE="$LOG_DIR/update.status"
+LOG_FILE="$LOG_DIR/update.log"
+
+RUN_VERIFY=false
+for arg in "$@"; do
+  case "$arg" in
+    --verify) RUN_VERIFY=true ;;
+    --help|-h)
+      cat <<'USAGE'
+Usage: bash status.sh [OPTIONS]
+
+Read-only snapshot of dotfiles health: repo git state + last update.sh result.
+
+Options:
+  --verify    also run verify.sh (the full health check; slower)
+  --help, -h  show this help
+USAGE
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $arg (try --help)"
+      exit 1
+      ;;
+  esac
+done
+
+# shellcheck source=scripts/lib/bootstrap_helpers.sh
+source "$DOTFILES_DIR/scripts/lib/bootstrap_helpers.sh"
+# shellcheck source=scripts/lib/status_helpers.sh
+source "$DOTFILES_DIR/scripts/lib/status_helpers.sh"
+setup_colors
+
+echo ""
+printf "${BOLD}  🩺  dotfiles status${RESET}\n"
+echo "  ─────────────────────────────────────────────────"
+
+# ── Repo ──────────────────────────────────────────────────────────────────────
+git_state "$DOTFILES_DIR"
+printf "  ${DIM}Repo${RESET}        %s\n" "${DOTFILES_DIR/#$HOME/~}"
+if [[ -n "$GIT_STATE_BRANCH" ]]; then
+  if [[ "$GIT_STATE_DIRTY" == true ]]; then
+    printf "  ${DIM}Branch${RESET}      %s  (${YELLOW}uncommitted changes${RESET})\n" "$GIT_STATE_BRANCH"
+  else
+    printf "  ${DIM}Branch${RESET}      %s  (${GREEN}clean${RESET})\n" "$GIT_STATE_BRANCH"
+  fi
+  if [[ "$GIT_STATE_UPSTREAM" == true ]]; then
+    if (( GIT_STATE_AHEAD > 0 || GIT_STATE_BEHIND > 0 )); then
+      printf "  ${DIM}Upstream${RESET}    ↑%s ahead · ↓%s behind\n" "$GIT_STATE_AHEAD" "$GIT_STATE_BEHIND"
+    else
+      printf "  ${DIM}Upstream${RESET}    in sync\n"
+    fi
+  else
+    printf "  ${DIM}Upstream${RESET}    (no upstream configured)\n"
+  fi
+else
+  warn "not a git repository: ${DOTFILES_DIR/#$HOME/~}"
+fi
+
+# ── Last update ───────────────────────────────────────────────────────────────
+echo "  ─────────────────────────────────────────────────"
+if [[ -f "$STATUS_FILE" ]]; then
+  _last=$(read_kv_value "$STATUS_FILE" last_run)
+  _result=$(read_kv_value "$STATUS_FILE" status)
+  _failed=$(read_kv_value "$STATUS_FILE" failed_steps)
+  _dur=$(read_kv_value "$STATUS_FILE" duration_seconds)
+  printf "  ${DIM}Last update${RESET} %s\n" "${_last:-unknown}"
+  if [[ "$_result" == "success" ]]; then
+    success "result: success  (${_dur:-?}s)"
+  else
+    warn "result: ${_result:-unknown}  (${_dur:-?}s)"
+    [[ -n "$_failed" ]] && warn "failed steps: $_failed"
+    info "details: ${LOG_FILE/#$HOME/~}"
+  fi
+else
+  info "No update.status yet — run:  bash ~/dotfiles/update.sh"
+  info "Schedule daily runs:         bash ~/dotfiles/scripts/setup-scheduler.sh"
+fi
+
+# ── Optional full health check ────────────────────────────────────────────────
+if [[ "$RUN_VERIFY" == true ]]; then
+  echo "  ─────────────────────────────────────────────────"
+  bash "$DOTFILES_DIR/verify.sh" || true
+fi
+
+echo ""

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -8,6 +8,7 @@
 # Usage:
 #   bash ~/dotfiles/scripts/status.sh            # repo + last-update summary
 #   bash ~/dotfiles/scripts/status.sh --verify   # also run the full verify.sh
+#   bash ~/dotfiles/scripts/status.sh --exit-code  # non-zero exit if unhealthy
 #   bash ~/dotfiles/scripts/status.sh --help
 
 set -euo pipefail
@@ -18,9 +19,11 @@ STATUS_FILE="$LOG_DIR/update.status"
 LOG_FILE="$LOG_DIR/update.log"
 
 RUN_VERIFY=false
+EXIT_CODE_MODE=false
 for arg in "$@"; do
   case "$arg" in
     --verify) RUN_VERIFY=true ;;
+    --exit-code) EXIT_CODE_MODE=true ;;
     --help|-h)
       cat <<'USAGE'
 Usage: bash status.sh [OPTIONS]
@@ -28,8 +31,9 @@ Usage: bash status.sh [OPTIONS]
 Read-only snapshot of dotfiles health: repo git state + last update.sh result.
 
 Options:
-  --verify    also run verify.sh (the full health check; slower)
-  --help, -h  show this help
+  --verify     also run verify.sh (the full health check; slower)
+  --exit-code  exit non-zero if unhealthy (last update failed, or --verify failed)
+  --help, -h   show this help
 USAGE
       exit 0
       ;;
@@ -52,10 +56,17 @@ echo "  ────────────────────────
 
 # ── Repo ──────────────────────────────────────────────────────────────────────
 git_state "$DOTFILES_DIR"
+_unhealthy=false
 printf "  ${DIM}Repo${RESET}        %s\n" "${DOTFILES_DIR/#$HOME/~}"
 if [[ -n "$GIT_STATE_BRANCH" ]]; then
   if [[ "$GIT_STATE_DIRTY" == true ]]; then
-    printf "  ${DIM}Branch${RESET}      %s  (${YELLOW}uncommitted changes${RESET})\n" "$GIT_STATE_BRANCH"
+    if (( GIT_STATE_UNTRACKED > 0 )); then
+      printf "  ${DIM}Branch${RESET}      %s  (${YELLOW}uncommitted changes · %s untracked${RESET})\n" "$GIT_STATE_BRANCH" "$GIT_STATE_UNTRACKED"
+    else
+      printf "  ${DIM}Branch${RESET}      %s  (${YELLOW}uncommitted changes${RESET})\n" "$GIT_STATE_BRANCH"
+    fi
+  elif (( GIT_STATE_UNTRACKED > 0 )); then
+    printf "  ${DIM}Branch${RESET}      %s  (${GREEN}clean${RESET}, %s untracked)\n" "$GIT_STATE_BRANCH" "$GIT_STATE_UNTRACKED"
   else
     printf "  ${DIM}Branch${RESET}      %s  (${GREEN}clean${RESET})\n" "$GIT_STATE_BRANCH"
   fi
@@ -86,6 +97,7 @@ if [[ -f "$STATUS_FILE" ]]; then
     warn "result: ${_result:-unknown}  (${_dur:-?}s)"
     [[ -n "$_failed" ]] && warn "failed steps: $_failed"
     info "details: ${LOG_FILE/#$HOME/~}"
+    _unhealthy=true
   fi
 else
   info "No update.status yet — run:  bash ~/dotfiles/update.sh"
@@ -95,7 +107,16 @@ fi
 # ── Optional full health check ────────────────────────────────────────────────
 if [[ "$RUN_VERIFY" == true ]]; then
   echo "  ─────────────────────────────────────────────────"
-  bash "$DOTFILES_DIR/verify.sh" || true
+  if ! bash "$DOTFILES_DIR/verify.sh"; then
+    _unhealthy=true
+  fi
 fi
 
 echo ""
+
+# With --exit-code, propagate an unhealthy state (failed last update or, when
+# --verify is used, a failing verify.sh) as a non-zero exit for scripting/CI.
+# Without it, status.sh is a pure report and always exits 0.
+if [[ "$EXIT_CODE_MODE" == true && "$_unhealthy" == true ]]; then
+  exit 1
+fi

--- a/scripts/tests/test_status_helpers.sh
+++ b/scripts/tests/test_status_helpers.sh
@@ -77,6 +77,13 @@ else
   fail "read_kv_value: last assignment" "expected failure"
 fi
 
+printf '# a full-line comment\nnote=a#b\n' > "$TMPDIR_BASE/hash.status"
+if [[ "$(read_kv_value "$TMPDIR_BASE/hash.status" note)" == "a#b" ]]; then
+  pass "read_kv_value: full-line comment skipped; '#' kept in value"
+else
+  fail "read_kv_value: inline #" "expected a#b"
+fi
+
 # ── git_state ─────────────────────────────────────────────────────────────────
 echo ""
 echo "=== git_state ==="
@@ -96,7 +103,7 @@ if command -v git &>/dev/null; then
   if (
     d="$TMPDIR_BASE/nogit"; mkdir -p "$d"
     git_state "$d"
-    [[ -z "$GIT_STATE_BRANCH" && "$GIT_STATE_DIRTY" == false && "$GIT_STATE_UPSTREAM" == false ]]
+    [[ -z "$GIT_STATE_BRANCH" && "$GIT_STATE_DIRTY" == false && "$GIT_STATE_UNTRACKED" == "0" && "$GIT_STATE_UPSTREAM" == false ]]
   ); then
     pass "git_state: non-git dir → defaults"
   else
@@ -108,7 +115,7 @@ if command -v git &>/dev/null; then
     r="$TMPDIR_BASE/clean"; _mkrepo "$r"
     echo hi > "$r/f"; git -C "$r" add f; git -C "$r" commit -q -m init --no-verify
     git_state "$r"
-    [[ -n "$GIT_STATE_BRANCH" && "$GIT_STATE_DIRTY" == false && "$GIT_STATE_UPSTREAM" == false ]]
+    [[ -n "$GIT_STATE_BRANCH" && "$GIT_STATE_DIRTY" == false && "$GIT_STATE_UNTRACKED" == "0" && "$GIT_STATE_UPSTREAM" == false ]]
   ); then
     pass "git_state: clean repo → branch set, not dirty"
   else
@@ -145,6 +152,55 @@ if command -v git &>/dev/null; then
     pass "git_state: ahead of upstream → ahead=1, behind=0"
   else
     fail "git_state: ahead of upstream" "expected ahead=1 behind=0"
+  fi
+
+  # untracked-only → not dirty, untracked counted
+  if (
+    r="$TMPDIR_BASE/untracked"; _mkrepo "$r"
+    echo hi > "$r/f"; git -C "$r" add f; git -C "$r" commit -q -m init --no-verify
+    echo new > "$r/extra.txt"
+    git_state "$r"
+    [[ "$GIT_STATE_DIRTY" == false && "$GIT_STATE_UNTRACKED" == "1" ]]
+  ); then
+    pass "git_state: untracked-only → dirty=false, untracked=1"
+  else
+    fail "git_state: untracked-only" "expected dirty=false untracked=1"
+  fi
+
+  # detached HEAD → branch shows detached@<sha>, no upstream
+  if (
+    r="$TMPDIR_BASE/detached"; _mkrepo "$r"
+    echo a > "$r/f"; git -C "$r" add f; git -C "$r" commit -q -m c1 --no-verify
+    echo b >> "$r/f"; git -C "$r" add f; git -C "$r" commit -q -m c2 --no-verify
+    git -C "$r" checkout -q HEAD~1
+    git_state "$r"
+    [[ "$GIT_STATE_BRANCH" == detached@* && "$GIT_STATE_UPSTREAM" == false ]]
+  ); then
+    pass "git_state: detached HEAD → detached@<sha>"
+  else
+    fail "git_state: detached HEAD" "expected detached@* and no upstream"
+  fi
+
+  # behind upstream → upstream=true, ahead=0, behind=1
+  if (
+    rem="$TMPDIR_BASE/brem.git"; git init -q --bare "$rem"
+    a="$TMPDIR_BASE/ba"; git clone -q "$rem" "$a"
+    git -C "$a" config user.email t@t; git -C "$a" config user.name t
+    git -C "$a" config commit.gpgsign false; git -C "$a" config core.hooksPath /dev/null
+    echo a > "$a/f"; git -C "$a" add f; git -C "$a" commit -q -m c1 --no-verify
+    git -C "$a" push -qu origin HEAD
+    b="$TMPDIR_BASE/bb"; git clone -q "$rem" "$b"
+    git -C "$b" config user.email t@t; git -C "$b" config user.name t
+    git -C "$b" config commit.gpgsign false; git -C "$b" config core.hooksPath /dev/null
+    echo b >> "$b/f"; git -C "$b" add f; git -C "$b" commit -q -m c2 --no-verify
+    git -C "$b" push -q origin HEAD
+    git -C "$a" fetch -q
+    git_state "$a"
+    [[ "$GIT_STATE_UPSTREAM" == true && "$GIT_STATE_AHEAD" == "0" && "$GIT_STATE_BEHIND" == "1" ]]
+  ); then
+    pass "git_state: behind upstream → ahead=0, behind=1"
+  else
+    fail "git_state: behind upstream" "expected ahead=0 behind=1"
   fi
 else
   printf "  SKIP  git_state (git not available)\n"

--- a/scripts/tests/test_status_helpers.sh
+++ b/scripts/tests/test_status_helpers.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# test_status_helpers.sh — unit tests for status_helpers.sh
+# Usage: bash scripts/tests/test_status_helpers.sh
+# shellcheck disable=SC1091,SC2030,SC2031,SC2034  # dynamic source; intentional subshell scoping; vars used by sourced fns
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() {
+  TESTS_PASSED=$(( TESTS_PASSED + 1 ))
+  TESTS_RUN=$(( TESTS_RUN + 1 ))
+  printf "  PASS  %s\n" "$1"
+}
+
+fail() {
+  TESTS_FAILED=$(( TESTS_FAILED + 1 ))
+  TESTS_RUN=$(( TESTS_RUN + 1 ))
+  printf "  FAIL  %s — %s\n" "$1" "$2"
+}
+
+TMPDIR_BASE=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+source "$SCRIPT_DIR/../lib/status_helpers.sh"
+
+# ── read_kv_value ─────────────────────────────────────────────────────────────
+echo ""
+echo "=== read_kv_value ==="
+
+SF="$TMPDIR_BASE/update.status"
+cat > "$SF" <<'EOF'
+# last run summary
+last_run=2026-06-16T03:00:00Z
+status=failure
+failed_steps=Homebrew, Rust
+duration_seconds=42
+EOF
+
+if [[ "$(read_kv_value "$SF" last_run)" == "2026-06-16T03:00:00Z" ]]; then
+  pass "read_kv_value: last_run"
+else
+  fail "read_kv_value: last_run" "value mismatch"
+fi
+
+if [[ "$(read_kv_value "$SF" status)" == "failure" ]]; then
+  pass "read_kv_value: status"
+else
+  fail "read_kv_value: status" "value mismatch"
+fi
+
+if [[ "$(read_kv_value "$SF" failed_steps)" == "Homebrew, Rust" ]]; then
+  pass "read_kv_value: value with spaces/commas preserved"
+else
+  fail "read_kv_value: failed_steps" "value mismatch"
+fi
+
+if [[ -z "$(read_kv_value "$SF" missing_key)" ]]; then
+  pass "read_kv_value: absent key → empty"
+else
+  fail "read_kv_value: absent key" "expected empty"
+fi
+
+if [[ -z "$(read_kv_value "$TMPDIR_BASE/does-not-exist" status)" ]]; then
+  pass "read_kv_value: missing file → empty"
+else
+  fail "read_kv_value: missing file" "expected empty"
+fi
+
+printf 'status=success\nstatus=failure\n' > "$TMPDIR_BASE/last.status"
+if [[ "$(read_kv_value "$TMPDIR_BASE/last.status" status)" == "failure" ]]; then
+  pass "read_kv_value: last assignment wins"
+else
+  fail "read_kv_value: last assignment" "expected failure"
+fi
+
+# ── git_state ─────────────────────────────────────────────────────────────────
+echo ""
+echo "=== git_state ==="
+
+if command -v git &>/dev/null; then
+  _mkrepo() {
+    local r="$1"
+    mkdir -p "$r"
+    git -C "$r" init -q
+    git -C "$r" config user.email t@t
+    git -C "$r" config user.name t
+    git -C "$r" config commit.gpgsign false
+    git -C "$r" config core.hooksPath /dev/null
+  }
+
+  # non-git directory → defaults
+  if (
+    d="$TMPDIR_BASE/nogit"; mkdir -p "$d"
+    git_state "$d"
+    [[ -z "$GIT_STATE_BRANCH" && "$GIT_STATE_DIRTY" == false && "$GIT_STATE_UPSTREAM" == false ]]
+  ); then
+    pass "git_state: non-git dir → defaults"
+  else
+    fail "git_state: non-git dir" "expected empty/false defaults"
+  fi
+
+  # clean repo → branch set, not dirty, no upstream
+  if (
+    r="$TMPDIR_BASE/clean"; _mkrepo "$r"
+    echo hi > "$r/f"; git -C "$r" add f; git -C "$r" commit -q -m init --no-verify
+    git_state "$r"
+    [[ -n "$GIT_STATE_BRANCH" && "$GIT_STATE_DIRTY" == false && "$GIT_STATE_UPSTREAM" == false ]]
+  ); then
+    pass "git_state: clean repo → branch set, not dirty"
+  else
+    fail "git_state: clean repo" "unexpected state"
+  fi
+
+  # dirty repo → dirty true
+  if (
+    r="$TMPDIR_BASE/dirty"; _mkrepo "$r"
+    echo hi > "$r/f"; git -C "$r" add f; git -C "$r" commit -q -m init --no-verify
+    echo more >> "$r/f"
+    git_state "$r"
+    [[ "$GIT_STATE_DIRTY" == true ]]
+  ); then
+    pass "git_state: dirty repo → dirty=true"
+  else
+    fail "git_state: dirty repo" "expected dirty=true"
+  fi
+
+  # ahead of upstream → upstream=true, ahead=1, behind=0
+  if (
+    rem="$TMPDIR_BASE/rem.git"; git init -q --bare "$rem"
+    r="$TMPDIR_BASE/clone"; git clone -q "$rem" "$r"
+    git -C "$r" config user.email t@t
+    git -C "$r" config user.name t
+    git -C "$r" config commit.gpgsign false
+    git -C "$r" config core.hooksPath /dev/null
+    echo a > "$r/f"; git -C "$r" add f; git -C "$r" commit -q -m c1 --no-verify
+    git -C "$r" push -qu origin HEAD
+    echo b >> "$r/f"; git -C "$r" commit -q -am c2 --no-verify
+    git_state "$r"
+    [[ "$GIT_STATE_UPSTREAM" == true && "$GIT_STATE_AHEAD" == "1" && "$GIT_STATE_BEHIND" == "0" ]]
+  ); then
+    pass "git_state: ahead of upstream → ahead=1, behind=0"
+  else
+    fail "git_state: ahead of upstream" "expected ahead=1 behind=0"
+  fi
+else
+  printf "  SKIP  git_state (git not available)\n"
+fi
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────"
+printf "  %d tests: %d passed, %d failed\n" "$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+echo "─────────────────────────────────────"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+  exit 1
+fi


### PR DESCRIPTION
## Summary
Adds `scripts/status.sh` (Phase 1 of the roadmap): a fast, read-only snapshot of dotfiles health. It surfaces two things at a glance without changing anything:

1. **Repo git state** — path, branch, clean/uncommitted, and ahead/behind vs upstream.
2. **Last `update.sh` result** — parsed from `logs/update.status` (which `update.sh` already writes on every run): timestamp, success/failure, failed steps, and duration. On failure it points at `logs/update.log`; if no status file exists yet it prints a hint to run/schedule updates.

`--verify` additionally runs the full `verify.sh`; `--help` shows usage. Aliased as `dotstatus`.

## Why
`update.sh` already records run results to `logs/update.status`, but nothing surfaced them. This makes the scheduled-update health (and repo state) discoverable in one command, building on existing observability rather than duplicating it.

## Organization
Everything lives under `scripts/` to keep the repo root limited to the four canonical entry points (`bootstrap/install/update/verify`):
- `scripts/status.sh` — the command (executable)
- `scripts/lib/status_helpers.sh` — `read_kv_value` + `git_state` (pure, side-effect-free)
- `scripts/tests/test_status_helpers.sh` — unit tests
- `home/zshrc` — `dotstatus` alias; docs in `README.md` and `scripts/README.md`

## Testing
- `scripts/tests/test_status_helpers.sh`: 10 cases pass (`read_kv_value` present/spaces/absent/missing/last-wins; `git_state` non-git/clean/dirty/ahead-of-upstream). Auto-discovered by `test-bootstrap.yml`.
- shellcheck `-S warning` clean; `bash -n` + `zsh -n` (for the new alias) clean.
- Live runs verified: no-status hint, seeded-success, and `--help`. Fixed a color-rendering bug found during validation (ANSI codes must be in the printf format string, not a `%s` arg).

## Links
- Plan: [Dotfiles Roadmap & Implementation Plan](https://app.warp.dev/drive/notebook/wPaZJANETXUVcedpLpANGv)
- Conversation: https://app.warp.dev/conversation/506da428-e423-49a0-aa5b-c240ff2f199e

Co-Authored-By: Oz <oz-agent@warp.dev>
