### PR TITLE
feat(bootstrap): guided first-run profile picker (roadmap item 10)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -61,7 +61,41 @@ setup_colors
 # ── Profile (durable per-machine identity) ────────────────────────────────────
 # shellcheck source=scripts/lib/profile_helpers.sh
 source "$(dirname "$0")/scripts/lib/profile_helpers.sh"
-DOTFILES_PROFILE="$(resolve_profile "$PROFILE_FLAG")"
+
+# pick_profile — interactive first-run picker. Prints a menu to stderr and echoes
+# the chosen profile to stdout (so it is safe inside $()). Accepts a number or a
+# profile name; empty input or EOF defaults to personal.
+pick_profile() {
+  local choice profile
+  while true; do
+    {
+      printf '\n  This machine has no saved profile yet — pick one:\n\n'
+      printf '    1) personal  (default) — full GUI Mac: core + GUI apps/casks + macOS defaults\n'
+      printf '    2) work                — personal plus the work overlay & work configs\n'
+      printf '    3) minimal             — core CLI + runtimes + core dotfiles only\n'
+      printf '    4) server              — headless macOS: core CLI + runtimes, no GUI\n\n'
+    } >&2
+    read -rp "  Profile [1-4 or name, Enter = personal]: " choice || choice=""
+    case "$choice" in
+      ""|1|personal) profile="personal"; break ;;
+      2|work)        profile="work";     break ;;
+      3|minimal)     profile="minimal";  break ;;
+      4|server)      profile="server";   break ;;
+      *) printf '  Not a valid choice: %s\n' "$choice" >&2 ;;
+    esac
+  done
+  printf '%s\n' "$profile"
+}
+
+# Resolve the active profile. On a genuine first run — no --profile flag, no
+# DOTFILES_PROFILE env, no persisted file — with an interactive TTY (and not a
+# dry-run), prompt the user. Otherwise use the normal precedence so
+# non-interactive/CI runs and explicit choices behave exactly as before.
+if [[ -z "$PROFILE_FLAG" && -z "${DOTFILES_PROFILE:-}" && ! -f "$DOTFILES_PROFILE_FILE" && "$DRY_RUN" != true && -t 0 ]]; then
+  DOTFILES_PROFILE="$(pick_profile)"
+else
+  DOTFILES_PROFILE="$(resolve_profile "$PROFILE_FLAG")"
+fi
 export DOTFILES_PROFILE
 # Persist so update/verify/status agree on this machine's profile (not in dry-run).
 if [[ "$DRY_RUN" != true ]]; then
@@ -86,6 +120,15 @@ printf "  ${DIM}Machine${RESET}  %s\n" "$(scutil --get ComputerName 2>/dev/null 
 printf "  ${DIM}Date${RESET}     %s\n" "$(date '+%a %b %d %Y  %H:%M')"
 printf "  ${DIM}Profile${RESET}  %s\n" "$DOTFILES_PROFILE"
 echo "  ─────────────────────────────────────────────────"
+
+# Component summary for the resolved profile — shown before any steps run.
+if [[ "$DRY_RUN" == true ]]; then
+  preview_profile "$DOTFILES_PROFILE"
+else
+  printf "  ${DIM}This profile sets up${RESET}\n"
+  profile_component_summary "$DOTFILES_PROFILE"
+  echo "  ─────────────────────────────────────────────────"
+fi
 
 # ── Pre-flight check ─────────────────────────────────────────────────────────
 if [[ "$SKIP_PREFLIGHT" == false ]] && [[ "$DRY_RUN" == false ]]; then

--- a/scripts/lib/dryrun_helpers.sh
+++ b/scripts/lib/dryrun_helpers.sh
@@ -19,6 +19,15 @@ dry_run_step() {
   printf "${CYAN}${BOLD}  ▸ [%d/%d]  %s${RESET}  ${DIM}(dry-run)${RESET}\n" "$STEP" "$TOTAL_STEPS" "$title"
 }
 
