### PR TITLE
fix(dry-run): silence arithmetic stderr noise + document bats workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@
 ## Validation
 <!-- Tick what you ran — see CONTRIBUTING.md "Before you commit". -->
 - [ ] `shellcheck -S warning` on changed bash; `zsh -n` on changed zsh files (`install.sh`, `home/zshrc`, …)
-- [ ] Ran the relevant `scripts/tests/test_*.sh`
+- [ ] Ran the bats suite (`bats scripts/tests/`)
 - [ ] Exercised install/verify against an isolated `HOME=$(mktemp -d)` (if behavior changed)
 
 ## Checklist

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,26 +43,28 @@ Two independent safety layers; full user-facing detail is in [docs/DRY_RUN_AND_P
 
 ## Tests
 
-Tests are plain bash scripts under `scripts/tests/test_*.sh` — there is no test framework. Run one directly:
+Unit tests use [bats-core](https://github.com/bats-core/bats-core) and live in `scripts/tests/test_*.bats`. Install bats with `brew install bats-core` (it's already in the `Brewfile`), then run the whole suite from the repo root:
 
 ```bash
-bash scripts/tests/test_verify_helpers.sh
-bash scripts/tests/test_bootstrap_helpers.sh
+bats scripts/tests/
 ```
 
-Convention (see `scripts/tests/test_verify_helpers.sh` for the reference implementation):
+You can also run a single file, e.g. `bats scripts/tests/test_verify_helpers.bats`.
 
-- `set -euo pipefail`; `pass` / `fail` helpers that increment run/pass/fail counters.
-- Build fixtures under a single `mktemp -d` directory and clean it up with `trap '...' EXIT`.
-- Source the helper under test inside a subshell `( ... )` so its globals don't leak between cases.
-- Assert on the result globals the helper sets, and `exit 1` at the end if any test failed.
+Convention (see `scripts/tests/test_verify_helpers.bats` for the reference implementation):
+
+- Every file is `#!/usr/bin/env bats` and starts with `load 'test_helper'`, which sources `scripts/tests/test_helper.bash` to expose `$LIB_DIR` / `$SCRIPTS_DIR` / `$REPO_ROOT`.
+- Write each case as a `@test "description" { ... }` block; a non-zero command inside the block fails the test.
+- Use the per-test scratch dir `$BATS_TEST_TMPDIR` for fixtures (bats creates and removes it automatically — no `mktemp -d` or `trap` cleanup needed).
+- Source the helper under test once at the file's top level (or in `setup()`), and assert on the result globals it sets.
+- Add new tests as `@test` blocks in the `*.bats` file next to the helper they cover; both CI and `bats scripts/tests/` auto-discover them, so no workflow edits are needed.
 
 Because the helpers are side-effect-free, tests exercise them directly against temporary `$HOME` / fixture directories.
 
 ## CI
 
 - **`.github/workflows/ci.yml`** — three jobs: `shellcheck` (bash scripts, `-S warning`), `zsh-syntax` (`zsh -n` on the zsh files plus a `Brewfile` parse check), and `install-smoke` (runs `zsh install.sh` against a throwaway `$HOME` and asserts every expected symlink exists).
-- **`.github/workflows/test-bootstrap.yml`** — runs the `scripts/tests/test_*.sh` unit tests (currently `test_bootstrap_helpers.sh`, `test_dryrun_helpers.sh`, `test_verify_helpers.sh`, `test_update_helpers.sh`, and `test_validate_templates.sh`) plus `bash -n` syntax checks when the relevant scripts change.
+- **`.github/workflows/test-bootstrap.yml`** — installs bats-core and runs the full `scripts/tests/*.bats` suite (auto-discovered via `bats scripts/tests/`), plus `bash -n` syntax checks on the scripts under test and a `bats --count` parse-check of every `.bats` file, when the relevant scripts change.
 
 ## Common tasks
 
@@ -87,12 +89,12 @@ Templates exist for configs that can't be committed verbatim because they carry 
 
 ### Add a verify check
 
-Add a side-effect-free `check_*` function to `scripts/lib/verify_helpers.sh` that sets result globals, add cases for it to `scripts/tests/test_verify_helpers.sh`, then wire a `step` + report block into `verify.sh`.
+Add a side-effect-free `check_*` function to `scripts/lib/verify_helpers.sh` that sets result globals, add `@test` cases for it to `scripts/tests/test_verify_helpers.bats`, then wire a `step` + report block into `verify.sh`.
 
 ## Before you commit
 
 - Run `shellcheck -S warning <script>` on any bash you touched, and `zsh -n <file>` on zsh files (`install.sh`, `scripts/setup_gpg_signing.sh`, `home/zshrc`, `home/zprofile`).
-- Run the relevant `scripts/tests/test_*.sh`.
+- Run the bats suite with `bats scripts/tests/` (install via `brew install bats-core` if needed).
 - For changes to install/verify behavior, exercise them against an isolated `HOME=$(mktemp -d)`.
 - New bash scripts start with `#!/usr/bin/env bash` and `set -euo pipefail`, and reuse `scripts/lib/bootstrap_helpers.sh` for output.
 - A repo-local pre-commit hook runs when `pre-commit` is installed and a `.pre-commit-config.yaml` is present.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ Automation scripts for system setup, configuration, and maintenance.
 
 - **`scripts/`** — runnable scripts (work setup, installers, `macos.sh`, `uninstall.sh`, `validate_templates.sh`, …).
 - **`scripts/lib/`** — sourced helper libraries (no side effects): `bootstrap_helpers.sh`, `verify_helpers.sh`, `dryrun_helpers.sh`, `update_helpers.sh`, `status_helpers.sh`, `profile_helpers.sh`.
-- **`scripts/tests/`** — hand-rolled unit tests (`test_*.sh`) for the helpers and validators.
+- **`scripts/tests/`** — [bats-core](https://github.com/bats-core/bats-core) unit tests (`test_*.bats`) for the helpers and validators, plus the shared `test_helper.bash`.
 
 ---
 
@@ -45,13 +45,13 @@ bash ~/dotfiles/scripts/status.sh --verify    # also run the full verify.sh
 bash ~/dotfiles/scripts/status.sh --exit-code # exit non-zero if unhealthy (for scripts/CI)
 ```
 
-Aliased as `dotstatus` in `home/zshrc`. Parsing and git-state helpers live in `lib/status_helpers.sh` (unit-tested by `tests/test_status_helpers.sh`).
+Aliased as `dotstatus` in `home/zshrc`. Parsing and git-state helpers live in `lib/status_helpers.sh` (unit-tested by `tests/test_status_helpers.bats`).
 
 ### `profile.sh`
 
 **Show or set this machine's profile.**
 
-`bash scripts/profile.sh [show | list | set <name>]` reads/writes `~/.config/dotfiles/profile` so an existing machine can adopt a profile (`personal` | `work` | `minimal` | `server`) without re-running bootstrap. Resolution logic lives in `lib/profile_helpers.sh` (unit-tested by `tests/test_profile_helpers.sh`); aliased `dotprofile`.
+`bash scripts/profile.sh [show | list | set <name>]` reads/writes `~/.config/dotfiles/profile` so an existing machine can adopt a profile (`personal` | `work` | `minimal` | `server`) without re-running bootstrap. Resolution logic lives in `lib/profile_helpers.sh` (unit-tested by `tests/test_profile_helpers.bats`); aliased `dotprofile`.
 
 ---
 
@@ -220,9 +220,25 @@ code --list-extensions
 
 ## Tests (`tests/`)
 
-Hand-rolled unit tests (no framework), auto-discovered and run by `.github/workflows/test-bootstrap.yml`: `test_bootstrap_helpers.sh`, `test_verify_helpers.sh`, `test_dryrun_helpers.sh`, `test_update_helpers.sh`, `test_status_helpers.sh`, and `test_validate_templates.sh`. Run one directly with `bash scripts/tests/<file>`.
+[bats-core](https://github.com/bats-core/bats-core) unit tests (`test_*.bats`), auto-discovered and run by `.github/workflows/test-bootstrap.yml`. Current files: `test_bootstrap_helpers.bats`, `test_verify_helpers.bats`, `test_dryrun_helpers.bats`, `test_update_helpers.bats`, `test_status_helpers.bats`, `test_profile_helpers.bats`, and `test_validate_templates.bats`.
 
-### `tests/test_bootstrap_helpers.sh`
+**Install bats** (already in the `Brewfile`):
+```bash
+brew install bats-core
+```
+
+**Run the suite** (from the repo root):
+```bash
+bats scripts/tests/           # whole suite
+bats scripts/tests/test_bootstrap_helpers.bats   # a single file
+```
+
+**Conventions:**
+- Each file is `#!/usr/bin/env bats` and starts with `load 'test_helper'`, sourcing `tests/test_helper.bash` for the `$LIB_DIR` / `$SCRIPTS_DIR` / `$REPO_ROOT` paths.
+- Write cases as `@test "description" { ... }` blocks; use the auto-managed scratch dir `$BATS_TEST_TMPDIR` for fixtures.
+- Add new tests as `@test` blocks in the `*.bats` file next to the helper they cover — CI and `bats scripts/tests/` discover them automatically.
+
+### `tests/test_bootstrap_helpers.bats`
 
 **Unit tests for bootstrap helper functions**
 
@@ -234,14 +250,7 @@ Tests the shell functions in `lib/bootstrap_helpers.sh`:
 
 **Usage:**
 ```bash
-bash ~/dotfiles/scripts/tests/test_bootstrap_helpers.sh
-```
-
-**Run in CI:**
-```yaml
-# .github/workflows/test-bootstrap.yml
-- name: Test bootstrap helpers
-  run: bash scripts/tests/test_bootstrap_helpers.sh
+bats scripts/tests/test_bootstrap_helpers.bats
 ```
 
 ---
@@ -267,7 +276,7 @@ echo "$SYMLINK_BROKEN_COUNT broken"
 
 ---
 
-### `tests/test_verify_helpers.sh`
+### `tests/test_verify_helpers.bats`
 
 **Unit tests for verify helper functions**
 
@@ -275,7 +284,7 @@ Tests the verification utility functions.
 
 **Usage:**
 ```bash
-bash ~/dotfiles/scripts/tests/test_verify_helpers.sh
+bats scripts/tests/test_verify_helpers.bats
 ```
 
 ---

--- a/scripts/lib/dryrun_helpers.sh
+++ b/scripts/lib/dryrun_helpers.sh
@@ -61,7 +61,7 @@ check_brew_bundle() {
   if ! command -v brew &>/dev/null; then
     info "Would install packages from Brewfile (Homebrew not yet installed)"
     local entry_count
-    entry_count=$(grep -cE "^(brew|cask|tap|mas)" "$brewfile" || echo "0")
+    entry_count=$(grep -cE "^(brew|cask|tap|mas)" "$brewfile" || true)
     info "Brewfile contains: $entry_count total entries"
     return
   fi
@@ -78,7 +78,7 @@ check_brew_bundle() {
   else
     # Count missing packages from the output
     local missing_count
-    missing_count=$(echo "$check_output" | grep -c "needs to be installed" || echo "0")
+    missing_count=$(echo "$check_output" | grep -c "needs to be installed" || true)
     if (( missing_count > 0 )); then
       info "Would install: $missing_count package(s)"
     else

--- a/scripts/tests/test_dryrun_helpers.bats
+++ b/scripts/tests/test_dryrun_helpers.bats
@@ -245,6 +245,27 @@ EOF
   ! echo "$out" | sed -n '/--ACTIONS--/,$p' | grep -q "brew bundle"
 }
 
+# Regression: the `grep -c ... || true` count idiom must yield a single clean
+# integer. The old `|| echo "0"` form appended a second line on no-match (grep
+# -c already prints "0"), feeding multiline input to `(( ... ))` and emitting an
+# arithmetic "syntax error" to stderr. Drive the brew-absent branch with a
+# Brewfile that has zero matching entries and assert stderr stays clean. PATH is
+# scoped to a bin dir holding only the coreutils the branch needs (grep/uname)
+# so `command -v brew` fails while grep itself stays available.
+@test "check_brew_bundle: brew absent, no entries → clean stderr, single count" {
+  local nobrew="$BATS_TEST_TMPDIR/nobrew_bin"
+  mkdir -p "$nobrew"
+  ln -sf "$(command -v grep)" "$nobrew/grep"
+  ln -sf "$(command -v uname)" "$nobrew/uname"
+  local bf="$BATS_TEST_TMPDIR/Brewfile_empty"
+  printf '# only comments, no brew/cask/tap/mas lines\n' > "$bf"
+  local errfile="$BATS_TEST_TMPDIR/brew_bundle.err"
+  out=$( export PATH="$nobrew"; check_brew_bundle "$bf" 2>"$errfile" )
+  echo "$out" | grep -q "Brewfile contains: 0 total entries"
+  [ ! -s "$errfile" ]
+  ! grep -qi "syntax error" "$errfile"
+}
+
 # ── check_work_configs (profile-gated) ────────────────────────────────────────
 # DOTFILES_PROFILE is exported per-case so current_profile is deterministic and
 # never reads the developer's real ~/.config/dotfiles/profile (env beats file).


### PR DESCRIPTION
Closes two Phase 2 follow-up polish gaps in one focused PR.

## GAP 1 — Quiet dry-run arithmetic stderr noise
`scripts/lib/dryrun_helpers.sh` used the `grep -c PATTERN || echo "0"` idiom in
`check_brew_bundle`. `grep -c` already prints `0` and exits non-zero on no
match, so `|| echo "0"` appended a **second** line. The resulting multiline
value was then fed to `(( count > 0 ))`, which threw an arithmetic *syntax
error* to stderr during `bootstrap.sh --dry-run`.

Fix: replace `|| echo "0"` with `|| true` for both counters (`entry_count`,
`missing_count`) so each is a single clean integer. Added a regression test in
`scripts/tests/test_dryrun_helpers.bats` asserting `check_brew_bundle` emits no
stderr on the no-match path.

## GAP 2 — Document the bats workflow (roadmap item 8)
The bats migration converted `scripts/tests/test_*.sh` → `*.bats` but left the
docs describing the retired hand-rolled flow. Updated:
- `CONTRIBUTING.md` — Tests, CI, "Add a verify check", and "Before you commit".
- `scripts/README.md` — Layout, Tests section, helper test references.
- `.github/pull_request_template.md` — validation checklist item.

These now describe running `bats scripts/tests/`, installing via
`brew install bats-core` (already in the `Brewfile`), the `test_helper.bash`
convention, and adding new tests as `@test` blocks next to the helper they cover.

## Validation
- `shellcheck -S warning scripts/lib/dryrun_helpers.sh` — clean
- `bats scripts/tests/` — 158 tests, all green
- `bash bootstrap.sh --dry-run` and `--dry-run --profile minimal` — exit 0, empty stderr (no arithmetic/syntax noise)

## Scope
Strictly limited to the owned files; did not touch `Brewfile`, `home/zshrc`,
`config/symlinks.map`, `config/sheldon/**`, `README.md`, or `docs/performance.md`
(owned by the parallel sheldon PR).

_Conversation: https://app.warp.dev/conversation/cf5a6fc2-f81f-451e-a432-70e838cee783_
_Run: https://oz.warp.dev/runs/019ed0ef-86d4-78c1-b6f0-a01de9f0e54e_

_This PR was generated with [Oz](https://warp.dev/oz)._
