### PR TITLE
docs(tutorials): add learning-oriented Tutorials section

### DIFF
--- a/docs/tutorials/adopt-profile.md
+++ b/docs/tutorials/adopt-profile.md
@@ -1,0 +1,135 @@
+# Adopt a profile on an existing machine
+
+Already set up a machine and want to **change** its profile — say, turn a
+`personal` laptop into a `work` one, or trim a desktop down to `minimal`? You do
+**not** need to re-run `bootstrap.sh`. This tutorial switches a profile in place
+with `dotprofile` (the alias for `scripts/profile.sh`) and re-applies it with
+`install.sh` + `update.sh`.
+
+A profile is the durable identity of a machine, persisted at
+`~/.config/dotfiles/profile` and honored by every lifecycle script. For the
+conceptual model and the per-component matrix, see the
+[Profiles reference](../profiles.md).
+
+## Step 1 — See the current profile
+
+Check what this machine is set to today:
+
+```sh
+dotprofile
+```
+
+```text
+  Active profile  personal
+  ℹ set in ~/.config/dotfiles/profile
+```
+
+If no profile file exists yet, you will instead see that it is the default
+(`personal`) with a hint to set one. List the available profiles any time:
+
+```sh
+dotprofile list
+```
+
+```text
+  Available profiles: minimal personal work server
+  Active: personal
+```
+
+!!! info "`dotprofile` is `scripts/profile.sh`"
+    The alias is shorthand for `bash ~/dotfiles/scripts/profile.sh`. If the alias
+    isn't loaded yet (for example in a non-interactive shell), call the script
+    directly.
+
+## Step 2 — Set the new profile
+
+Persist the new profile. For example, adopt `work`:
+
+```sh
+dotprofile set work
+```
+
+```text
+  ✓ profile set to 'work'  (~/.config/dotfiles/profile)
+  ℹ Apply it: zsh ~/dotfiles/install.sh  &&  bash ~/dotfiles/update.sh
+```
+
+`set` validates the name against `minimal | personal | work | server` (an
+unknown name is rejected), then writes it to `~/.config/dotfiles/profile` via
+`persist_profile`. Setting the profile only records the choice — it does not yet
+change what is installed or linked. That is the next step.
+
+!!! tip "Try it without persisting"
+    To preview a profile's effect for a single command instead of persisting it,
+    set the `DOTFILES_PROFILE` environment variable, which outranks the file:
+    `DOTFILES_PROFILE=work bash ~/dotfiles/verify.sh`. A one-off `--profile` flag
+    on `bootstrap.sh` outranks everything. Precedence is
+    `--profile flag > DOTFILES_PROFILE env > profile file > default`.
+
+## Step 3 — Re-link dotfiles for the new profile
+
+Re-run the symlink installer so the set of linked dotfiles matches the new
+profile (adopting `work`/`gui`-tagged files, or skipping them when you downgrade):
+
+```sh
+zsh ~/dotfiles/install.sh
+```
+
+`install.sh` is idempotent and reads `current_profile`, creating only the links
+that apply to the now-active profile. Records tagged for other profiles are
+skipped, and any real file already at a destination is backed up to
+`~/.dotfiles_backup/` before a link replaces it — nothing is overwritten in
+place. Each link is reported as **current**, **linked**, **backed up**, or
+**skip**.
+
+## Step 4 — Re-run update to install the rest
+
+Pull in the profile's packages and run the health check:
+
+```sh
+bash ~/dotfiles/update.sh
+```
+
+This re-runs `install.sh`, then upgrades Homebrew (installing any newly relevant
+overlay packages on the next `brew bundle`/drift cycle), mise runtimes, Rust, and
+gems, and finishes with `verify.sh`. Because `update.sh` reads `current_profile`,
+it only touches the components the new profile includes.
+
+!!! note "Switching *to* `work`?"
+    The work-configs prompt (Maven/Yarn/Continue/Claude/AWS) and corporate
+    certificates are part of bootstrap's `work` step, not `update.sh`. Run that
+    setup explicitly: `bash ~/dotfiles/scripts/setup_work_configs.sh`. The
+    [Set up a work laptop](work-laptop.md) tutorial covers the full work flow.
+
+## Step 5 — Confirm the switch
+
+Verify the machine is healthy under the new profile and confirm the banner shows
+it:
+
+```sh
+bash ~/dotfiles/verify.sh
+```
+
+`verify.sh` prints `Profile  work` (or whichever you chose) and filters its
+symlink and Brewfile-drift checks by that profile, so it won't flag dotfiles or
+packages intentionally excluded by the new profile. A quick recap:
+
+```sh
+dotstatus
+```
+
+The status snapshot's `Profile` line should now read the profile you adopted.
+
+## Done
+
+Switching a machine's profile is just: `dotprofile set <name>` →
+`zsh ~/dotfiles/install.sh` → `bash ~/dotfiles/update.sh`. No re-bootstrap
+required, because every lifecycle script reads the same persisted profile.
+
+## Where to next
+
+- [Profiles reference](../profiles.md) — the precedence rules and the full
+  per-component matrix.
+- [Set up a work laptop](work-laptop.md) — the complete `work`-profile flow.
+- [Usage & lifecycle](../usage.md) — every command and flag for `install.sh`,
+  `update.sh`, `verify.sh`, and `status.sh`.

