### PR TITLE
feat(profiles): per-profile Brewfile overlays (PR 2.3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,10 +69,15 @@ jobs:
           done
           echo "All shell files pass zsh syntax check."
 
-      - name: Validate Brewfile parses cleanly
+      - name: Validate Brewfiles parse cleanly
         # brew bundle list reads the Brewfile DSL without installing anything.
-        # A malformed entry (bad tap, typo in formula name format) will exit non-zero.
-        run: brew bundle list --all --file=Brewfile
+        # A malformed entry (bad tap, typo in formula name format) exits non-zero.
+        # Covers the core Brewfile and every profile overlay.
+        run: |
+          for bf in Brewfile Brewfile.personal Brewfile.work; do
+            echo "==> $bf"
+            brew bundle list --all --file="$bf"
+          done
 
   # ------------------------------------------------------------------
   # 3. install-smoke — run install.sh against an isolated temp $HOME

--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,12 @@
-# Brewfile — declarative Homebrew packages
-# Install everything: brew bundle
-# Install and upgrade: brew bundle --upgrade
-# Check what's missing: brew bundle check
+# Brewfile — core CLI packages (Homebrew formulae) for ALL profiles.
+#
+# Profiles layer GUI/app packages on top (see scripts/lib/profile_helpers.sh):
+#   Brewfile.personal — GUI casks, fonts, apps (personal, work)
+#   Brewfile.work     — work-only additions (work)
+# bootstrap.sh installs this core file plus the active profile's overlays;
+# `minimal`/`server` get core only. Keep GUI/cask entries OUT of this file.
+#
+# Install core: brew bundle --file=Brewfile   (check: brew bundle check)
 
 # ------------------
 # Shell & prompt
@@ -26,7 +31,6 @@ brew "git-delta"               # syntax-highlighted diffs
 brew "lazygit"                 # terminal UI for git
 brew "gh"                      # GitHub CLI
 brew "gnupg"                   # GPG for signing commits
-cask "git-credential-manager" # cross-platform credential helper — GitHub, GitHub Enterprise, Bitbucket
 
 # ------------------
 # Runtime management
@@ -64,22 +68,3 @@ brew "newman"         # CLI runner for Insomnia/Postman collections (useful in C
 brew "redis"          # in-memory data store — background jobs (Sidekiq), caching, sessions
 brew "imagemagick"    # image conversion and manipulation (resize, crop, format conversion)
 brew "pdftk-java"     # PDF toolkit — merge, split, fill forms, extract pages
-
-# ------------------
-# Fonts
-# ------------------
-cask "font-fira-code"                  # Fira Code (editor font with ligatures)
-cask "font-jetbrains-mono-nerd-font"   # JetBrains Mono with Nerd Font icons (terminal font)
-
-# ------------------
-# Apps (casks)
-# ------------------
-cask "insomnia"            # GUI REST/GraphQL client — API design, collections, team sharing
-cask "raycast"             # launcher, clipboard history, window management
-cask "visual-studio-code"  # editor
-cask "postgres-app"        # Postgres.app — PostgreSQL with a macOS GUI
-cask "dbeaver-community"   # universal database GUI (Postgres, MySQL, SQLite, etc.)
-cask "ghostty"             # preferred terminal — GPU-accelerated, native macOS (config in config/ghostty/config)
-cask "hyper"               # fallback terminal built on web technologies (Tokyo Night theme configured in hyper.js)
-cask "github"              # GitHub Desktop — GUI for Git and GitHub
-cask "flux"                # f.lux — adjusts screen color temperature based on time of day to reduce eye strain

--- a/Brewfile.personal
+++ b/Brewfile.personal
@@ -1,0 +1,27 @@
+# Brewfile.personal — GUI casks, fonts, and apps for profiles WITH a desktop
+# (personal, work). Layered on top of the core Brewfile by bootstrap.sh; skipped
+# on minimal/server. Install standalone: brew bundle --file=~/dotfiles/Brewfile.personal
+
+# ------------------
+# Git (GUI credential helper)
+# ------------------
+cask "git-credential-manager" # cross-platform credential helper — GitHub, GitHub Enterprise, Bitbucket
+
+# ------------------
+# Fonts
+# ------------------
+cask "font-fira-code"                  # Fira Code (editor font with ligatures)
+cask "font-jetbrains-mono-nerd-font"   # JetBrains Mono with Nerd Font icons (terminal font)
+
+# ------------------
+# Apps (casks)
+# ------------------
+cask "insomnia"            # GUI REST/GraphQL client — API design, collections, team sharing
+cask "raycast"             # launcher, clipboard history, window management
+cask "visual-studio-code"  # editor
+cask "postgres-app"        # Postgres.app — PostgreSQL with a macOS GUI
+cask "dbeaver-community"   # universal database GUI (Postgres, MySQL, SQLite, etc.)
+cask "ghostty"             # preferred terminal — GPU-accelerated, native macOS (config in config/ghostty/config)
+cask "hyper"               # fallback terminal built on web technologies (Tokyo Night theme configured in hyper.js)
+cask "github"              # GitHub Desktop — GUI for Git and GitHub
+cask "flux"                # f.lux — adjusts screen color temperature based on time of day to reduce eye strain

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Stored at `~/.config/dotfiles/profile`; precedence is `--profile` flag > `DOTFIL
 | `config/nvim/init.lua` | `~/.config/nvim/init.lua` | Neovim — dependency-free baseline (Space leader, 2-space indent, diagnostics) |
 | `vscode/settings.json` | `~/Library/.../Code/User/settings.json` | VS Code settings |
 | `vscode/extensions.txt` | _(auto-installed)_ | Core VS Code extensions |
-| `Brewfile` | _(used by bootstrap)_ | All Homebrew packages and casks |
+| `Brewfile` · `Brewfile.personal` · `Brewfile.work` | _(used by bootstrap)_ | Core CLI formulae + per-profile overlays (GUI casks/fonts/apps; work additions) |
 | `home/npmrc` | `~/.npmrc` | npm defaults — `save-exact`, no fund/update noise |
 | `update.sh` | _(run to update)_ | Upgrade all packages, runtimes, and gems; runs health check at end |
 | `verify.sh` | _(run to verify)_ | Health check — symlinks, missing tools, installed runtimes, stale backups |
@@ -272,14 +272,22 @@ Quick reference — [full descriptions, rationale, and usage in docs/tools.md](d
 
 ## Package management
 
+Packages are split by profile (see [Machine profile](#machine-profile)):
+
+- **`Brewfile`** — core CLI formulae, installed for every profile.
+- **`Brewfile.personal`** — GUI casks, fonts, and apps (`personal`, `work`).
+- **`Brewfile.work`** — work-only additions: Gradle, kubectl, Helm (`work`).
+
+`bootstrap.sh` installs the core file plus the active profile's overlays automatically; `minimal`/`server` get core only.
+
 ```sh
-brew bundle --file=~/dotfiles/Brewfile          # install everything
-brew bundle check --file=~/dotfiles/Brewfile    # check what's missing
+brew bundle --file=~/dotfiles/Brewfile           # core CLI tools (all profiles)
+brew bundle --file=~/dotfiles/Brewfile.personal  # GUI casks/fonts/apps (personal/work)
+brew bundle --file=~/dotfiles/Brewfile.work      # work-only additions
+brew bundle check --file=~/dotfiles/Brewfile     # check what's missing
 ```
 
-To add a package: edit `Brewfile`, run `brew bundle`. To upgrade all packages, use `update.sh` — it runs `brew upgrade` as part of the full update cycle.
-
-Work machine? Also run `brew bundle --file=~/dotfiles/Brewfile.work`.
+To add a package: put CLI formulae in `Brewfile`, GUI casks/fonts/apps in `Brewfile.personal`, then run `brew bundle`. To upgrade everything, use `update.sh`.
 
 ---
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -145,30 +145,25 @@ fi
 
 if [[ "$DRY_RUN" == true ]]; then
   dry_run_step "📦  Packages (brew bundle)"
-  check_brew_bundle "$DOTFILES_DIR/Brewfile"
+  while IFS= read -r _bf; do
+    check_brew_bundle "$_bf"
+  done < <(profile_brewfiles "$DOTFILES_PROFILE" "$DOTFILES_DIR")
 else
   step "📦  Packages (brew bundle)"
-  # Clean up any stale lock files
-  info "Preparing package installation..."
+  info "Preparing package installation for profile '$DOTFILES_PROFILE'..."
   rm -f "$DOTFILES_DIR/Brewfile.lock.json" 2>/dev/null || true
 
-  # Temporarily disable ALL error handling for brew bundle
-  # This ensures the script ALWAYS continues to the next step
-  info "Installing Homebrew packages (will adopt any existing GUI apps)..."
-  (
-    set +e
-    HOMEBREW_CASK_OPTS="--adopt" brew bundle --verbose --no-upgrade --file="$DOTFILES_DIR/Brewfile"
-    exit 0  # Force success exit code
-  ) || true
-  _brew_exit_code=$?
-
-  # Always report success and continue
-  if [[ $_brew_exit_code -eq 0 ]]; then
-    success "Brew packages installed"
-  else
-    warn "Some Brew packages may have failed — continuing with setup anyway"
-    warn "Run 'brew bundle --verbose' manually later to retry any failed packages"
-  fi
+  # Install the core Brewfile plus the active profile's overlays. Each file runs
+  # in a forced-continue subshell so a single failure never aborts bootstrap.
+  while IFS= read -r _bf; do
+    info "Installing from ${_bf##*/} (will adopt existing GUI apps)..."
+    (
+      set +e
+      HOMEBREW_CASK_OPTS="--adopt" brew bundle --verbose --no-upgrade --file="$_bf"
+      exit 0  # Force success exit code
+    ) || true
+  done < <(profile_brewfiles "$DOTFILES_PROFILE" "$DOTFILES_DIR")
+  success "Brew packages installed (profile: $DOTFILES_PROFILE)"
 fi
 
 if [[ "$DRY_RUN" == true ]]; then

--- a/docs/work-machine.md
+++ b/docs/work-machine.md
@@ -6,14 +6,22 @@ Work machines need extra tools (API clients, database CLIs, Kubernetes, Java bui
 
 ## 1. Install work-specific packages
 
-Run the base Brewfile first, then the work overlay:
+Mark the machine's profile as `work` and `bootstrap.sh` (or `update.sh`) installs the core `Brewfile` plus the `Brewfile.personal` (GUI) and `Brewfile.work` overlays automatically:
 
 ```sh
-brew bundle --file=~/dotfiles/Brewfile        # shared base (all machines)
-brew bundle --file=~/dotfiles/Brewfile.work   # work additions
+bash ~/dotfiles/scripts/profile.sh set work   # mark this machine as a work device
+# then run bootstrap, or on an existing machine bundle the files below
 ```
 
-`Brewfile.work` adds: Gradle, kubectl, and Helm. Everything else you might expect here — Insomnia, newman, Redis, and Maven — is already in the base `Brewfile` since it's useful on every machine. PostgreSQL CLI tools are intentionally excluded: Postgres.app (installed by the base Brewfile) provides them and installing `postgresql@xx` via Homebrew can cause conflicts.
+To run the bundles manually:
+
+```sh
+brew bundle --file=~/dotfiles/Brewfile           # core CLI (all profiles)
+brew bundle --file=~/dotfiles/Brewfile.personal  # GUI casks/fonts/apps
+brew bundle --file=~/dotfiles/Brewfile.work      # work additions
+```
+
+`Brewfile.work` adds: Gradle, kubectl, and Helm. Insomnia is a GUI app in `Brewfile.personal`; newman, Redis, and Maven are core CLI tools in `Brewfile`. PostgreSQL CLI tools are intentionally excluded: Postgres.app (from `Brewfile.personal`) provides them and installing `postgresql@xx` via Homebrew can cause conflicts.
 
 ---
 

--- a/scripts/lib/profile_helpers.sh
+++ b/scripts/lib/profile_helpers.sh
@@ -86,3 +86,18 @@ profile_includes() {
   done
   return 1
 }
+
+# profile_brewfiles PROFILE DOTFILES_DIR — echo the Brewfile paths to install for
+# PROFILE, one per line: the core Brewfile always, plus Brewfile.personal for GUI
+# profiles (personal/work) and Brewfile.work for work. minimal/server get core
+# only. Only files that exist are emitted.
+profile_brewfiles() {
+  local profile="$1" dir="$2"
+  printf '%s\n' "$dir/Brewfile"
+  if profile_includes "$profile" gui && [[ -f "$dir/Brewfile.personal" ]]; then
+    printf '%s\n' "$dir/Brewfile.personal"
+  fi
+  if profile_includes "$profile" work && [[ -f "$dir/Brewfile.work" ]]; then
+    printf '%s\n' "$dir/Brewfile.work"
+  fi
+}

--- a/scripts/tests/test_dryrun_helpers.sh
+++ b/scripts/tests/test_dryrun_helpers.sh
@@ -38,6 +38,10 @@ setup_colors
 STEP=0
 TOTAL_STEPS=13
 source "$SCRIPT_DIR/../lib/dryrun_helpers.sh"
+# check_dotfile_symlinks resolves the active profile (current_profile) and filters
+# records by it (profile_includes), exactly as bootstrap.sh does at runtime —
+# source profile_helpers so those functions are available to the tests too.
+source "$SCRIPT_DIR/../lib/profile_helpers.sh"
 
 # ── Shared fake dotfiles checkout ─────────────────────────────────────────────
 # check_dotfile_symlinks reads $DOTFILES_DIR/<src> only for the readlink compare,

--- a/scripts/tests/test_profile_helpers.sh
+++ b/scripts/tests/test_profile_helpers.sh
@@ -117,6 +117,34 @@ else
   fail "profile_includes: multi-tag" "unexpected matching"
 fi
 
+# ── profile_brewfiles ─────────────────────────────────────────────────────────
+echo ""
+echo "=== profile_brewfiles ==="
+BFD="$TMPDIR_BASE/bf"; mkdir -p "$BFD"
+: > "$BFD/Brewfile"; : > "$BFD/Brewfile.personal"; : > "$BFD/Brewfile.work"
+count_bf() { profile_brewfiles "$1" "$BFD" | wc -l | tr -d '[:space:]'; }
+if [[ "$(count_bf minimal)" == "1" && "$(count_bf server)" == "1" ]]; then
+  pass "profile_brewfiles: minimal/server -> core only"
+else
+  fail "profile_brewfiles: minimal/server" "expected 1 file"
+fi
+if [[ "$(count_bf personal)" == "2" ]]; then
+  pass "profile_brewfiles: personal -> core + personal"
+else
+  fail "profile_brewfiles: personal" "expected 2 files"
+fi
+if [[ "$(count_bf work)" == "3" ]]; then
+  pass "profile_brewfiles: work -> core + personal + work"
+else
+  fail "profile_brewfiles: work" "expected 3 files"
+fi
+rm -f "$BFD/Brewfile.personal" "$BFD/Brewfile.work"
+if [[ "$(count_bf work)" == "1" ]]; then
+  pass "profile_brewfiles: missing overlay files are omitted"
+else
+  fail "profile_brewfiles: missing overlays" "expected 1 file"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "─────────────────────────────────────"

--- a/verify.sh
+++ b/verify.sh
@@ -144,17 +144,27 @@ else
   WARNINGS=$(( WARNINGS + ${#DOTFILES_GIT_HEALTH_ISSUES[@]} ))
 fi
 
-# ── 8. Brewfile drift ────────────────────────────────────────────────────
+# ── 8. Brewfile drift ───────────────────────────────────
 step "🍺  Brewfile drift"
-check_brewfile_drift "$DOTFILES_DIR/Brewfile"
+# Check the core Brewfile plus the active profile's overlays.
+_drift_warn=0
+_drift_skipped=true
+while IFS= read -r _bf; do
+  check_brewfile_drift "$_bf"
+  [[ "$BREWFILE_DRIFT_SKIPPED" == "true" ]] && continue
+  _drift_skipped=false
+  if [[ "$BREWFILE_DRIFT_OK" != "true" ]]; then
+    warn "$BREWFILE_DRIFT_ISSUE"
+    _drift_warn=$(( _drift_warn + 1 ))
+  fi
+done < <(profile_brewfiles "$_profile" "$DOTFILES_DIR")
 
-if [[ "$BREWFILE_DRIFT_SKIPPED" == "true" ]]; then
+if [[ "$_drift_skipped" == "true" ]]; then
   info "brew not installed — skipping Brewfile drift check"
-elif [[ "$BREWFILE_DRIFT_OK" == "true" ]]; then
-  success "Brewfile in sync with installed packages"
+elif (( _drift_warn == 0 )); then
+  success "Brewfile(s) in sync with installed packages (profile: $_profile)"
 else
-  warn "$BREWFILE_DRIFT_ISSUE"
-  WARNINGS=$(( WARNINGS + 1 ))
+  WARNINGS=$(( WARNINGS + _drift_warn ))
 fi
 
 # ── 9. Git config include ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
**PR 2.3 of the Phase 2 profiles work** — packages are now selected per profile. Builds on PR 2.2 (#49).

- **`Brewfile`** → core CLI formulae only (all profiles).
- **`Brewfile.personal`** (new) → GUI casks, fonts, and apps (`personal`, `work`).
- **`Brewfile.work`** → unchanged (Gradle, kubectl, Helm; `work`).
- **`profile_helpers.sh`** → new `profile_brewfiles <profile> <dir>` lists the files for a profile (core always; `+personal` for personal/work; `+work` for work; `minimal`/`server` = core only).
- **`bootstrap.sh`** → the package step (real **and** `--dry-run`) installs the core file plus the active profile's overlays.
- **`verify.sh`** → the Brewfile-drift check loops over the active profile's brewfiles.
- **CI** → the Brewfile-parse job validates all three files.

## Invariant
`personal` = core (33) + `Brewfile.personal` (12) = **45 entries**, identical to today's single Brewfile — existing machines see no change. `minimal`/`server` install core only.

## Testing
- shellcheck `-S warning` + `bash -n`/`zsh -n` clean.
- Unit tests: `test_profile_helpers` **20** (incl. 4 new `profile_brewfiles` cases); `test_verify_helpers` **39**.
- All three Brewfiles parse (core 33 · personal 12 · work 3).
- `bootstrap --dry-run` selects the right files per profile: **minimal→1, personal→2, work→3**.

## Links
- Plan: [Phase 2: Install Profiles & Modularity](https://app.warp.dev/drive/notebook/9obHEwdFdqaIo4jTEpomfH)
- Conversation: https://app.warp.dev/conversation/506da428-e423-49a0-aa5b-c240ff2f199e

Co-Authored-By: Oz <oz-agent@warp.dev>
