### PR TITLE
feat(zsh): manage plugins with sheldon (roadmap item 11)

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -14,6 +14,7 @@
 brew "starship"       # cross-shell prompt
 brew "zoxide"         # smart cd with frecency ranking
 brew "fzf"            # fuzzy finder (Ctrl+R history, Ctrl+T file picker)
+brew "sheldon"        # fast, declarative zsh plugin manager (config: config/sheldon/plugins.toml)
 
 # ------------------
 # File & search

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Stored at `~/.config/dotfiles/profile`; precedence is `--profile` flag > `DOTFIL
 | `home/psqlrc` | `~/.psqlrc` | psql defaults — `\x auto`, `\timing`, per-DB history |
 | `home/editorconfig` | `~/.editorconfig` | Global EditorConfig fallback |
 | `config/nvim/init.lua` | `~/.config/nvim/init.lua` | Neovim — dependency-free baseline (Space leader, 2-space indent, diagnostics) |
+| `config/sheldon/plugins.toml` | `~/.config/sheldon/plugins.toml` | Zsh plugins via [sheldon](https://sheldon.cli.rs) — fast-syntax-highlighting, zsh-autosuggestions |
 | `vscode/settings.json` | `~/Library/.../Code/User/settings.json` | VS Code settings |
 | `vscode/extensions.txt` | _(auto-installed)_ | Core VS Code extensions |
 | `Brewfile` · `Brewfile.personal` · `Brewfile.work` | _(used by bootstrap)_ | Core CLI formulae + per-profile overlays (GUI casks/fonts/apps; work additions) |

--- a/config/sheldon/plugins.toml
+++ b/config/sheldon/plugins.toml
@@ -1,0 +1,16 @@
+# plugins.toml — declarative zsh plugin manifest for sheldon.
+#
+# Symlinked to ~/.config/sheldon/plugins.toml (see config/symlinks.map) and
+# sourced from home/zshrc via `eval "$(sheldon source)"`. sheldon downloads each
+# plugin on first source and generates the source lines; refresh pinned commits
+# with `sheldon lock --update`.
+#
+# These two plugins were previously hand-cloned into ~/.zsh and sourced manually;
+# sheldon now manages them declaratively so every machine gets the same set.
+shell = "zsh"
+
+[plugins.fast-syntax-highlighting]
+github = "zdharma-continuum/fast-syntax-highlighting"
+
+[plugins.zsh-autosuggestions]
+github = "zsh-users/zsh-autosuggestions"

--- a/config/symlinks.map
+++ b/config/symlinks.map
@@ -38,3 +38,4 @@ config/direnvrc        .config/direnv/direnvrc
 config/mise.toml       .config/mise/config.toml
 config/ghostty/config  .config/ghostty/config  gui
 config/nvim/init.lua   .config/nvim/init.lua
+config/sheldon/plugins.toml  .config/sheldon/plugins.toml

--- a/home/zshrc
+++ b/home/zshrc
@@ -179,13 +179,16 @@ command -v bat &>/dev/null && alias cat='bat --paging=never'
 eval "$(starship init zsh)"
 test -f ~/afs_localprops.sh && source ~/afs_localprops.sh
 
-# Optional plugins if installed
-if [ -f "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh" ]; then
-  source "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
-fi
-
-if [ -f "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" ]; then
-  source "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
+# Zsh plugins — managed declaratively by sheldon (config: ~/.config/sheldon/plugins.toml).
+# Falls back to manually-cloned plugins under ~/.zsh so a machine without sheldon
+# (e.g. before bootstrap installs it) still gets highlighting + autosuggestions.
+if command -v sheldon &>/dev/null; then
+  eval "$(sheldon source)"
+else
+  [ -f "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh" ] && \
+    source "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
+  [ -f "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" ] && \
+    source "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
 fi
 
 # Enable enhanced menu selection in completions


### PR DESCRIPTION
## Summary
Phase 3 / roadmap item 11 — manage zsh plugins declaratively with **sheldon** instead of hand-cloned repos sourced from `~/.zsh`.

- **Brewfile**: add `sheldon` to the core CLI set (all profiles).
- **config/sheldon/plugins.toml** (new): declarative manifest for the two plugins previously sourced manually — `fast-syntax-highlighting` + `zsh-autosuggestions`; symlinked to `~/.config/sheldon/plugins.toml`.
- **home/zshrc**: `eval "$(sheldon source)"` when sheldon is on PATH, with a fallback to the existing `~/.zsh` manual sourcing. Load position unchanged.
- **config/symlinks.map + README**: track and document the new config.

## Safety / backward compat
The zshrc change is guarded: with no sheldon installed, the existing manual sourcing runs unchanged — current machines see **no behavior change** until `sheldon` is installed (via the Brewfile on next bootstrap/update).

## Validation
- `zsh -n home/zshrc` clean
- `plugins.toml` valid TOML (shell=zsh, 2 plugins)
- bats suite **157/157**
- sheldon isn't installed locally yet, so the live `sheldon source` path runs on first install; the guarded fallback covers the interim, and CI install-smoke verifies the new symlink.

Co-Authored-By: Oz <oz-agent@warp.dev>