### PR TITLE
docs: v1.1.0 release notes + README docs-site polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-06-16
+
+First release since `v1.0.0`. Adds machine profiles, encrypted secrets, a live
+MkDocs documentation site, sheldon-managed zsh plugins, a Neovim baseline, and
+expanded CI/testing — plus a guided first-run experience.
+
 ### Added
-- Neovim baseline: `config/nvim/init.lua` (symlinked to `~/.config/nvim/init.lua`) plus `neovim` in the `Brewfile`. Dependency-free defaults — Space leader, line numbers, 2-space indent, smart-case search, system clipboard, readable diagnostics, and highlight-on-yank.
+- **Machine profiles** — every machine now resolves a profile (`personal`, `work`, `minimal`, `server`) that drives which packages, dotfiles, and bootstrap steps apply.
+  - Profile resolution and persistence with precedence `--profile` flag > `DOTFILES_PROFILE` env > `~/.config/dotfiles/profile` > `personal`, managed via `scripts/profile.sh` (aliased `dotprofile`).
+  - Profile-aware symlinking — `config/symlinks.map` entries can be tagged so only the active profile's dotfiles install.
+  - Per-profile Homebrew overlays — `Brewfile.personal` (GUI casks/fonts/apps on `personal`/`work`) and `Brewfile.work` (work-only additions) layered over the core `Brewfile`.
+  - Profile-gated bootstrap steps — work configs run only on `work`; macOS defaults only on `personal`/`work` (skipped on `minimal`/`server`).
+  - Guided first-run profile picker — `bootstrap.sh` prompts for a profile on a fresh machine and persists the choice.
+- **Encrypted secrets** — sops + age workflow via `scripts/secrets.sh` and `.sops.yaml`, documented in `docs/secrets.md`.
+- **Neovim baseline** — `config/nvim/init.lua` (symlinked to `~/.config/nvim/init.lua`) plus `neovim` in the `Brewfile`. Dependency-free defaults — Space leader, line numbers, 2-space indent, smart-case search, system clipboard, readable diagnostics, and highlight-on-yank.
+- **Zsh plugins via [sheldon](https://sheldon.cli.rs)** — `config/sheldon/plugins.toml` (symlinked to `~/.config/sheldon/plugins.toml`) managing fast-syntax-highlighting and zsh-autosuggestions.
+- **Documentation site** — MkDocs Material site deployed to GitHub Pages at <https://bradbergeron-us.github.io/dotfiles/> (`mkdocs.yml`, `.github/workflows/docs.yml`, `site_url`, pinned `docs/requirements.txt`).
+- **GitHub templates** — issue and pull request templates under `.github/`.
+- **Bootstrap dry-run CI** — `.github/workflows` job exercising `bootstrap.sh --dry-run` so the no-op path stays green.
+
+### Changed
+- **Test suite migrated to bats-core** — hand-rolled `scripts/lib/` unit tests replaced with bats-core tests, with `.github/workflows/test-bootstrap.yml` updated to run them. CONTRIBUTING now documents the bats workflow.
+
+### Fixed
+- Silenced dry-run stderr noise so `bootstrap.sh --dry-run` output stays clean.
 
 ## [1.0.0] - 2026-06-16
 
@@ -54,5 +77,6 @@ toolchain, work-machine support, and CI.
 #### Documentation
 - `README.md`, `CONTRIBUTING.md`, and `docs/` (tools, work-machine setup, GPG signing, dry-run/preflight, performance).
 
-[Unreleased]: https://github.com/bradbergeron-us/dotfiles/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/bradbergeron-us/dotfiles/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/bradbergeron-us/dotfiles/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/bradbergeron-us/dotfiles/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 Personal macOS dotfiles — zsh, tmux, git, and a full developer toolchain.
 
 ![CI](https://github.com/bradbergeron-us/dotfiles/actions/workflows/test-bootstrap.yml/badge.svg)
+![Docs](https://github.com/bradbergeron-us/dotfiles/actions/workflows/docs.yml/badge.svg)
+
+📖 **[Read the docs →](https://bradbergeron-us.github.io/dotfiles/)** — full documentation site (MkDocs Material, deployed to GitHub Pages).
 
 > **Security Note:** This repository contains safe-to-share configuration templates. Machine-specific configs with actual GPG keys, work emails, and infrastructure URLs are stored in `~/.config/git/*.gitconfig` and are never committed. See [Git Commit Signing](#git-commit-signing) for details.
 
@@ -398,9 +401,19 @@ git push
 
 ## 📚 Documentation
 
+The full documentation site is published at **<https://bradbergeron-us.github.io/dotfiles/>**. Every page is also browsable in [`docs/`](docs/):
+
 | Doc | Contents |
 |-----|---------|
-| [docs/tools.md](docs/tools.md) | Full descriptions, rationale, and commands for every tool |
-| [docs/work-setup-complete.md](docs/work-setup-complete.md) | **Complete work machine setup guide** — end-to-end from fresh macOS to production-ready |
-| [docs/work-machine.md](docs/work-machine.md) | Additional work topics — Brewfile.work, zshrc.local, direnv, NVM migration |
-| [docs/performance.md](docs/performance.md) | Shell startup optimization history and benchmarks |
+| [Home](docs/index.md) | Documentation landing page and site overview |
+| [Dry-Run & Pre-flight](docs/DRY_RUN_AND_PREFLIGHT.md) | Previewing changes and read-only system checks before bootstrap |
+| [GPG Commit Signing](docs/GPG_SIGNING.md) | SSH/GPG signing, per-organization configs, uploading keys, troubleshooting |
+| [Encrypted Secrets](docs/secrets.md) | sops + age workflow for encrypting and managing secrets |
+| [Machine Profiles](docs/profiles.md) | `personal`/`work`/`minimal`/`server` profiles, selection precedence, and how they drive packages, symlinks, and bootstrap steps |
+| [Usage & Lifecycle](docs/usage.md) | Day-to-day lifecycle — bootstrap, dry-run, update, verify, status, and scheduling |
+| [Work Machine](docs/work-machine.md) | Additional work topics — Brewfile.work, zshrc.local, direnv, NVM migration |
+| [Complete Work Setup Guide](docs/work-setup-complete.md) | **End-to-end work machine setup** — from fresh macOS to production-ready |
+| [Claude Code SSL Fix](docs/claude-code-ssl-fix.md) | Resolving Claude Code SSL/certificate issues behind a corporate proxy |
+| [Tool Reference](docs/tools.md) | Full descriptions, rationale, and commands for every tool |
+| [Shell Performance](docs/performance.md) | Shell startup optimization history and benchmarks |
+| [Contributing](docs/contributing.md) | Contribution workflow — bats-core tests, shellcheck, CI jobs, and conventional commits |


### PR DESCRIPTION
## Summary
Release notes for **v1.1.0** plus README documentation-site polish. Scoped to `CHANGELOG.md` and `README.md` only (no `docs/` or `mkdocs.yml`).

### CHANGELOG.md
- New `## [1.1.0] - 2026-06-16` section in Keep a Changelog format (Added / Changed / Fixed) capturing everything merged since `v1.0.0`.
- Machine profiles (#48–#51, #58) presented as one coherent feature; also covers GitHub templates (#46), Neovim baseline (#47), encrypted secrets (#53), bootstrap dry-run CI (#54), bats-core migration (#55), MkDocs docs site (#52), sheldon zsh plugins (#56), and the dry-run stderr fix (#57).
- Folded the old `[Unreleased]` Neovim entry into 1.1.0; left a fresh empty `[Unreleased]`.
- Added a `1.1.0` version-compare link and repointed `[Unreleased]` to `v1.1.0...HEAD`.

### README.md
- Added a `docs.yml` workflow badge next to the CI badge and a prominent link to the live site: https://bradbergeron-us.github.io/dotfiles/
- Expanded the **📚 Documentation** section into a complete list of every published page.

> Note: `docs/profiles.md`, `docs/usage.md`, and `docs/contributing.md` are added by sibling PRs in this same batch. They are referenced at those paths and resolve once those PRs merge.

### Not in scope
- No `v1.1.0` git tag is created/pushed here — tagging happens later after all PRs land, with explicit user confirmation.

### Shared files
- None. This PR does **not** touch `mkdocs.yml`, so no nav-edit conflict with sibling docs PRs.

### Validation
- gitleaks pre-commit hook: **Passed**.
- Verified all README doc links resolve in-repo except the three sibling-PR pages (`profiles.md`, `usage.md`, `contributing.md`), which resolve on merge.
- `mkdocs build --strict` not applicable (no `docs/` or `mkdocs.yml` changes; `README.md` is not part of the site build).

_Conversation: https://app.warp.dev/conversation/494a439d-a240-48d7-a3ea-45889245b74c_
_Run: https://oz.warp.dev/runs/019ed126-7ab2-7a56-8bc0-81031009163f_

_This PR was generated with [Oz](https://warp.dev/oz)._
