### PR TITLE
Add Ghostty as preferred terminal (config + install wiring)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -74,6 +74,7 @@ cask "raycast"             # launcher, clipboard history, window management
 cask "visual-studio-code"  # editor
 cask "postgres-app"        # Postgres.app — PostgreSQL with a macOS GUI
 cask "dbeaver-community"   # universal database GUI (Postgres, MySQL, SQLite, etc.)
-cask "hyper"               # terminal built on web technologies (Tokyo Night theme configured in hyper.js)
+cask "ghostty"             # preferred terminal — GPU-accelerated, native macOS (config in config/ghostty/config)
+cask "hyper"               # fallback terminal built on web technologies (Tokyo Night theme configured in hyper.js)
 cask "github"              # GitHub Desktop — GUI for Git and GitHub
 cask "flux"                # f.lux — adjusts screen color temperature based on time of day to reduce eye strain

--- a/README.md
+++ b/README.md
@@ -159,7 +159,8 @@ To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
 | `home/gitconfig` | `~/.gitconfig` _(include)_ | Git defaults, delta pager, SSH signing — loaded via a thin `~/.gitconfig` (not a symlink) so `git config --global` / tool writes stay out of the repo |
 | `home/gitignore_global` | `~/.gitignore_global` | Global ignores — macOS, editors, Java, Go |
 | `home/tmux.conf` | `~/.tmux.conf` | tmux — `C-a` prefix, vim keys, TPM plugins |
-| `home/hyper.js` | `~/.hyper.js` | Hyper — Tokyo Night theme, JetBrains Mono |
+| `config/ghostty/config` | `~/.config/ghostty/config` | **Ghostty (preferred terminal)** — Tokyo Night, JetBrains Mono Nerd Font |
+| `home/hyper.js` | `~/.hyper.js` | Hyper _(fallback terminal)_ — Tokyo Night theme, JetBrains Mono |
 | `config/starship.toml` | `~/.config/starship.toml` | Starship prompt config |
 | `config/mise.toml` | `~/.config/mise/config.toml` | Global runtime versions (Ruby, Node, Java, Python, Go) |
 | `config/direnvrc` | `~/.config/direnv/direnvrc` | Shared `layout python` / `layout node` helpers |
@@ -242,6 +243,8 @@ Quick reference — [full descriptions, rationale, and usage in docs/tools.md](d
 
 | App | What it does |
 |-----|-------------|
+| [Ghostty](https://ghostty.org) | Preferred terminal — GPU-accelerated, native macOS; Tokyo Night + JetBrains Mono Nerd Font (`config/ghostty/config`) |
+| [Hyper](https://hyper.is) | Fallback terminal — kept installed during the Ghostty transition (`home/hyper.js`) |
 | [Raycast](https://raycast.com) | Launcher, clipboard history, window management — replaces Spotlight |
 | [Insomnia](https://insomnia.rest) | GUI REST/GraphQL client — API design, collections, team sharing |
 | [OrbStack](https://orbstack.dev) | Docker Desktop replacement — starts in <1s, lower RAM/CPU |

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -1,0 +1,57 @@
+# Ghostty — terminal emulator config
+# Symlinked to ~/.config/ghostty/config by install.sh (see config/symlinks.map).
+# Validate after editing:  ghostty +validate-config
+# Mirrors the Tokyo Night + JetBrains Mono Nerd Font setup from home/hyper.js so
+# the look stays consistent while Ghostty is the preferred terminal.
+
+# ── Font ──────────────────────────────────────────────────────────────────────
+font-family = JetBrainsMono Nerd Font
+font-size = 14
+# Keep programming ligatures (Hyper had disableLigatures = false)
+font-feature = +calt
+font-feature = +liga
+
+# ── Theme (Tokyo Night — matches home/hyper.js) ─────────────────────────────────
+background = 1a1b26
+foreground = c0caf5
+
+selection-background = 33467c
+selection-foreground = c0caf5
+
+# Standard Tokyo Night 16-color ANSI palette
+palette = 0=#15161e
+palette = 1=#f7768e
+palette = 2=#9ece6a
+palette = 3=#e0af68
+palette = 4=#7aa2f7
+palette = 5=#bb9af7
+palette = 6=#7dcfff
+palette = 7=#a9b1d6
+palette = 8=#414868
+palette = 9=#f7768e
+palette = 10=#9ece6a
+palette = 11=#e0af68
+palette = 12=#7aa2f7
+palette = 13=#bb9af7
+palette = 14=#7dcfff
+palette = 15=#c0caf5
+
+# ── Cursor ──────────────────────────────────────────────────────────────────────
+cursor-style = block
+cursor-style-blink = true
+cursor-color = c0caf5
+
+# ── Window ──────────────────────────────────────────────────────────────────────
+# Hyper used padding: '10px 14px' (vertical horizontal)
+window-padding-x = 14
+window-padding-y = 10
+window-padding-balance = true
+mouse-hide-while-typing = true
+
+# ── macOS ──────────────────────────────────────────────────────────────────────
+# Treat the left Option key as Alt so meta keybindings (e.g. word motions) work.
+macos-option-as-alt = left
+
+# ── Shell ──────────────────────────────────────────────────────────────────────
+# Default shell is zsh on this machine; Ghostty auto-detects shell integration.
+shell-integration = zsh

--- a/config/symlinks.map
+++ b/config/symlinks.map
@@ -32,3 +32,4 @@ home/ssh_config        .ssh/config
 config/starship.toml   .config/starship.toml
 config/direnvrc        .config/direnv/direnvrc
 config/mise.toml       .config/mise/config.toml
+config/ghostty/config  .config/ghostty/config


### PR DESCRIPTION
## Summary
Adds Ghostty as the preferred terminal emulator while keeping Hyper installed as a fallback during the transition. The Ghostty config mirrors the existing Tokyo Night + JetBrains Mono Nerd Font look so the experience stays consistent.

## Changes
- **`config/ghostty/config`** (new): Tokyo Night palette, `JetBrainsMono Nerd Font` @ 14, ligatures, block/blinking cursor, padding mirroring `home/hyper.js`, `macos-option-as-alt = left`, zsh shell integration.
- **`Brewfile`**: add `cask "ghostty"`; relabel `cask "hyper"` as fallback.
- **`config/symlinks.map`**: symlink `config/ghostty/config` → `~/.config/ghostty/config` (picked up automatically by `install.sh`, `verify.sh`, `bootstrap --dry-run`, and CI).
- **`README.md`**: document Ghostty as the preferred terminal in the dotfiles + Apps tables; mark Hyper as fallback.

## Testing
- Installed via `brew install --cask ghostty` (Ghostty 1.3.1).
- Symlinked the config and ran `ghostty +validate-config` → passed.
- gitleaks pre-commit hook passed on commit.

## Notes
- Hyper is intentionally left installed as a fallback (per the task's "do not remove Hyper yet" step).
- A `ghostty` shell alias was added to `~/.zshrc.local` (machine-specific, not committed).
- Manual visual checklist (fonts, Nerd Font icons, tmux colors, Starship, copy/paste, Option/Alt, splits, scrolling) remains to be done after launching the app.

🔗 Warp conversation: https://app.warp.dev/conversation/d24aae16-820a-4832-95cf-d25d2996ab22

Co-Authored-By: Oz <oz-agent@warp.dev>