### PR TITLE
chore: add GitHub PR and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,28 @@
+---
+name: Bug report
+about: Something in the dotfiles isn't working as expected
+title: "[bug] "
+labels: bug
+---
+
+## What happened
+<!-- The behavior you saw. -->
+
+## Expected
+<!-- What you expected instead. -->
+
+## Steps to reproduce
+1.
+2.
+
+## Environment
+- macOS version:
+- Shell (zsh / bash):
+- Apple Silicon or Intel:
+- Command involved (e.g. `bootstrap.sh`, `update.sh`, `verify.sh`):
+
+## Diagnostics
+<!-- Paste relevant output. -->
+- `bash ~/dotfiles/scripts/status.sh`:
+- `bash ~/dotfiles/verify.sh` (if relevant):
+- `logs/update.status` / `logs/update.log` (for update issues):

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Usage & setup docs
+    url: https://github.com/bradbergeron-us/dotfiles#readme
+    about: Check the README and docs/ before filing — many questions are answered there.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest a tool, config, or workflow improvement
+title: "[feature] "
+labels: enhancement
+---
+
+## Problem / motivation
+<!-- What's missing or painful today? -->
+
+## Proposed change
+<!-- The tool, config, or script change you'd like. -->
+
+## Alternatives considered
+<!-- Other approaches you weighed. -->
+
+## Additional context
+<!-- Does it fit the macOS-only scope? Personal vs work machine? Profile-specific? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+<!-- What does this change, and why? -->
+
+## Type
+- [ ] Feature
+- [ ] Fix
+- [ ] Refactor / chore
+- [ ] Docs
+
+## Validation
+<!-- Tick what you ran — see CONTRIBUTING.md "Before you commit". -->
+- [ ] `shellcheck -S warning` on changed bash; `zsh -n` on changed zsh files (`install.sh`, `home/zshrc`, …)
+- [ ] Ran the relevant `scripts/tests/test_*.sh`
+- [ ] Exercised install/verify against an isolated `HOME=$(mktemp -d)` (if behavior changed)
+
+## Checklist
+- [ ] New tracked dotfile? Added a line to `config/symlinks.map` and a row to the README table
+- [ ] Changed a real `bootstrap.sh` step? Updated its `--dry-run` preview in `scripts/lib/dryrun_helpers.sh`
+- [ ] Updated docs (`README.md` / `docs/`) and the `CHANGELOG.md` `[Unreleased]` section as needed
+- [ ] No secrets or machine-specific values committed (gitleaks runs in CI and pre-commit)
+
+## Notes
+<!-- Links, screenshots, or follow-ups. -->


### PR DESCRIPTION
## Summary
Adds GitHub PR and issue templates (Phase 1 of the roadmap) so contributions follow the repo's existing conventions.

- **`.github/pull_request_template.md`** — short, aligned with `CONTRIBUTING.md` "Before you commit": Summary, Type, Validation (`shellcheck -S warning`, `zsh -n`, `scripts/tests/test_*.sh`, isolated-`HOME`), and a Checklist (new dotfile → `config/symlinks.map` + README row, `bootstrap.sh` step → `--dry-run` preview parity, docs + `CHANGELOG.md` `[Unreleased]`, no secrets).
- **`.github/ISSUE_TEMPLATE/bug_report.md`** — repro + environment + diagnostics (nudges `status.sh`/`verify.sh`/`logs/`).
- **`.github/ISSUE_TEMPLATE/feature_request.md`** — motivation/proposal with a macOS-only/profile scope prompt.
- **`.github/ISSUE_TEMPLATE/config.yml`** — keeps blank issues enabled and adds a README contact link.

## Notes
- Docs/config-only; no scripts touched.
- Verified the new files are tracked (not caught by the `*.*/` ignore rule, since `!.github/` re-includes them).

## Links
- Plan: [Dotfiles Roadmap & Implementation Plan](https://app.warp.dev/drive/notebook/wPaZJANETXUVcedpLpANGv)
- Conversation: https://app.warp.dev/conversation/506da428-e423-49a0-aa5b-c240ff2f199e

Co-Authored-By: Oz <oz-agent@warp.dev>
