### PR TITLE
feat(nvim): minimal dependency-free Neovim baseline

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -39,6 +39,11 @@ brew "rustup"         # Rust toolchain manager — bootstrap.sh runs rustup-init
 brew "ruff"           # extremely fast Python linter and formatter (from Astral, same team as uv)
 
 # ------------------
+# Editor
+# ------------------
+brew "neovim"         # terminal editor — dependency-free baseline config in config/nvim/init.lua
+
+# ------------------
 # Terminal multiplexer
 # ------------------
 brew "tmux"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Neovim baseline: `config/nvim/init.lua` (symlinked to `~/.config/nvim/init.lua`) plus `neovim` in the `Brewfile`. Dependency-free defaults — Space leader, line numbers, 2-space indent, smart-case search, system clipboard, readable diagnostics, and highlight-on-yank.
+
 ## [1.0.0] - 2026-06-16
 
 First tagged release. Captures the matured macOS dotfiles setup: a one-command

--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ To re-symlink without upgrading packages: `zsh ~/dotfiles/install.sh`
 | `home/pryrc` | `~/.pryrc` | Pry REPL defaults |
 | `home/psqlrc` | `~/.psqlrc` | psql defaults — `\x auto`, `\timing`, per-DB history |
 | `home/editorconfig` | `~/.editorconfig` | Global EditorConfig fallback |
+| `config/nvim/init.lua` | `~/.config/nvim/init.lua` | Neovim — dependency-free baseline (Space leader, 2-space indent, diagnostics) |
 | `vscode/settings.json` | `~/Library/.../Code/User/settings.json` | VS Code settings |
 | `vscode/extensions.txt` | _(auto-installed)_ | Core VS Code extensions |
 | `Brewfile` | _(used by bootstrap)_ | All Homebrew packages and casks |
