### PR TITLE
feat(profiles): profile-aware symlinks (PR 2.2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,28 +84,32 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Run install.sh against temp HOME
+      - name: Run install.sh against temp HOME (profile-aware)
         run: |
+          # Shared verifier: every map record must be linked iff it applies to
+          # PROFILE (per profile_includes + the optional tag column).
+          # shellcheck source=scripts/lib/profile_helpers.sh
+          source scripts/lib/profile_helpers.sh
+          verify_links() {
+            local h="$1" prof="$2" src dest tags
+            while read -r src dest tags; do
+              [[ -z "$src" || "$src" == \#* ]] && continue
+              if profile_includes "$prof" "${tags:-}"; then
+                if [[ -L "$h/$dest" ]]; then echo "OK         $dest"; else echo "MISSING    $dest (expected for $prof)" && return 1; fi
+              else
+                if [[ -e "$h/$dest" || -L "$h/$dest" ]]; then echo "UNEXPECTED $dest (should be skipped for $prof)" && return 1; else echo "skip       $dest (not in $prof)"; fi
+              fi
+            done < config/symlinks.map
+            return 0
+          }
+
+          # --- Default profile (personal): full set, same as before profiles ---
           export HOME=$(mktemp -d)
           echo "Isolated HOME: $HOME"
           zsh install.sh
           echo ""
-          echo "--- Verifying symlinks ---"
-
-          # Verify every destination in the manifest is a symlink. The manifest
-          # (config/symlinks.map) is the single source of truth install.sh links
-          # from, so this list can never drift from what install.sh creates.
-          while read -r src dest; do
-            [[ -z "$src" || "$src" == \#* ]] && continue
-            if [[ -L "$HOME/$dest" ]]; then
-              echo "OK  $dest"
-            else
-              echo "MISSING  $dest" && exit 1
-            fi
-          done < config/symlinks.map
-
-          echo ""
-          echo "All symlinks verified."
+          echo "--- Verifying symlinks (personal) ---"
+          verify_links "$HOME" personal
 
           echo ""
           echo "--- Verifying ~/.gitconfig is a thin include (not a symlink) ---"
@@ -130,11 +134,23 @@ jobs:
             echo "FAIL  second run did not report '0 backed up'" && exit 1
           fi
 
+          # --- minimal profile: GUI-tagged links must be skipped ---
           echo ""
-          echo "--- Residue: no publisher.extension files created in the repo dir ---"
-          # The original bug left empty VS Code extension-id files (e.g.
-          # ms-python.python) at the repo root. install.sh must not create or modify
-          # anything tracked here, so the working tree must stay clean after running.
+          echo "--- Verifying minimal profile skips gui-tagged links ---"
+          MIN_HOME=$(mktemp -d)
+          HOME="$MIN_HOME" DOTFILES_PROFILE=minimal zsh install.sh
+          verify_links "$MIN_HOME" minimal
+          for gui_dest in .hyper.js .config/ghostty/config; do
+            if [[ -e "$MIN_HOME/$gui_dest" || -L "$MIN_HOME/$gui_dest" ]]; then
+              echo "FAIL  $gui_dest should be skipped on minimal" && exit 1
+            fi
+          done
+          echo "OK  gui-tagged links skipped on minimal"
+
+          echo ""
+          echo "--- Residue: no files created/modified in the repo dir ---"
+          # install.sh must not create or modify anything tracked here, so the
+          # working tree must stay clean after running.
           residue=$(git status --porcelain --untracked-files=all)
           if [[ -n "$residue" ]]; then
             echo "FAIL  install.sh created/modified files in the repo dir:"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ Because the helpers are side-effect-free, tests exercise them directly against t
 The dotfile→destination mapping is a single source of truth in `config/symlinks.map`; `install.sh`, `verify.sh`, `bootstrap.sh --dry-run`, and the CI install-smoke job all read it. To track a new dotfile:
 
 1. Add the file to the repo (`home/`, or `config/` for XDG configs).
-2. **`config/symlinks.map`** — add one `src  dest` line (src relative to the repo root, dest relative to `$HOME`). Every consumer picks it up automatically — no other script or workflow needs editing.
+2. **`config/symlinks.map`** — add one `src  dest [tags]` line (src relative to the repo root, dest relative to `$HOME`; an optional comma-separated profile-tag column — e.g. `gui` for GUI-only configs — controls which profiles get the link, see `scripts/lib/profile_helpers.sh`). Every consumer picks it up automatically — no other script or workflow needs editing.
 3. **`README.md`** — add a row to the Dotfiles table (human-readable reference).
 
 Non-symlink setup (the thin `~/.gitconfig` include, the `~/.config/git/local.gitconfig` seed, the global pre-commit hook, and VS Code settings/extensions) is intentionally bespoke in `install.sh` and is deliberately not part of the manifest.

--- a/config/symlinks.map
+++ b/config/symlinks.map
@@ -1,8 +1,12 @@
 # symlinks.map — single source of truth for tracked dotfile symlinks.
 #
-# One record per line:  <src>  <dest>
+# One record per line:  <src>  <dest>  [tags]
 #   src   path relative to the dotfiles repo root (DOTFILES_DIR)
 #   dest  path relative to $HOME
+#   tags  optional, comma-separated profile tags controlling which profiles get
+#         the link (see scripts/lib/profile_helpers.sh: profile_includes).
+#         Omit/blank = all profiles. `gui` = personal+work (skipped on
+#         minimal/server); `work` = work only; a profile name = that profile.
 # Columns are whitespace-separated; blank lines and # comments are ignored.
 #
 # Consumed by install.sh (creates the links), verify.sh (checks them),
@@ -18,7 +22,7 @@
 home/zshrc             .zshrc
 home/zprofile          .zprofile
 home/tmux.conf          .tmux.conf
-home/hyper.js          .hyper.js
+home/hyper.js          .hyper.js              gui
 home/gitignore_global  .gitignore_global
 home/gemrc             .gemrc
 home/irbrc             .irbrc
@@ -32,5 +36,5 @@ home/ssh_config        .ssh/config
 config/starship.toml   .config/starship.toml
 config/direnvrc        .config/direnv/direnvrc
 config/mise.toml       .config/mise/config.toml
-config/ghostty/config  .config/ghostty/config
+config/ghostty/config  .config/ghostty/config  gui
 config/nvim/init.lua   .config/nvim/init.lua

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 BACKUP_DIR="$HOME/.dotfiles_backup/$(date +%Y%m%d_%H%M%S)"
 
 # Counters
-typeset -i _linked=0 _current=0 _backed=0
+typeset -i _linked=0 _current=0 _backed=0 _skipped=0
 
 info()    { print -P "%F{cyan}  → %f$*"; }
 success() { print -P "%F{green}  ✓ %f$*"; }
@@ -45,9 +45,24 @@ echo "  ────────────────────────
 # (install.sh creates them; verify.sh, bootstrap --dry-run, and CI read the
 # same file, so the mapping lives in exactly one place.)
 SYMLINK_MAP="$DOTFILES_DIR/config/symlinks.map"
+
+# Resolve the active profile so only records that apply to it are linked. Sourcing
+# is side-effect-free. With nothing set this resolves to `personal`, which
+# includes every tag in use today (gui + core) — i.e. the same set as before
+# profiles existed (plain `zsh install.sh` still links everything).
+# shellcheck source=scripts/lib/profile_helpers.sh
+source "$DOTFILES_DIR/scripts/lib/profile_helpers.sh"
+_PROFILE="$(current_profile)"
+info "profile   $_PROFILE"
+
 if [[ -r "$SYMLINK_MAP" ]]; then
-  while read -r src_rel dest_rel; do
+  while read -r src_rel dest_rel tags_rel; do
     [[ -z "$src_rel" || "$src_rel" == \#* ]] && continue
+    if ! profile_includes "$_PROFILE" "${tags_rel:-}"; then
+      info "skip      $dest_rel  (not in profile $_PROFILE)"
+      (( _skipped++ )) || true
+      continue
+    fi
     dest="$HOME/$dest_rel"
     mkdir -p "$(dirname "$dest")"
     symlink "$DOTFILES_DIR/$src_rel" "$dest"
@@ -134,7 +149,7 @@ fi
 
 echo ""
 echo "  ─────────────────────────────────────────────────"
-success "${_linked} linked  ·  ${_current} current  ·  ${_backed} backed up"
+success "${_linked} linked  ·  ${_current} current  ·  ${_backed} backed up  ·  ${_skipped} skipped"
 if (( _backed > 0 )); then
   backup "backups saved to ${BACKUP_DIR/$HOME/\~}"
 fi

--- a/scripts/lib/dryrun_helpers.sh
+++ b/scripts/lib/dryrun_helpers.sh
@@ -216,14 +216,18 @@ check_dotfile_symlinks() {
   dry_run_log "Run: install.sh (symlink dotfiles)"
 
   # Read tracked symlinks from config/symlinks.map (single source of truth) as
-  # "dest_abs:src_rel" entries so the comparison loop below is unchanged. Using
-  # the same manifest install.sh and verify.sh read means this preview can never
-  # drift from what is actually linked.
+  # "dest_abs:src_rel" entries so the comparison loop below is unchanged. Honor
+  # the active profile's tag filter (3rd column) exactly like install.sh so the
+  # preview matches what would actually be linked.
+  local _profile
+  _profile="$(current_profile)"
+  info "Profile: $_profile (gui-tagged links are skipped on minimal/server)"
   local -a files=()
-  local manifest="$DOTFILES_DIR/config/symlinks.map" _src _dest
+  local manifest="$DOTFILES_DIR/config/symlinks.map" _src _dest _tags
   if [[ -r "$manifest" ]]; then
-    while read -r _src _dest; do
+    while read -r _src _dest _tags; do
       [[ -z "$_src" || "$_src" == \#* ]] && continue
+      profile_includes "$_profile" "${_tags:-}" || continue
       files+=("$HOME/$_dest:$_src")
     done < "$manifest"
   fi

--- a/scripts/lib/profile_helpers.sh
+++ b/scripts/lib/profile_helpers.sh
@@ -17,11 +17,12 @@ DOTFILES_PROFILE_FILE="${DOTFILES_PROFILE_FILE:-$HOME/.config/dotfiles/profile}"
 
 # valid_profile NAME — return 0 if NAME is a known profile.
 valid_profile() {
-  local name="$1" known
-  for known in $DOTFILES_PROFILES; do
-    [[ "$name" == "$known" ]] && return 0
-  done
-  return 1
+  # `case` membership avoids splitting $DOTFILES_PROFILES, which bash splits but
+  # zsh does not — important because install.sh (zsh) sources this file.
+  case " $DOTFILES_PROFILES " in
+    *" $1 "*) return 0 ;;
+    *)        return 1 ;;
+  esac
 }
 
 # resolve_profile [FLAG] — echo the active profile, in increasing precedence:
@@ -33,14 +34,16 @@ valid_profile() {
 # through) so a typo can never select an invalid profile. Always echoes a valid
 # profile.
 resolve_profile() {
+  # if-based control flow (no bare `A && B`) so this is safe under both bash and
+  # zsh errexit — install.sh (zsh) resolves the profile via current_profile.
   local flag="${1:-}" result="$DOTFILES_DEFAULT_PROFILE" v
   if [[ -f "$DOTFILES_PROFILE_FILE" ]]; then
     v="$(tr -d '[:space:]' < "$DOTFILES_PROFILE_FILE" 2>/dev/null || true)"
-    valid_profile "$v" && result="$v"
+    if valid_profile "$v"; then result="$v"; fi
   fi
   v="${DOTFILES_PROFILE:-}"
-  [[ -n "$v" ]] && valid_profile "$v" && result="$v"
-  [[ -n "$flag" ]] && valid_profile "$flag" && result="$flag"
+  if [[ -n "$v" ]] && valid_profile "$v"; then result="$v"; fi
+  if [[ -n "$flag" ]] && valid_profile "$flag"; then result="$flag"; fi
   echo "$result"
 }
 
@@ -65,15 +68,20 @@ persist_profile() {
 #   work           -> work
 #   <profile-name> -> that profile exactly (minimal | personal | work | server)
 profile_includes() {
-  local profile="$1" tags="${2:-}" tag
+  local profile="$1" tags="${2:-}" tag rest
   [[ -z "$tags" ]] && return 0
-  tags="${tags//,/ }"  # normalize commas to spaces
-  for tag in $tags; do
+  rest="${tags//,/ }"  # normalize commas to spaces
+  # Walk tokens with parameter expansion only (no word-splitting, so this works
+  # the same in bash and zsh).
+  while [[ -n "$rest" ]]; do
+    tag="${rest%% *}"            # first token (whole string if no space)
+    if [[ "$rest" == *" "* ]]; then rest="${rest#* }"; else rest=""; fi
+    [[ -z "$tag" ]] && continue  # skip empties from repeated separators
     case "$tag" in
       core) return 0 ;;
-      gui)  [[ "$profile" == "personal" || "$profile" == "work" ]] && return 0 ;;
-      work) [[ "$profile" == "work" ]] && return 0 ;;
-      *)    [[ "$profile" == "$tag" ]] && return 0 ;;
+      gui)  if [[ "$profile" == "personal" || "$profile" == "work" ]]; then return 0; fi ;;
+      work) if [[ "$profile" == "work" ]]; then return 0; fi ;;
+      *)    if [[ "$profile" == "$tag" ]]; then return 0; fi ;;
     esac
   done
   return 1

--- a/scripts/lib/verify_helpers.sh
+++ b/scripts/lib/verify_helpers.sh
@@ -11,16 +11,21 @@
 # check_symlinks consumes. Defaults to empty so the array is always set.
 DOTFILES_SYMLINKS=()
 
-# load_symlink_map MANIFEST
-# Populates DOTFILES_SYMLINKS from a symlinks.map manifest of "src dest" records
-# (whitespace-separated; blank lines and # comments ignored). A missing manifest
-# leaves the array empty.
+# load_symlink_map MANIFEST [PROFILE]
+# Populates DOTFILES_SYMLINKS from a symlinks.map manifest of "src dest [tags]"
+# records (whitespace-separated; blank lines and # comments ignored). When
+# PROFILE is given and profile_includes is available (profile_helpers.sh
+# sourced), records whose optional tag column excludes PROFILE are skipped.
+# A missing manifest leaves the array empty.
 load_symlink_map() {
-  local manifest="$1" src dest
+  local manifest="$1" profile="${2:-}" src dest tags
   DOTFILES_SYMLINKS=()
   [[ -f "$manifest" ]] || return 0
-  while read -r src dest; do
+  while read -r src dest tags; do
     [[ -z "$src" || "$src" == \#* ]] && continue
+    if [[ -n "$profile" ]] && command -v profile_includes >/dev/null 2>&1; then
+      profile_includes "$profile" "${tags:-}" || continue
+    fi
     DOTFILES_SYMLINKS+=("$src:$dest")
   done < "$manifest"
 }

--- a/scripts/tests/test_verify_helpers.sh
+++ b/scripts/tests/test_verify_helpers.sh
@@ -192,6 +192,43 @@ else
   fail "load_symlink_map + check_symlinks end-to-end" "subshell exited non-zero"
 fi
 
+# Case 4: optional tag column + profile filtering (uses profile_helpers.sh)
+MAP_TAGGED="$TMPDIR_BASE/symlinks_tagged.map"
+cat > "$MAP_TAGGED" << 'EOF'
+home/zshrc     .zshrc
+home/hyper.js  .hyper.js   gui
+EOF
+if (
+  source "$SCRIPT_DIR/../lib/profile_helpers.sh"
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  load_symlink_map "$MAP_TAGGED" minimal
+  [[ "${#DOTFILES_SYMLINKS[@]}" -eq 1 ]] || { printf "  FAIL  minimal count: expected 1, got %s\n" "${#DOTFILES_SYMLINKS[@]}"; exit 1; }
+  [[ "${DOTFILES_SYMLINKS[0]}" == "home/zshrc:.zshrc" ]] || { printf "  FAIL  minimal kept wrong entry: %s\n" "${DOTFILES_SYMLINKS[0]}"; exit 1; }
+); then
+  pass "load_symlink_map: profile=minimal skips gui-tagged record"
+else
+  fail "load_symlink_map: profile filter (minimal)" "subshell exited non-zero"
+fi
+if (
+  source "$SCRIPT_DIR/../lib/profile_helpers.sh"
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  load_symlink_map "$MAP_TAGGED" personal
+  [[ "${#DOTFILES_SYMLINKS[@]}" -eq 2 ]] || { printf "  FAIL  personal count: expected 2, got %s\n" "${#DOTFILES_SYMLINKS[@]}"; exit 1; }
+); then
+  pass "load_symlink_map: profile=personal keeps gui-tagged record"
+else
+  fail "load_symlink_map: profile filter (personal)" "subshell exited non-zero"
+fi
+if (
+  source "$SCRIPT_DIR/../lib/verify_helpers.sh"
+  load_symlink_map "$MAP_TAGGED"
+  [[ "${#DOTFILES_SYMLINKS[@]}" -eq 2 ]] || { printf "  FAIL  no-profile count: expected 2, got %s\n" "${#DOTFILES_SYMLINKS[@]}"; exit 1; }
+); then
+  pass "load_symlink_map: no profile arg keeps all records (back-compat)"
+else
+  fail "load_symlink_map: no-profile back-compat" "subshell exited non-zero"
+fi
+
 # ── check_required_tools ────────────────────────────────────────────────────────
 echo ""
 echo "=== check_required_tools ==="

--- a/verify.sh
+++ b/verify.sh
@@ -30,6 +30,8 @@ TOTAL_STEPS=9
 source "$DOTFILES_DIR/scripts/lib/bootstrap_helpers.sh"
 # shellcheck source=scripts/lib/verify_helpers.sh
 source "$DOTFILES_DIR/scripts/lib/verify_helpers.sh"
+# shellcheck source=scripts/lib/profile_helpers.sh
+source "$DOTFILES_DIR/scripts/lib/profile_helpers.sh"
 setup_colors
 
 REQUIRED_TOOLS=(
@@ -51,11 +53,12 @@ echo "  ────────────────────────
 
 # ── 1. Symlinks ───────────────────────────────────────────────────────────
 step "🔗  Symlinks"
-load_symlink_map "$DOTFILES_DIR/config/symlinks.map"
+_profile="$(current_profile)"
+load_symlink_map "$DOTFILES_DIR/config/symlinks.map" "$_profile"
 check_symlinks "$DOTFILES_DIR" "$HOME"
 
 if [[ "$SYMLINK_BROKEN_COUNT" -eq 0 ]]; then
-  success "$SYMLINK_OK_COUNT symlinks OK"
+  success "$SYMLINK_OK_COUNT symlinks OK (profile: $_profile)"
 else
   for broken in "${SYMLINK_BROKEN_LIST[@]}"; do
     warn "$broken"


### PR DESCRIPTION
## Summary
**PR 2.2 of the Phase 2 profiles work** — the active profile now actually selects which dotfiles get linked. Builds on PR 2.1 (#48).

- **`config/symlinks.map`** — optional 3rd column of comma-separated profile tags; blank = all profiles (backward compatible). Tagged `home/hyper.js` and `config/ghostty/config` as `gui`.
- **`install.sh`** — sources `profile_helpers`, resolves the active profile, skips records whose tags exclude it (reports a `skipped` count). Plain `zsh install.sh` resolves to `personal`, which includes every tag in use today → links the full set, exactly as before.
- **`verify.sh` / `verify_helpers.sh`** — `load_symlink_map` reads the tag column and takes an optional profile; verify checks only the active profile's links and shows `… symlinks OK (profile: …)`. A no-profile call still loads everything (back-compat, keeps existing tests green).
- **`dryrun_helpers.sh`** — `bootstrap --dry-run` preview is profile-aware.
- **`profile_helpers.sh`** — made `valid_profile`/`profile_includes`/`resolve_profile` zsh-safe (case + `while` parsing, `if`-based flow) since `install.sh` (zsh) now sources them. Bash behavior unchanged.

## Behavior
- `personal`/`work` → GUI links included; `minimal`/`server` → GUI links skipped.
- Invariant preserved: with no profile selected, every entry point behaves exactly as today (`personal`).

## Testing
- shellcheck `-S warning`, `bash -n`, `zsh -n` clean.
- Unit tests: `test_verify_helpers.sh` +3 `load_symlink_map` filtering cases (now **39**); `profile_helpers` **16**.
- Live: `personal` links hyper/ghostty/zshrc; `minimal` skips the GUI configs; `verify --profile minimal` → `15 symlinks OK`; dry-run previews 17 (personal) vs 15 (minimal).
- **CI install-smoke is now profile-aware**: a `personal` run (full set) + a `minimal` run asserting GUI links are skipped. This was also required — the old `read -r src dest` would have folded the new tag column into `dest`.

## Links
- Plan: [Phase 2: Install Profiles & Modularity](https://app.warp.dev/drive/notebook/9obHEwdFdqaIo4jTEpomfH)
- Conversation: https://app.warp.dev/conversation/506da428-e423-49a0-aa5b-c240ff2f199e

Co-Authored-By: Oz <oz-agent@warp.dev>