+# preview_profile PROFILE — dry-run mirror of the bootstrap first-run summary.
+# profile_component_summary comes from profile_helpers.sh, which bootstrap.sh
+# sources before this file.
+preview_profile() {
+  printf "  ${DIM}This profile would set up${RESET}\n"
+  profile_component_summary "$1"
+  echo "  ─────────────────────────────────────────────────"
+}
+
 # Check if Xcode CLI tools would be installed
 check_xcode() {
   if ! xcode-select -p &>/dev/null; then

--- a/scripts/lib/profile_helpers.sh
+++ b/scripts/lib/profile_helpers.sh
@@ -101,3 +101,21 @@ profile_brewfiles() {
     printf '%s\n' "$dir/Brewfile.work"
   fi
 }
+
+# profile_component_summary PROFILE — echo a short, human-readable summary of the
+# components a profile enables (runtimes, dotfiles, package overlay, GUI apps,
+# work configs, macOS defaults). Pure (echo only, no UI/prompt/exit), so it is
+# shared by the bootstrap first-run picker and the dry-run preview and is unit-
+# testable. Everything derives from profile_includes, so it stays in sync with
+# how install.sh / bootstrap.sh actually gate each component.
+profile_component_summary() {
+  local profile="$1" gui=no work=no overlay="core only"
+  if profile_includes "$profile" gui;  then gui=yes;  overlay="core + GUI (Brewfile.personal)"; fi
+  if profile_includes "$profile" work; then work=yes; overlay="$overlay + work (Brewfile.work)"; fi
+  printf '  Runtimes (mise)      yes\n'
+  printf '  Core CLI + dotfiles  yes\n'
+  printf '  Package overlay      %s\n' "$overlay"
+  printf '  GUI apps + dotfiles  %s\n' "$gui"
+  printf '  Work configs         %s\n' "$work"
+  printf '  macOS defaults       %s\n' "$gui"
+}

--- a/scripts/tests/test_profile_helpers.bats
+++ b/scripts/tests/test_profile_helpers.bats
@@ -139,3 +139,34 @@ setup() {
   : > "$bfd/Brewfile"
   [ "$(profile_brewfiles work "$bfd" | wc -l | tr -d '[:space:]')" = "1" ]
 }
+
+# ── profile_component_summary ─────────────────────────────────────────────────
+@test "profile_component_summary: minimal → core only, no GUI/work/macOS" {
+  run profile_component_summary minimal
+  [ "$status" -eq 0 ]
+  grep -qE 'Package overlay +core only' <<<"$output"
+  grep -qE 'GUI apps \+ dotfiles +no' <<<"$output"
+  grep -qE 'Work configs +no' <<<"$output"
+  grep -qE 'macOS defaults +no' <<<"$output"
+}
+
+@test "profile_component_summary: personal → GUI overlay, macOS yes, work no" {
+  run profile_component_summary personal
+  grep -qE 'core \+ GUI \(Brewfile.personal\)' <<<"$output"
+  grep -qE 'GUI apps \+ dotfiles +yes' <<<"$output"
+  grep -qE 'macOS defaults +yes' <<<"$output"
+  grep -qE 'Work configs +no' <<<"$output"
+}
+
+@test "profile_component_summary: work → GUI + work overlay, work yes" {
+  run profile_component_summary work
+  grep -qE '\+ work \(Brewfile.work\)' <<<"$output"
+  grep -qE 'Work configs +yes' <<<"$output"
+  grep -qE 'macOS defaults +yes' <<<"$output"
+}
+
+@test "profile_component_summary: server → core only, no GUI" {
+  run profile_component_summary server
+  grep -qE 'Package overlay +core only' <<<"$output"
+  grep -qE 'GUI apps \+ dotfiles +no' <<<"$output"
+}


### PR DESCRIPTION
## Summary
Phase 3 / roadmap item 10 — guided first-run UX. On a genuine first run (no `--profile`, no `DOTFILES_PROFILE`, no persisted `~/.config/dotfiles/profile`) **and** an interactive TTY (and not `--dry-run`), `bootstrap.sh` now prompts for a profile and prints a short component summary before running. Everything else is unchanged.

- **`profile_helpers.sh`**: new pure, unit-tested `profile_component_summary` — describes a profile's components (runtimes, core dotfiles, package overlay, GUI apps + dotfiles, work configs, macOS defaults), derived from `profile_includes` so it stays in sync with the real gating.
- **`bootstrap.sh`**: `pick_profile()` menu (number or name; Enter/EOF → personal); first-run interactive selection else the existing precedence; persists the choice; prints the component summary in the banner before steps.
- **`dryrun_helpers.sh`**: `preview_profile()` mirrors the summary for `--dry-run`.
- **tests**: 4 `profile_component_summary` bats cases.

## Safety / non-interactive
The picker is guarded by `-t 0` **and** `DRY_RUN != true`, so CI and piped/non-interactive runs never prompt — they fall back to `personal` / `DOTFILES_PROFILE` / persisted exactly as before. Existing `--profile` runs are unchanged.

## Validation
- `bash -n` + `zsh -n bootstrap.sh`; `shellcheck -S warning` clean
- `bats scripts/tests/` → **162/162**
- `bootstrap.sh --dry-run --profile {personal,work,minimal,server}` shows the correct summary + gating; `bootstrap-dryrun` CI assertions still satisfied
- `pick_profile` maps 1-4 / names / empty / invalid-then-valid correctly

Co-Authored-By: Oz <oz-agent@warp.dev>