@@ -252,6 +253,7 @@ Quick reference — [full descriptions, rationale, and usage in docs/tools.md](d
 | [Insomnia](https://insomnia.rest) | GUI REST/GraphQL client — API design, collections, team sharing |
 | [OrbStack](https://orbstack.dev) | Docker Desktop replacement — starts in <1s, lower RAM/CPU |
 | [VS Code](https://code.visualstudio.com) | Editor — settings and extensions tracked in `vscode/` |
+| [Neovim](https://neovim.io) | Terminal editor — dependency-free baseline in `config/nvim/init.lua` |
 | [Postgres.app](https://postgresapp.com) | PostgreSQL with a macOS GUI |
 | [DBeaver](https://dbeaver.io) | Universal database GUI |
 

--- a/config/nvim/init.lua
+++ b/config/nvim/init.lua
@@ -1,0 +1,71 @@
+-- init.lua — minimal, dependency-free Neovim baseline (managed by dotfiles).
+--
+-- No plugin manager and no external plugins, so it works on any fresh machine
+-- with just Neovim installed. Layer machine-specific config under
+-- ~/.config/nvim/ (e.g. a lua/ directory or a file you source) — that is not
+-- tracked by this repo.
+
+-- Leader keys (set before any mappings).
+vim.g.mapleader = " "
+vim.g.maplocalleader = " "
+
+local opt = vim.opt
+
+-- UI
+opt.number = true
+opt.relativenumber = true
+opt.cursorline = true
+opt.signcolumn = "yes"      -- avoid text shifting when signs appear
+opt.termguicolors = true    -- 24-bit color (diagnostics, themes)
+opt.scrolloff = 5
+opt.wrap = false
+opt.colorcolumn = "100"
+opt.mouse = "a"
+
+-- Indentation — 2 spaces, expand tabs
+opt.expandtab = true
+opt.shiftwidth = 2
+opt.tabstop = 2
+opt.softtabstop = 2
+opt.smartindent = true
+
+-- Search — case-insensitive unless the query has a capital
+opt.ignorecase = true
+opt.smartcase = true
+opt.hlsearch = true
+opt.incsearch = true
+
+-- System clipboard integration (uses pbcopy/pbpaste on macOS when present)
+opt.clipboard = "unnamedplus"
+
+-- Files / persistence
+opt.swapfile = false
+opt.backup = false
+opt.undofile = true         -- persistent undo across sessions
+opt.updatetime = 300
+
+-- Splits open where you expect
+opt.splitright = true
+opt.splitbelow = true
+
+-- Core mappings
+local map = vim.keymap.set
+map("n", "<leader>w", "<cmd>write<cr>", { desc = "Save file" })
+map("n", "<leader>q", "<cmd>quit<cr>", { desc = "Quit window" })
+map("n", "<Esc>", "<cmd>nohlsearch<cr>", { desc = "Clear search highlight" })
+
+-- Readable diagnostics without any colorscheme/plugin dependency
+vim.diagnostic.config({
+  virtual_text = true,
+  severity_sort = true,
+  float = { border = "rounded" },
+})
+
+-- Briefly highlight yanked text (built-in; vim.hl on 0.11+, vim.highlight before)
+vim.api.nvim_create_autocmd("TextYankPost", {
+  desc = "Highlight on yank",
+  callback = function()
+    local hl = vim.hl or vim.highlight
+    hl.on_yank({ timeout = 150 })
+  end,
+})

--- a/config/symlinks.map
+++ b/config/symlinks.map
@@ -33,3 +33,4 @@ config/starship.toml   .config/starship.toml
 config/direnvrc        .config/direnv/direnvrc
 config/mise.toml       .config/mise/config.toml
 config/ghostty/config  .config/ghostty/config
+config/nvim/init.lua   .config/nvim/init.lua

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -178,6 +178,13 @@ git commit --no-verify         # skip hooks (use sparingly)
 
 ---
 
+## Editor
+
+### [Neovim](https://neovim.io)
+A hyperextensible, Vim-based terminal editor. This repo ships a **dependency-free baseline** at `config/nvim/init.lua` (symlinked to `~/.config/nvim/init.lua`): no plugin manager and no external plugins, so it works on any fresh machine with just Neovim installed. It sets sensible defaults — a Space leader, line numbers (relative + absolute), 2-space indentation, smart-case search, system-clipboard integration, `termguicolors`, readable diagnostics, and highlight-on-yank — plus a few core mappings (`<leader>w` write, `<leader>q` quit, `<Esc>` clears search highlight). Layer machine-specific config under `~/.config/nvim/` (e.g. a `lua/` directory), which is not tracked here.
+
+---
+
 ## tmux
 
 ### [tmux](https://github.com/tmux/tmux)


### PR DESCRIPTION
## Summary
Adds a minimal, **dependency-free** Neovim baseline (final Phase 1 item) so a fresh machine gets a sane terminal editor with no plugin manager or external plugins.

- **`config/nvim/init.lua`** (new) — Space leader, absolute+relative line numbers, 2-space indent, smart-case search, system-clipboard integration, persistent undo, `termguicolors`, readable diagnostics, highlight-on-yank, and core mappings (`<leader>w` write, `<leader>q` quit, `<Esc>` clears search highlight). Uses a `vim.hl`/`vim.highlight` guard for cross-version compatibility.
- **`config/symlinks.map`** — `config/nvim/init.lua → ~/.config/nvim/init.lua` (auto-covered by install/verify/dry-run + the CI install-smoke job).
- **`Brewfile`** — new `# Editor` section with `brew "neovim"` so the config is usable after bootstrap.
- **Docs** — README Dotfiles table + Apps row, a `## Editor` section in `docs/tools.md`, and a `CHANGELOG.md` `[Unreleased]` entry.

## Testing
- `brew bundle list --all --file=Brewfile` parses (neovim present).
- `install.sh` against an isolated `HOME` creates the `~/.config/nvim/init.lua` symlink (CI install-smoke verifies this too).
- Note: `nvim`/`lua` aren't installed on the dev box yet (neovim is newly added here), so the Lua wasn't headless-checked locally; it uses only stable built-in APIs.

## Links
- Plan: [Dotfiles Roadmap & Implementation Plan](https://app.warp.dev/drive/notebook/wPaZJANETXUVcedpLpANGv)
- Conversation: https://app.warp.dev/conversation/506da428-e423-49a0-aa5b-c240ff2f199e

Co-Authored-By: Oz <oz-agent@warp.dev>
