### PR TITLE
docs: add MkDocs Material documentation site (item 9)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,9 @@ jobs:
         with:
           python-version: "3.x"
           cache: pip
+          cache-dependency-path: docs/requirements.txt
       - name: Install MkDocs Material
-        run: pip install mkdocs-material
+        run: pip install -r docs/requirements.txt
       - name: Build site
         run: mkdocs build --strict
       - name: Upload Pages artifact

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Allow only one concurrent deployment, but do not cancel in-progress PR builds.
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build (mkdocs build --strict)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+          cache: pip
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+      - name: Build site
+        run: mkdocs build --strict
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ config/git/*.gitconfig
 age-key.txt
 keys.txt
 *.dec
+
+# MkDocs build output (docs site is built in CI, never committed)
+site/

--- a/docs/DRY_RUN_AND_PREFLIGHT.md
+++ b/docs/DRY_RUN_AND_PREFLIGHT.md
@@ -211,6 +211,6 @@ Potential improvements:
 
 ## Related
 
-- [Bootstrap guide](../README.md#quick-start)
-- [Update script](../update.sh) — Keep everything current
-- [Verify script](../verify.sh) — Health check
+- [Bootstrap guide](https://github.com/bradbergeron-us/dotfiles#quick-start)
+- [Update script](https://github.com/bradbergeron-us/dotfiles/blob/main/update.sh) — Keep everything current
+- [Verify script](https://github.com/bradbergeron-us/dotfiles/blob/main/verify.sh) — Health check

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,73 @@
+# dotfiles
+
+Personal macOS dotfiles — zsh, tmux, git, and a full developer toolchain.
+
+This site documents the [`bradbergeron-us/dotfiles`](https://github.com/bradbergeron-us/dotfiles)
+repository. For the canonical, always-current overview, see the
+[README on GitHub](https://github.com/bradbergeron-us/dotfiles#readme).
+
+## Quick start
+
+```sh
+git clone https://github.com/bradbergeron-us/dotfiles.git ~/dotfiles
+bash ~/dotfiles/bootstrap.sh
+```
+
+`bootstrap.sh` runs once on a fresh Mac and handles everything: Homebrew, all
+packages, runtimes (Ruby, Node, Java, Python, Go, Rust), dotfile symlinks, and
+macOS defaults. Open a new terminal when it finishes.
+
+Preview what would happen without changing anything:
+
+```sh
+bash ~/dotfiles/bootstrap.sh --dry-run
+```
+
+See [Dry-Run & Pre-flight](DRY_RUN_AND_PREFLIGHT.md) for details.
+
+## Machine profiles
+
+Each machine has a **profile** that selects which packages, dotfiles, and steps
+apply:
+
+- **`personal`** (default) — full GUI Mac: core CLI + GUI casks/fonts/apps + macOS defaults.
+- **`work`** — `personal` plus the work overlay (extra tooling, work git/signing).
+- **`minimal`** — core CLI toolchain + runtimes + core dotfiles only.
+- **`server`** — headless macOS: core CLI + runtimes + core dotfiles, no GUI, no macOS defaults.
+
+Show or set a machine's profile without re-bootstrapping:
+
+```sh
+bash ~/dotfiles/scripts/profile.sh           # show the active profile (aliased: dotprofile)
+bash ~/dotfiles/scripts/profile.sh set work  # persist this machine's profile
+```
+
+The profile is stored at `~/.config/dotfiles/profile`. Precedence is
+`--profile` flag > `DOTFILES_PROFILE` env > that file > `personal`.
+
+## Keeping everything current
+
+```sh
+bash ~/dotfiles/update.sh              # pull, re-symlink, upgrade packages, health check
+bash ~/dotfiles/update.sh --dry-run    # preview everything; change nothing
+bash ~/dotfiles/update.sh --no-upgrade # pull + re-symlink + verify only
+```
+
+Other handy commands:
+
+- `bash ~/dotfiles/verify.sh` — standalone health check.
+- `bash ~/dotfiles/scripts/status.sh` — quick read-only snapshot (aliased `dotstatus`).
+- `zsh ~/dotfiles/install.sh` — re-symlink without upgrading packages.
+
+## Documentation
+
+- **Setup**
+    - [Dry-Run & Pre-flight](DRY_RUN_AND_PREFLIGHT.md) — preview and validate before installing.
+    - [GPG Commit Signing](GPG_SIGNING.md) — set up signed Git commits.
+- **Work machine**
+    - [Work Machine Setup](work-machine.md) — the layered work overlay approach.
+    - [Complete Work Setup Guide](work-setup-complete.md) — full corporate-environment walkthrough.
+    - [Claude Code SSL Fix](claude-code-ssl-fix.md) — corporate certificate workaround.
+- **Reference**
+    - [Tool Reference](tools.md) — every tool in the Brewfile, with rationale and usage.
+    - [Shell Performance](performance.md) — how shell startup was cut by ~97%.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,4 @@
+# Documentation site build dependencies (MkDocs Material).
+# Used by .github/workflows/docs.yml; install with:
+#   pip install -r docs/requirements.txt
+mkdocs-material==9.7.6

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -2,7 +2,7 @@
 
 This repo can store secrets (API tokens, `.env` files, credentials) **encrypted in git** using [sops](https://github.com/getsops/sops) with the [age](https://github.com/FiloSottile/age) backend. Encrypted files are safe to commit; only someone holding the matching age **private key** can decrypt them.
 
-The encryption policy lives in [`.sops.yaml`](../.sops.yaml). A small wrapper, [`scripts/secrets.sh`](../scripts/secrets.sh), provides `edit` / `encrypt` / `decrypt` helpers.
+The encryption policy lives in [`.sops.yaml`](https://github.com/bradbergeron-us/dotfiles/blob/main/.sops.yaml). A small wrapper, [`scripts/secrets.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/scripts/secrets.sh), provides `edit` / `encrypt` / `decrypt` helpers.
 
 ---
 
@@ -26,7 +26,7 @@ The encryption policy lives in [`.sops.yaml`](../.sops.yaml). A small wrapper, [
    age-keygen -o ~/.config/sops/age/keys.txt
    ```
    This prints a line like `# public key: age1qpz...`. The file also contains your **private** key — keep it secret.
-3. **Register your public key** in [`.sops.yaml`](../.sops.yaml): replace the placeholder recipient(s) under `creation_rules` with the `age1...` public key from step 2, then commit `.sops.yaml`.
+3. **Register your public key** in [`.sops.yaml`](https://github.com/bradbergeron-us/dotfiles/blob/main/.sops.yaml): replace the placeholder recipient(s) under `creation_rules` with the `age1...` public key from step 2, then commit `.sops.yaml`.
    - To share secrets across multiple machines or teammates, list each public key as its own `age:` entry — every listed recipient can decrypt.
    - After changing recipients, re-key existing files with `sops updatekeys <file>`.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,7 +1,7 @@
 # Tool Reference
 
-Full descriptions, rationale, and usage for every tool in the [Brewfile](../Brewfile).
-For a quick summary of all tools, see the [tools table in the README](../README.md#tools).
+Full descriptions, rationale, and usage for every tool in the [Brewfile](https://github.com/bradbergeron-us/dotfiles/blob/main/Brewfile).
+For a quick summary of all tools, see the [tools table in the README](https://github.com/bradbergeron-us/dotfiles#tools).
 
 ---
 
@@ -379,7 +379,7 @@ For Clipboard History: assign `Cmd+Shift+V` in Settings → Extensions → Clipb
 
 ## Scripts
 
-### [`update.sh`](../update.sh)
+### [`update.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/update.sh)
 A one-command maintenance script that keeps the machine current without a full re-bootstrap. Run it manually any time, or automate it with `scripts/setup-scheduler.sh`.
 
 ```sh
@@ -399,7 +399,7 @@ Logs are written to `~/dotfiles/logs/update.log` when running via launchd.
 
 ---
 
-### [`verify.sh`](../verify.sh)
+### [`verify.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/verify.sh)
 A standalone environment health check. Run it any time to confirm the machine is in a good state — useful when returning to a machine after time away, after a failed update, or when something feels broken.
 
 ```sh
@@ -422,7 +422,7 @@ Errors require action (run `install.sh`). Warnings are informational — the exi
 
 ---
 
-### [`setup-scheduler.sh`](../scripts/setup-scheduler.sh)
+### [`setup-scheduler.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/scripts/setup-scheduler.sh)
 Installs a launchd `LaunchAgent` that runs `update.sh` daily at 9 AM. Uses the modern `launchctl bootstrap`/`bootout` API.
 
 ```sh

--- a/docs/work-setup-complete.md
+++ b/docs/work-setup-complete.md
@@ -752,7 +752,7 @@ Only templates and documentation are committed.
 
 ### Documentation
 
-- [Main README](../README.md) - General dotfiles information
+- [Main README](https://github.com/bradbergeron-us/dotfiles#readme) - General dotfiles information
 - [Work Machine Setup](work-machine.md) - Additional work-specific topics
 - [Tools Guide](tools.md) - Tool-specific configuration
 - [Performance](performance.md) - Optimization tips

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,67 @@
+site_name: dotfiles
+site_description: Personal macOS dotfiles — zsh, tmux, git, and a full developer toolchain.
+site_author: Brad Bergeron
+repo_name: bradbergeron-us/dotfiles
+repo_url: https://github.com/bradbergeron-us/dotfiles
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+    - toc.follow
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Setup:
+      - Dry-Run & Pre-flight: DRY_RUN_AND_PREFLIGHT.md
+      - GPG Commit Signing: GPG_SIGNING.md
+      - Encrypted Secrets: secrets.md
+  - Work Machine:
+      - Overview: work-machine.md
+      - Complete Setup Guide: work-setup-complete.md
+      - Claude Code SSL Fix: claude-code-ssl-fix.md
+  - Reference:
+      - Tool Reference: tools.md
+      - Shell Performance: performance.md


### PR DESCRIPTION
## Summary
Adds a MkDocs (Material theme) documentation site that publishes the existing `docs/` tree to GitHub Pages (roadmap Phase 2, item 9).

- **`mkdocs.yml`** (repo root): Material theme with light/dark palette toggle, a `nav` covering every page under `docs/`, common Markdown / PyMdown extensions, and the built-in search plugin.
- **`docs/index.md`**: landing page that summarizes/references the README — quick start, machine profiles, the update workflow, and an index of the other docs.
- **`.github/workflows/docs.yml`**: on `pull_request` → build only (`mkdocs build --strict`, no deploy); on push to `main` → build + deploy to GitHub Pages via `actions/configure-pages` + `actions/upload-pages-artifact` + `actions/deploy-pages`. Ubuntu runner, `mkdocs-material` installed via pip.
- **`docs/*.md`**: retargeted a handful of cross-repo links (`README`, `Brewfile`, `update.sh`, `verify.sh`, `setup-scheduler.sh`) from `../`-relative paths to absolute GitHub URLs so the published site links resolve and the strict build passes. No docs were moved or restructured.

## Shared-file appends
- **`.gitignore`**: append-only — added `site/` (MkDocs build output) under a short comment. No other lines touched.

## Scope
Owns `mkdocs.yml`, `docs/index.md` (+ minimal link fixes in existing docs), and the new `.github/workflows/docs.yml`. No edits to other workflows.

## Validation
- `uvx --with mkdocs-material mkdocs build --strict` → green (0 warnings).
- Existing unit suite (as CI runs it): `for t in scripts/tests/test_*.sh; do bash "$t"; done` → 7/7 pass.
- Confirmed new files are tracked and not caught by `.gitignore` patterns (`git check-ignore` clean for the workflow, `mkdocs.yml`, `docs/index.md`).

_Conversation: https://app.warp.dev/conversation/4426fe55-09ca-415e-bb32-0087b3599002_

_Run: https://oz.warp.dev/runs/019ecf20-4a03-7877-9861-633ccfdb610a_

_This PR was generated with [Oz](https://warp.dev/oz)._
