### PR TITLE
feat(secrets): encrypted secrets workflow with sops + age

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,11 @@ vivaxy.*
 # Git configs with actual keys/emails (only templates are tracked)
 config/git/*.gitconfig
 !config/git/*.template
+
+# Secrets (sops + age) — NEVER commit private keys or decrypted output.
+# See docs/secrets.md. Age private keys live at ~/.config/sops/age/keys.txt
+# (outside the repo); these guard against stray copies inside it.
+*.agekey
+age-key.txt
+keys.txt
+*.dec

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,25 @@
+# .sops.yaml — sops + age encryption policy for this repo.
+#
+# `creation_rules` tell sops which files to encrypt and to which age recipient
+# (public key). On `sops <file>` / `scripts/secrets.sh encrypt <file>`, sops
+# matches the file path against `path_regex` top-to-bottom and uses the first
+# match's `age` recipients.
+#
+# SETUP (one time, per machine — see docs/secrets.md):
+#   1. Generate an age key:  age-keygen -o ~/.config/sops/age/keys.txt
+#   2. Copy the "public key:" line it prints (starts with `age1...`).
+#   3. Replace the placeholder recipient below with that public key, commit it.
+# The PRIVATE key stays at ~/.config/sops/age/keys.txt (outside this repo, see
+# .gitignore) and is what sops uses to DECRYPT. Only the PUBLIC key goes here.
+#
+# Add more recipients (one per line) to share secrets across machines/teammates;
+# every listed recipient can decrypt.
+
+creation_rules:
+  # Anything under a top-level secrets/ dir, or named *.secret / *.enc.
+  - path_regex: (^|/)secrets/.*\.(ya?ml|json|env|ini|toml|txt)$
+    age: >-
+      age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsferecipientplaceholder
+  - path_regex: \.(secret|enc)\.(ya?ml|json|env|ini|toml|txt)$
+    age: >-
+      age1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqsferecipientplaceholder

--- a/Brewfile
+++ b/Brewfile
@@ -67,4 +67,10 @@ brew "direnv"         # per-directory environment variables via .envrc files
 brew "newman"         # CLI runner for Insomnia/Postman collections (useful in CI)
 brew "redis"          # in-memory data store — background jobs (Sidekiq), caching, sessions
 brew "imagemagick"    # image conversion and manipulation (resize, crop, format conversion)
-brew "pdftk-java"     # PDF toolkit — merge, split, fill forms, extract pages
+brew "pdftk-java"    # PDF toolkit — merge, split, fill forms, extract pages
+
+# ------------------
+# Secrets management
+# ------------------
+brew "sops"           # encrypt/decrypt structured files in git (see scripts/secrets.sh, docs/secrets.md)
+brew "age"            # modern file-encryption backend used by sops (key at ~/.config/sops/age/keys.txt)

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,71 @@
+# Encrypted Secrets (sops + age)
+
+This repo can store secrets (API tokens, `.env` files, credentials) **encrypted in git** using [sops](https://github.com/getsops/sops) with the [age](https://github.com/FiloSottile/age) backend. Encrypted files are safe to commit; only someone holding the matching age **private key** can decrypt them.
+
+The encryption policy lives in [`.sops.yaml`](../.sops.yaml). A small wrapper, [`scripts/secrets.sh`](../scripts/secrets.sh), provides `edit` / `encrypt` / `decrypt` helpers.
+
+---
+
+## How it works
+
+- **age** is the encryption backend. You hold a key pair: a **public key** (`age1...`, safe to share/commit) and a **private key** (secret, never committed).
+- **sops** encrypts only the *values* in structured files (YAML/JSON/env/etc.), leaving keys readable so diffs stay meaningful. It reads `.sops.yaml` to decide which files to encrypt and to which recipient(s).
+- Your private key lives at `~/.config/sops/age/keys.txt` — **outside this repo**. sops finds it via the `SOPS_AGE_KEY_FILE` environment variable, which `scripts/secrets.sh` defaults to that path.
+
+---
+
+## Setup (one time per machine)
+
+1. **Install the tools** (already in the core `Brewfile`):
+   ```sh
+   brew bundle --file=~/dotfiles/Brewfile   # installs sops + age
+   ```
+2. **Generate your age key pair**:
+   ```sh
+   mkdir -p ~/.config/sops/age
+   age-keygen -o ~/.config/sops/age/keys.txt
+   ```
+   This prints a line like `# public key: age1qpz...`. The file also contains your **private** key — keep it secret.
+3. **Register your public key** in [`.sops.yaml`](../.sops.yaml): replace the placeholder recipient(s) under `creation_rules` with the `age1...` public key from step 2, then commit `.sops.yaml`.
+   - To share secrets across multiple machines or teammates, list each public key as its own `age:` entry — every listed recipient can decrypt.
+   - After changing recipients, re-key existing files with `sops updatekeys <file>`.
+
+> **Backup your private key.** If you lose `~/.config/sops/age/keys.txt`, encrypted files become unrecoverable. Store a copy in a password manager or other secure vault — never in this repo.
+
+---
+
+## Daily usage
+
+Files are matched by the `path_regex` rules in `.sops.yaml`. By default this repo encrypts files under a `secrets/` directory and files named `*.secret.*` / `*.enc.*` (e.g. `secrets/aws.yaml`, `config.secret.env`).
+
+Edit a secret (decrypts to a temp file in `$EDITOR`, re-encrypts on save):
+```sh
+bash ~/dotfiles/scripts/secrets.sh edit secrets/aws.yaml
+```
+
+Encrypt an existing plaintext file in place:
+```sh
+bash ~/dotfiles/scripts/secrets.sh encrypt secrets/aws.yaml
+```
+
+Decrypt to a plaintext sibling file (`<file>.dec`, gitignored):
+```sh
+bash ~/dotfiles/scripts/secrets.sh decrypt secrets/aws.yaml
+# → writes secrets/aws.yaml.dec  (delete it when done)
+```
+
+You can also call `sops` directly; the wrapper just sets `SOPS_AGE_KEY_FILE` and adds guard rails:
+```sh
+sops secrets/aws.yaml            # edit in place
+sops --decrypt secrets/aws.yaml  # print plaintext to stdout
+```
+
+---
+
+## Safety model
+
+- **Never commit private keys.** `~/.config/sops/age/keys.txt` lives outside the repo. `.gitignore` also blocks stray copies inside it: `*.agekey`, `age-key.txt`, `keys.txt`.
+- **Never commit decrypted output.** The `decrypt` command writes `*.dec` files, which `.gitignore` blocks. Delete them when finished.
+- **Only commit sops-encrypted files.** Inspect a file before committing — an encrypted sops file contains `sops:` metadata and `ENC[...]` values. If you see raw plaintext secrets, stop and encrypt first.
+- **Defense in depth.** The repo's `gitleaks` pre-commit hook and CI job scan for accidentally committed secrets, but the encryption boundary above is the primary protection.
+- **Rotate on exposure.** If a private key or plaintext secret is ever exposed, rotate the affected credentials and generate a new age key, then `sops updatekeys` all files.

--- a/scripts/secrets.sh
+++ b/scripts/secrets.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# secrets.sh — thin, safe wrapper around `sops` + `age` for encrypted secrets.
+#
+# Encryption policy (which files, which recipients) lives in .sops.yaml at the
+# repo root. The age PRIVATE key lives OUTSIDE the repo at
+# ~/.config/sops/age/keys.txt and is used to decrypt. See docs/secrets.md.
+#
+# Usage:
+#   bash ~/dotfiles/scripts/secrets.sh edit    <file>   # open decrypted in $EDITOR, re-encrypt on save
+#   bash ~/dotfiles/scripts/secrets.sh encrypt <file>   # encrypt <file> in place
+#   bash ~/dotfiles/scripts/secrets.sh decrypt <file>   # write plaintext to <file>.dec (gitignored)
+#   bash ~/dotfiles/scripts/secrets.sh --help
+
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck source=scripts/lib/bootstrap_helpers.sh
+source "$DOTFILES_DIR/scripts/lib/bootstrap_helpers.sh"
+setup_colors
+
+# Default key location (override by exporting SOPS_AGE_KEY_FILE before running).
+export SOPS_AGE_KEY_FILE="${SOPS_AGE_KEY_FILE:-$HOME/.config/sops/age/keys.txt}"
+
+usage() {
+  cat <<'USAGE'
+Usage: bash secrets.sh <command> [file]
+
+  edit <file>      Open <file> decrypted in $EDITOR; sops re-encrypts on save.
+  encrypt <file>   Encrypt <file> in place using the recipients in .sops.yaml.
+  decrypt <file>   Decrypt <file> to <file>.dec (gitignored — never commit it).
+  --help, -h       Show this help.
+
+Setup (one time):
+  1. brew bundle --file=~/dotfiles/Brewfile     # installs sops + age
+  2. age-keygen -o ~/.config/sops/age/keys.txt  # generates your key pair
+  3. Put the printed public key (age1...) into .sops.yaml creation_rules.
+
+The age PRIVATE key (~/.config/sops/age/keys.txt) and any decrypted *.dec
+files must NEVER be committed. See docs/secrets.md for the full safety model.
+USAGE
+}
+
+# require_cmd NAME — fail with guidance if a dependency is missing.
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    warn "required command '$1' not found"
+    info "install it: brew bundle --file=\"$DOTFILES_DIR/Brewfile\""
+    return 1
+  fi
+}
+
+# require_file FILE — fail if the target file is missing.
+require_file() {
+  if [[ -z "${1:-}" ]]; then
+    warn "no file given"
+    info "usage: secrets.sh ${ACTION:-<command>} <file>"
+    return 1
+  fi
+  if [[ ! -f "$1" ]]; then
+    warn "file not found: $1"
+    return 1
+  fi
+}
+
+# warn_missing_key — soft warning if the age private key is absent.
+warn_missing_key() {
+  if [[ ! -f "$SOPS_AGE_KEY_FILE" ]]; then
+    warn "age key not found at $SOPS_AGE_KEY_FILE"
+    info "generate one: age-keygen -o \"$SOPS_AGE_KEY_FILE\""
+  fi
+}
+
+cmd_edit() {
+  local file="${1:-}"
+  require_cmd sops
+  require_file "$file"
+  warn_missing_key
+  info "opening $file in \$EDITOR (sops re-encrypts on save)"
+  sops "$file"
+}
+
+cmd_encrypt() {
+  local file="${1:-}"
+  require_cmd sops
+  require_file "$file"
+  info "encrypting $file in place"
+  sops --encrypt --in-place "$file"
+  success "encrypted $file"
+}
+
+cmd_decrypt() {
+  local file="${1:-}"
+  require_cmd sops
+  require_file "$file"
+  warn_missing_key
+  local out="$file.dec"
+  sops --decrypt "$file" >"$out"
+  success "decrypted to $out"
+  warn "$out is plaintext and gitignored — delete it when done; never commit it"
+}
+
+main() {
+  local action="${1:-}"
+  ACTION="$action"
+  case "$action" in
+    edit)            shift; cmd_edit "$@" ;;
+    encrypt)         shift; cmd_encrypt "$@" ;;
+    decrypt)         shift; cmd_decrypt "$@" ;;
+    --help|-h|help)  usage ;;
+    "")              usage; exit 1 ;;
+    *)               warn "unknown command '$action'"; usage; exit 1 ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Adds an encrypted-secrets workflow using **sops + age** (roadmap item 6), letting secrets be committed to git encrypted and decrypted only by holders of the matching age private key.

- **`Brewfile`** — appended `sops` + `age` under a new "Secrets management" section (core CLI formulae). **Append-only.**
- **`.sops.yaml`** — `creation_rules` encrypting matched files (`secrets/**`, `*.secret.*`, `*.enc.*`) to an age recipient, with inline setup instructions. The age **private** key lives at `~/.config/sops/age/keys.txt`, outside the repo.
- **`scripts/secrets.sh`** — small bash wrapper (`set -euo pipefail`) sourcing `scripts/lib/bootstrap_helpers.sh` for `info`/`success`/`warn` + `setup_colors`. Subcommands: `edit <file>`, `encrypt <file>`, `decrypt <file>`, `--help`. Executable, `shellcheck -S warning` clean.
- **`docs/secrets.md`** — setup (generate an age key, register its public key in `.sops.yaml`), daily usage, and the safety model (never commit private keys or decrypted output).
- **`.gitignore`** — appended rules for age private keys (`*.agekey`, `age-key.txt`, `keys.txt`) and decrypted output (`*.dec`), grouped under a comment. **Append-only.**

## Shared-file appends (call-out for merge)
- `Brewfile`: append-only, new "Secrets management" group at end.
- `.gitignore`: append-only, new "Secrets (sops + age)" group at end.
These are trivially rebaseable against sibling PRs.

## Note on tests
Per the orchestration plan, this PR does **not** add `scripts/tests/test_*.sh` — unit tests for `secrets.sh` will follow in the bats-core migration (item 8), which owns the test suite.

## Validation
- `shellcheck -S warning scripts/secrets.sh` → clean.
- `bash scripts/secrets.sh --help` → works; no-arg and unknown-command paths exit 1 with usage.
- Installed `sops` + `age` locally and ran a full encrypt→decrypt round-trip in a temp dir using the wrapper: values encrypted to `ENC[...]`, no plaintext leak, decrypt restored the original. No artifacts committed.
- `git check-ignore` confirms `*.dec`, `*.agekey`, `keys.txt`, `age-key.txt` are ignored.
- Full existing suite green: `for t in scripts/tests/test_*.sh; do bash "$t"; done` → 7 files, 157 tests, 0 failed.
- `gitleaks` pre-commit hook passed.

_Conversation: https://app.warp.dev/conversation/9b80dafb-d502-4551-8698-97d23ef6b834_
_Run: https://oz.warp.dev/runs/019ecf20-49ff-7051-adaf-87674a488071_
_Plans_:
- _[Phase 2: profiles + remaining roadmap items](https://app.warp.dev/plan/9d0face4-db3a-4b6c-8636-265e2af74e89)_

_This PR was generated with [Oz](https://warp.dev/oz)._