--- a/docs/tutorials/getting-started.md
+++ b/docs/tutorials/getting-started.md
@@ -1,0 +1,229 @@
+# Getting started: your first hour
+
+This tutorial takes a **brand-new Mac** from nothing to a fully managed
+development environment, then shows you the everyday loop that keeps it healthy.
+It is learning-oriented: follow it top to bottom and you will end with a
+verified setup and the muscle memory for the daily commands.
+
+Allow roughly an hour — most of that is unattended package and runtime
+installation. Every command below maps to a real script in the repo, and the
+output snippets are illustrative of what you will see.
+
+!!! note "What you need first"
+    A Mac running macOS 12 (Monterey) or later, an internet connection, and a
+    GitHub account. You do **not** need Homebrew, Xcode, or any developer tools
+    installed yet — `bootstrap.sh` installs them for you.
+
+## Step 1 — Clone the repo
+
+Clone into `~/dotfiles` (the path every script assumes):
+
+```sh
+git clone https://github.com/bradbergeron-us/dotfiles.git ~/dotfiles
+```
+
+!!! tip "No git yet?"
+    A fresh Mac may not have `git`. Running any `git` command triggers Apple's
+    "command line developer tools" installer — accept it, wait for it to finish,
+    then re-run the clone. `bootstrap.sh` also installs the full Xcode Command
+    Line Tools in Step 1 below.
+
+## Step 2 — Run bootstrap
+
+Kick off the one-time setup:
+
+```sh
+bash ~/dotfiles/bootstrap.sh
+```
+
+`bootstrap.sh` runs a **14-step** setup: Xcode Command Line Tools, Homebrew,
+packages (`brew bundle`), fzf shell integration, an SSH signing key, GitHub CLI
+auth, mise runtimes, Yarn via Corepack, Rust via rustup, git-lfs, dotfile
+symlinks (it calls `install.sh`), optional work configs, and macOS defaults.
+
+### The first-run profile picker
+
+Because this is a genuine first run (no `--profile` flag, no `DOTFILES_PROFILE`
+environment variable, no saved profile file, and an interactive terminal),
+bootstrap greets you with the profile picker before doing anything:
+
+```text
+  This machine has no saved profile yet — pick one:
+
+    1) personal  (default) — full GUI Mac: core + GUI apps/casks + macOS defaults
+    2) work                — personal plus the work overlay & work configs
+    3) minimal             — core CLI + runtimes + core dotfiles only
+    4) server              — headless macOS: core CLI + runtimes, no GUI
+
+  Profile [1-4 or name, Enter = personal]:
+```
+
+For your first personal Mac, press **Enter** to accept `personal`. You can type
+a number (`1`–`4`) or a name (`personal`, `work`, `minimal`, `server`). The
+choice is **persisted** to `~/.config/dotfiles/profile` so that `update.sh`,
+`verify.sh`, and `status.sh` all agree on this machine's profile afterward.
+
+!!! info "Skipping the picker"
+    Pass the profile up front to bypass the prompt entirely:
+    `bash ~/dotfiles/bootstrap.sh --profile work`. See the
+    [Adopt a profile](adopt-profile.md) tutorial and the
+    [Profiles reference](../profiles.md) for the full precedence rules.
+
+### The component summary
+
+Right after the profile is resolved, bootstrap prints a banner and a summary of
+exactly what this profile will set up — derived from `profile_component_summary`
+so it always matches what the steps actually do:
+
+```text
+  🚀  dotfiles bootstrap  —  macOS developer setup
+  ─────────────────────────────────────────────────
+  Machine  Brad's MacBook Pro
+  Date     Mon Jun 16 2026  09:00
+  Profile  personal
+  ─────────────────────────────────────────────────
+  This profile sets up
+  Runtimes (mise)      yes
+  Core CLI + dotfiles  yes
+  Package overlay      core + GUI (Brewfile.personal)
+  GUI apps + dotfiles  yes
+  Work configs         no
+  macOS defaults       yes
+  ─────────────────────────────────────────────────
+```
+
+Use this as a sanity check: if the profile line or the component rows are not
+what you expected, `Ctrl-C` now and re-run with the right `--profile`.
+
+### What to expect during the steps
+
+A few steps are interactive or long-running:
+
+- **Pre-flight check** — validates the system first. Critical errors abort the
+  run; warnings prompt you to continue (auto-continuing after 10 seconds).
+- **SSH key for commit signing** — if you have no `~/.ssh/id_ed25519`, bootstrap
+  generates one, copies the public key to your clipboard, and pauses with
+  instructions to add it to GitHub as a **Signing Key** at
+  `https://github.com/settings/ssh/new`. Press Enter once you have added it.
+- **GitHub CLI auth** — if `gh` is installed but not logged in, it runs
+  `gh auth login`.
+- **Runtimes via mise** — installing runtimes can take 5–10 minutes (compiling
+  from source). It prompts before installing and auto-continues after 10s.
+
+When everything finishes you will see:
+
+```text
+  🎉  Bootstrap complete  in 18m 42s
+  ─────────────────────────────────────────────────
+
+  Next steps
+  1. Edit ~/.zshrc.local with machine-specific config
+  2. Open a new terminal  (or: source ~/.zshrc)
+  3. Keep everything current: bash ~/dotfiles/update.sh
+```
+
+!!! tip "Preview without changing anything"
+    Curious before you commit? `bash ~/dotfiles/bootstrap.sh --dry-run` walks
+    through every step and the component preview without installing a thing (and
+    without persisting a profile or showing the picker). See
+    [Dry-Run & Pre-flight](../DRY_RUN_AND_PREFLIGHT.md).
+
+## Step 3 — Open a new shell
+
+The dotfiles set up zsh, the starship prompt, and dozens of tools. Pick up the
+new configuration by opening a new terminal tab, or reload in place:
+
+```sh
+exec zsh
+```
+
+You should now have a starship prompt and aliases like `dotstatus` available.
+
+## Step 4 — Verify the setup
+
+Confirm the environment is healthy with the read-only health check:
+
+```sh
+bash ~/dotfiles/verify.sh
+```
+
+`verify.sh` covers **nine** areas: symlinks, required tools, stale backups, the
+SSH key, git-lfs, mise runtimes, dotfiles git health, Brewfile drift, and the
+git config include. A clean run ends with:
+
+```text
+  ✅  All checks passed  (3s)
+```
+
+Only broken symlinks are treated as an error (exit `1`); everything else is a
+non-blocking warning. If you see warnings, the message tells you how to fix
+them — for example `missing: <tool> — run: bash ~/dotfiles/bootstrap.sh`.
+
+For an even faster look, use the status snapshot (aliased to `dotstatus`):
+
+```sh
+dotstatus
+```
+
+```text
+  🩺  dotfiles status
+  ─────────────────────────────────────────────────
+  Profile     personal
+  Repo        ~/dotfiles
+  Branch      main  (clean)
+  Upstream    in sync
+  ─────────────────────────────────────────────────
+  No update.status yet — run:  bash ~/dotfiles/update.sh
+```
+
+`dotstatus` shows the active profile, the repo's git state, and the result of
+the last `update.sh` run. Right after bootstrap there is no update status yet —
+that is expected.
+
+## Step 5 — The daily loop
+
+From here on, one command keeps everything current:
+
+```sh
+bash ~/dotfiles/update.sh
+```
+
+`update.sh` runs **seven** self-healing steps: pull the dotfiles
+(`git pull --rebase --autostash`), re-run `install.sh` to pick up new symlinks,
+upgrade Homebrew, upgrade mise runtimes, update Rust, update Ruby gems, and
+finally run `verify.sh`. An individual step failing never aborts the run —
+failures are collected and reported at the end:
+
+```text
+  ✅  Update complete  in 1m 12s
+```
+
+After an update, `dotstatus` reflects the last run:
+
+```text
+  Last update 2026-06-16T16:00:00Z
+  ✓ result: success  (72s)
+```
+
+!!! tip "Make it automatic"
+    Schedule a daily run with launchd:
+    `bash ~/dotfiles/scripts/setup-scheduler.sh` (runs at 9 AM). See
+    [Usage & lifecycle](../usage.md#scheduling-daily-updates-setup-schedulersh)
+    for scheduler options and per-machine defaults.
+
+## You're set up
+
+You now have a verified environment and the everyday loop:
+
+- `bash ~/dotfiles/update.sh` — pull, re-symlink, upgrade, verify.
+- `dotstatus` — a quick read-only snapshot.
+- `bash ~/dotfiles/verify.sh` — the full health check on demand.
+
+## Where to next
+
+- [Set up a work laptop](work-laptop.md) — the guided `work`-profile flow with
+  corporate configs, secrets, and commit signing.
+- [Adopt a profile on an existing machine](adopt-profile.md) — switch profiles
+  without re-bootstrapping.
+- [Profiles reference](../profiles.md) — how profiles gate every component.
+- [Usage & lifecycle](../usage.md) — the complete command and flag reference.

--- a/docs/tutorials/work-laptop.md
+++ b/docs/tutorials/work-laptop.md
@@ -1,0 +1,190 @@
+# Set up a work laptop
+
+This tutorial walks a fresh **work** Mac from clone to a verified state using the
+`work` profile. The `work` profile is a superset of `personal`: it adds the work
+package overlay (`Brewfile.work`), `work`-tagged dotfiles, and the work-configs
+prompt for corporate Maven/Yarn/Bundle/Continue/Claude/AWS setup.
+
+This page focuses on the work-specific decisions — the profile, the work-configs
+prompt, secrets, and commit signing. For an annotated walkthrough of the generic
+steps, do the [Getting started](getting-started.md) tutorial first. For the
+exhaustive corporate reference (certificates, AWS Bedrock, VS Code extensions),
+see the [Complete Work Machine Setup Guide](../work-setup-complete.md).
+
+!!! note "Before you start"
+    Have on hand: access to your dotfiles repo, corporate network/VPN access, and
+    any registry or AWS credentials your team uses. macOS 12+ with admin access.
+
+## Step 1 — Clone and bootstrap with the work profile
+
+Clone the repo, then bootstrap with `--profile work` so you never have to touch
+the picker:
+
+```sh
+git clone https://github.com/bradbergeron-us/dotfiles.git ~/dotfiles
+bash ~/dotfiles/bootstrap.sh --profile work
+```
+
+Passing `--profile work` resolves and **persists** the `work` profile to
+`~/.config/dotfiles/profile`, so `update.sh`, `verify.sh`, and `status.sh` all
+treat this machine as a work machine afterward. The component summary confirms
+the work-specific rows are enabled:
+
+```text
+  Profile  work
+  ─────────────────────────────────────────────────
+  This profile sets up
+  Runtimes (mise)      yes
+  Core CLI + dotfiles  yes
+  Package overlay      core + GUI (Brewfile.personal) + work (Brewfile.work)
+  GUI apps + dotfiles  yes
+  Work configs         yes
+  macOS defaults       yes
+  ─────────────────────────────────────────────────
+```
+
+Note the package overlay line: `work` installs the core `Brewfile`,
+`Brewfile.personal` (GUI), **and** `Brewfile.work`, in that order.
+
+## Step 2 — Set up commit signing (SSH key)
+
+During the **SSH key for commit signing** step, if you have no
+`~/.ssh/id_ed25519`, bootstrap generates an Ed25519 key, registers it for local
+signature verification (`~/.config/git/allowed_signers`), and copies the public
+key to your clipboard. It then pauses with instructions:
+
+```text
+  Action required: add your key to GitHub
+
+  Your public key is already on your clipboard. Go to:
+    https://github.com/settings/ssh/new
+
+  Title:    e.g. 'MacBook Pro — commit signing'
+  Key type: Signing Key  ← not Authentication Key
+  Key:      paste from clipboard
+```
+
+Add the key to GitHub as a **Signing Key** (not an Authentication Key), then
+press Enter to continue. From here every commit is SSH-signed and GitHub shows a
+**Verified** badge.
+
+!!! tip "Already have a key?"
+    If `~/.ssh/id_ed25519` exists, bootstrap skips generation and keeps your
+    current key. To use GPG instead of SSH signing, see
+    [GPG Commit Signing](../GPG_SIGNING.md).
+
+## Step 3 — Answer the work-configs prompt
+
+Because the profile is `work`, bootstrap reaches the **Work-specific
+configurations** step (other profiles skip it entirely). It prompts:
+
+```text
+  Setup work configs (.m2, .yarnrc, .continue, .claude, .aws)?
+
+  Run work configuration setup? [y/N]
+```
+
+Answer `y` to run `scripts/setup_work_configs.sh` now (recommended on first
+setup). It interactively offers to create each corporate config — Maven
+(`~/.m2/settings.xml`), Yarn (`~/.yarnrc`), Bundle (`~/.bundle/config`), Continue
+(`~/.continue/config.yaml`), Claude Code (`~/.claude/settings.json`), and AWS
+(`~/.aws/config`) — backing up any existing file first.
+
+If you answer `n`, you can run it manually any time:
+
+```sh
+bash ~/dotfiles/scripts/setup_work_configs.sh
+```
+
+!!! info "Corporate certificates and Claude Code SSL"
+    Behind a corporate proxy you will likely also need the Zscaler root
+    certificate and `NODE_EXTRA_CA_CERTS`. Those steps live in the
+    [Complete Work Machine Setup Guide](../work-setup-complete.md) and
+    [Claude Code SSL Fix](../claude-code-ssl-fix.md).
+
+## Step 4 — Encrypt your work secrets (sops + age)
+
+Store work tokens and credentials **encrypted in git** with sops + age. `sops`
+and `age` ship in the core `Brewfile`, so they are already installed. One-time
+key setup per machine:
+
+```sh
+mkdir -p ~/.config/sops/age
+age-keygen -o ~/.config/sops/age/keys.txt
+```
+
+This prints your `age1...` **public key**. Register it as a recipient in
+`.sops.yaml`, commit that file, then edit secrets through the wrapper:
+
+```sh
+bash ~/dotfiles/scripts/secrets.sh edit secrets/work.yaml
+```
+
+!!! warning "Back up the private key"
+    `~/.config/sops/age/keys.txt` lives **outside** the repo and is never
+    committed. If you lose it, encrypted files become unrecoverable — store a
+    copy in your password manager. Full details, including re-keying and the
+    safety model, are in [Encrypted Secrets](../secrets.md).
+
+## Step 5 — Tune updates for pinned tooling
+
+Work machines often pin tool versions. Run the daily loop in `--no-upgrade` mode
+so it still pulls dotfiles, re-symlinks, and verifies, but skips
+brew/mise/rustup/gem upgrades:
+
+```sh
+bash ~/dotfiles/update.sh --no-upgrade
+```
+
+To make that the persistent default — including for the scheduled launchd job,
+which does **not** source your shell rc — set it in the per-machine config file:
+
+```sh
+mkdir -p ~/.config/dotfiles
+printf 'NO_UPGRADE=true\n' >> ~/.config/dotfiles/update.conf
+```
+
+`update.sh` reads `~/.config/dotfiles/update.conf` directly on every run. See
+[Usage & lifecycle](../usage.md#per-machine-defaults-updateconf) for the full
+precedence (config file < environment < flags).
+
+## Step 6 — Reach a verified state
+
+Open a new shell and run the health check:
+
+```sh
+exec zsh
+bash ~/dotfiles/verify.sh
+```
+
+`verify.sh` prints the active profile in its banner (`Profile  work`) and uses it
+to filter the symlink check and Brewfile-drift check — so it validates the core,
+personal, **and** work Brewfiles together. Aim for:
+
+```text
+  ✅  All checks passed  (3s)
+```
+
+A quick repeatable snapshot afterward:
+
+```sh
+dotstatus
+```
+
+It reports the active profile, the repo's git state, and the result of the last
+`update.sh` run.
+
+## You're done
+
+Your work laptop is now on the `work` profile with corporate configs, encrypted
+secrets, verified commit signing, and an update loop tuned for pinned tooling.
+
+## Where to next
+
+- [Complete Work Machine Setup Guide](../work-setup-complete.md) — certificates,
+  AWS Bedrock/SSO, registries, and VS Code extensions in depth.
+- [Encrypted Secrets](../secrets.md) — the full sops + age workflow.
+- [Profiles reference](../profiles.md) — how the `work` profile gates each
+  component.
+- [Adopt a profile on an existing machine](adopt-profile.md) — switch an
+  existing machine to (or from) `work`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,10 @@ plugins:
 
 nav:
   - Home: index.md
+  - Tutorials:
+      - Getting Started (Your First Hour): tutorials/getting-started.md
+      - Set Up a Work Laptop: tutorials/work-laptop.md
+      - Adopt a Profile: tutorials/adopt-profile.md
   - Profiles: profiles.md
   - Usage: usage.md
   - Setup:


### PR DESCRIPTION
## Summary
Adds a learning-oriented **Tutorials** section (Diátaxis) to the docs site, with three guided walkthroughs grounded in the repo's actual scripts (`bootstrap.sh`, `scripts/lib/profile_helpers.sh`, `verify.sh`, `update.sh`, `scripts/status.sh`, `scripts/profile.sh`):

- **`docs/tutorials/getting-started.md`** — "Your first hour": fresh Mac → clone → `bash bootstrap.sh` (walks the interactive first-run profile picker and the `profile_component_summary` output) → open a new shell → `verify.sh` / `dotstatus` → the daily `update.sh` loop. Annotated commands with expected output.
- **`docs/tutorials/work-laptop.md`** — guided `work`-profile setup: `bootstrap --profile work`, SSH commit signing, the work-configs prompt, sops+age secrets, and `--no-upgrade` tuning, ending at a verified state.
- **`docs/tutorials/adopt-profile.md`** — switching/adopting a profile on an existing machine via `dotprofile` / `scripts/profile.sh set`, then re-running `install.sh` + `update.sh`.

All pages use relative links to existing docs (Profiles, Usage, Secrets, Work Machine, etc.) for depth.

## mkdocs --strict result
`uvx --with mkdocs-material mkdocs build --strict` — clean, **zero warnings**, exit 0.

## mkdocs.yml nav note
Adds a single `Tutorials:` nav section (the three pages) immediately after `Home`. This is the only shared-file change; later docs PRs will rebase trivially.

_Conversation: https://app.warp.dev/conversation/02fdfa6e-8366-4b0c-ad21-af8fbae946e9_
_Run: https://oz.warp.dev/runs/019ed143-998b-7eca-b8e2-d7f9a32e28e0_

_This PR was generated with [Oz](https://warp.dev/oz)._
