### PR TITLE
docs: reference & explanation (architecture, troubleshooting, glossary) + performance/secrets enrichment

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,234 @@
+# Architecture
+
+How the pieces fit together: a small set of lifecycle scripts read a few
+**single-source-of-truth (SSOT)** files and reshape a machine according to its
+[profile](profiles.md). This page is the mental model — what each script does,
+where the SSOT files are consumed, and how a change flows from one file to every
+consumer.
+
+## The big picture
+
+```mermaid
+flowchart TB
+  subgraph SSOT["Single sources of truth"]
+    SM["config/symlinks.map"]
+    MISE["config/mise.toml"]
+    SHELDON["config/sheldon/plugins.toml"]
+    BREW["Brewfile (+ .personal / .work overlays)"]
+    SOPS[".sops.yaml"]
+    CONF["~/.config/dotfiles/update.conf"]
+    PROF["~/.config/dotfiles/profile"]
+  end
+
+  subgraph LIFECYCLE["Lifecycle scripts"]
+    BOOT["bootstrap.sh"]
+    INSTALL["install.sh"]
+    UPDATE["update.sh"]
+    VERIFY["verify.sh"]
+    STATUS["scripts/status.sh"]
+  end
+
+  PROF -->|resolve_profile| BOOT
+  PROF -->|current_profile| INSTALL
+  PROF -->|current_profile| UPDATE
+  PROF -->|current_profile| VERIFY
+  PROF -->|current_profile| STATUS
+
+  BOOT -->|preflight + installs tools| BREW
+  BOOT -->|installs runtimes| MISE
+  BOOT -->|delegates symlinking| INSTALL
+  INSTALL -->|reads links to create| SM
+  INSTALL -->|symlinks plugin manifest| SHELDON
+
+  UPDATE -->|git pull + re-run| INSTALL
+  UPDATE -->|brew/mise/rustup upgrades| BREW
+  UPDATE -->|health check| VERIFY
+  UPDATE -->|reads defaults| CONF
+
+  VERIFY -->|checks links| SM
+  VERIFY -->|checks runtimes| MISE
+  VERIFY -->|checks drift| BREW
+
+  STATUS -->|reads last-run result| LOG["logs/update.status"]
+  UPDATE -->|writes| LOG
+  SOPS -.->|policy for secrets.sh| SEC["scripts/secrets.sh"]
+```
+
+## Lifecycle scripts
+
+The repo is driven by five scripts. Each is safe to re-run (idempotent) and
+reads the active profile so it only touches the components that profile
+includes.
+
+### `bootstrap.sh` — one-time setup on a fresh Mac
+
+Installs everything and links your dotfiles. It runs a 14-step sequence:
+Xcode CLT → Homebrew → `brew bundle` (profile Brewfiles) → fzf integration →
+SSH signing key → `gh` auth → mise runtimes → Corepack/Yarn → Rust → TPM note →
+git-lfs → **dotfile symlinks (delegates to `install.sh`)** → work configs (work
+profile) → macOS defaults (GUI profiles).
+
+On a genuine first run (no `--profile`, no `DOTFILES_PROFILE`, no persisted
+profile file, interactive TTY, not a dry-run) it shows the **first-run picker**
+to choose `personal` / `work` / `minimal` / `server`, then persists the choice.
+
+```sh
+bash bootstrap.sh                 # interactive, picks/uses a profile
+bash bootstrap.sh --profile work  # force a profile
+bash bootstrap.sh --dry-run       # preview every step, change nothing
+bash bootstrap.sh --skip-preflight
+```
+
+Before any changes it runs [`scripts/preflight.sh`](DRY_RUN_AND_PREFLIGHT.md)
+(OS, arch, disk, network, conflicting package managers, existing dotfiles, …).
+Critical errors abort; warnings prompt to continue.
+
+### `install.sh` — symlink dotfiles into `$HOME`
+
+The symlink engine. It resolves `current_profile`, reads
+[`config/symlinks.map`](#configsymlinksmap), and for each record that applies to
+the profile creates `~/<dest> → <repo>/<src>`. Existing real files are moved to a
+timestamped backup under `~/.dotfiles_backup/<date>/` before linking.
+
+It also performs the **non-symlink** setup that does not belong in the map: the
+thin `~/.gitconfig` include (see below), seeding `~/.config/git/local.gitconfig`,
+the global `pre-commit` hook, and VS Code settings/extensions.
+
+```sh
+zsh install.sh   # re-link for the current profile (run after editing the map)
+```
+
+### `update.sh` — keep everything current
+
+The daily maintenance script. Seven steps:
+
+1. **Dotfiles** — `git pull --rebase --autostash` (skipped if the tree is dirty
+   unless `--force-pull`; an interrupted rebase is auto-aborted).
+2. **Symlinks** — re-run `install.sh` to pick up new/renamed links.
+3. **Homebrew** — `brew update && upgrade && autoremove && cleanup`.
+4. **Runtimes** — `mise upgrade`.
+5. **Rust** — `rustup update`.
+6. **Ruby gems / uv tools** — `gem update --system`, `uv tool upgrade --all`.
+7. **Health check** — runs `verify.sh`.
+
+Steps are individually fault-tolerant: a failure is recorded, not fatal, and the
+run finishes. On completion it writes `logs/update.status` and, on failure,
+posts a macOS notification.
+
+```sh
+bash update.sh              # full update
+bash update.sh --no-upgrade # pull + re-symlink + verify only (pinned tooling)
+bash update.sh --no-pull    # skip git pull
+bash update.sh --dry-run    # preview, change nothing
+```
+
+Schedule it daily via launchd with
+[`scripts/setup-scheduler.sh`](troubleshooting.md#scheduled-updates).
+
+### `verify.sh` — read-only health check
+
+Nine checks: broken symlinks (the only **error**, exit 1), required tools,
+stale backups, SSH key, git-lfs global init, mise runtimes installed, dotfiles
+git health (conflict markers / parseable git config), Brewfile drift, and the
+`~/.gitconfig` include. Everything except broken symlinks is a non-fatal
+warning. `update.sh` calls it automatically as its final step.
+
+```sh
+bash verify.sh
+```
+
+### `scripts/status.sh` — quick snapshot (`dotstatus`)
+
+Read-only and fast. Prints the repo's git state (branch, dirty/untracked,
+ahead/behind) plus the result of the last `update.sh` run (read from
+`logs/update.status`). Aliased to `dotstatus`.
+
+```sh
+bash scripts/status.sh             # repo + last-update summary
+bash scripts/status.sh --verify    # also run the full verify.sh
+bash scripts/status.sh --exit-code # non-zero exit if unhealthy (for scripting)
+```
+
+## The profile system
+
+A [**profile**](profiles.md) is the durable identity of a machine
+(`minimal` / `personal` / `work` / `server`), persisted at
+`~/.config/dotfiles/profile`. The pure helpers in
+[`scripts/lib/profile_helpers.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/scripts/lib/profile_helpers.sh)
+(`resolve_profile`, `current_profile`, `profile_includes`, `profile_brewfiles`,
+…) are shared by every lifecycle script, so the active profile gates the same
+components everywhere — package overlays, profile-tagged symlinks, work configs,
+and macOS defaults. See [Machine Profiles](profiles.md) for the full tag rules.
+
+## Single sources of truth
+
+The design goal is **one place to change each thing**. Every consumer reads the
+same file, so adding a tracked dotfile, a runtime, or a plugin is a one-line
+edit that the whole toolchain picks up.
+
+### `config/symlinks.map`
+
+The manifest of tracked dotfile symlinks — one `<src> <dest> [tags]` record per
+line. `src` is relative to the repo, `dest` is relative to `$HOME`, and the
+optional `tags` column (`gui`, `work`, a profile name, or blank for all) gates
+which profiles get the link.
+
+Consumed by `install.sh` (creates the links), `verify.sh` (checks them),
+`bootstrap.sh --dry-run` (previews them), and the CI install-smoke job. Add a
+tracked dotfile by adding one line here — every consumer picks it up.
+
+!!! note "Bespoke, not in the map"
+    The `~/.gitconfig` thin include, `local.gitconfig` seed, global pre-commit
+    hook, and VS Code settings are intentionally **not** symlinks. They live as
+    bespoke logic in `install.sh`.
+
+### `config/mise.toml`
+
+The runtime version manifest (`node`, `ruby`, `java`, `python`, `go`).
+`bootstrap.sh` parses it to install runtimes; `verify.sh` checks they are
+installed; `mise` itself reads the symlinked copy at `~/.config/mise/config.toml`
+for automatic per-project version switching.
+
+### `config/sheldon/plugins.toml`
+
+The declarative zsh plugin manifest for [sheldon](glossary.md#sheldon).
+Symlinked to `~/.config/sheldon/plugins.toml` and sourced from `home/zshrc` via
+`eval "$(sheldon source)"`. Add a `[plugins.<name>]` block to add a plugin on
+every machine.
+
+### `Brewfile` and overlays
+
+The core `Brewfile` plus the `Brewfile.personal` (GUI) and `Brewfile.work`
+overlays. `profile_brewfiles` decides which files apply: core always, `.personal`
+for GUI profiles, `.work` for the work profile. `bootstrap.sh` installs from this
+list; `verify.sh` checks the same list for drift.
+
+### `.sops.yaml`
+
+The encryption policy for [sops + age](secrets.md): `creation_rules` map file
+paths (`path_regex`) to age recipients (public keys). `scripts/secrets.sh` and
+`sops` read it to decide which files to encrypt and for whom. See
+[Encrypted Secrets](secrets.md).
+
+### `~/.config/dotfiles/update.conf`
+
+Per-machine defaults for `update.sh` (e.g. `NO_UPGRADE=true`). Read **directly**
+by `update.sh` on every run — crucial because the scheduled launchd job does not
+source your shell rc, so an env var in `~/.zshrc` would never reach it. Precedence
+is config file < environment variables < command-line flags.
+
+### The thin `~/.gitconfig` include
+
+`~/.gitconfig` is a **real file**, not a symlink. `install.sh` writes a tiny file
+that `[include]`s the tracked `home/gitconfig`. Keeping it a real file means
+`git config --global …` and tools like `gh auth setup-git` write into your local
+file (overriding shared defaults on that machine only) instead of corrupting the
+tracked repo file. `verify.sh` confirms the include is intact.
+
+## Where to go next
+
+- [Machine Profiles](profiles.md) — the tag rules behind every gate above.
+- [Troubleshooting](troubleshooting.md) — what to do when a step fails.
+- [Glossary](glossary.md) — definitions for the terms used here.
+- The **How-to guides** section — task-oriented recipes (add a tracked dotfile,
+  add a package, rotate a secret, add a zsh plugin, recover from a failed update).

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,109 @@
+# Glossary
+
+Definitions for the terms used throughout this repo and its docs. Repo-specific
+concepts come first, followed by the third-party tools in the toolchain.
+
+## Repo concepts
+
+### Profile
+The durable identity of a managed machine — one of `minimal`, `personal`,
+`work`, or `server`. Persisted at `~/.config/dotfiles/profile` and honored by
+every lifecycle script, so one shared repo can serve several distinct devices.
+Selects which packages, dotfiles, and setup steps apply. See
+[Machine Profiles](profiles.md).
+
+### Overlay
+An additive layer applied on top of the core set for certain profiles. The
+package overlays are `Brewfile.personal` (GUI profiles) and `Brewfile.work`
+(work profile), layered onto the always-installed core `Brewfile`. Dotfiles are
+"overlaid" similarly via profile `tags` in `config/symlinks.map`.
+
+### SSOT (single source of truth)
+A file that is the one and only place a given fact is declared, read by every
+consumer so a change propagates everywhere. The repo's SSOT files are
+`config/symlinks.map`, `config/mise.toml`, `config/sheldon/plugins.toml`, the
+`Brewfile`(+overlays), `.sops.yaml`, and `~/.config/dotfiles/update.conf`. See
+[Architecture](architecture.md#single-sources-of-truth).
+
+### Tag
+The optional third column in `config/symlinks.map` (and the convention behind
+the Brewfile overlays) that gates which profiles an item applies to: blank/`core`
+= all, `gui` = `personal`+`work`, `work` = `work` only, or a profile name for
+that profile exactly. Interpreted by `profile_includes`.
+
+### Dry-run
+A preview mode (`--dry-run` on `bootstrap.sh` and `update.sh`) that reports every
+action it *would* take without changing anything — no installs, symlinks,
+backups, or prompts. See [Dry-Run and Pre-flight](DRY_RUN_AND_PREFLIGHT.md).
+
+### Pre-flight
+The system-readiness check (`scripts/preflight.sh`) that `bootstrap.sh` runs
+before making any changes: OS/arch, disk, network, conflicting package managers,
+permissions, existing dotfiles, and repo integrity. Critical errors abort;
+warnings prompt to continue. See [Dry-Run and Pre-flight](DRY_RUN_AND_PREFLIGHT.md).
+
+### First-run picker
+The interactive menu `bootstrap.sh` shows on a genuine first run (no profile flag,
+env var, or persisted file, on an interactive terminal) to choose a profile.
+Pressing Enter accepts the default, `personal`.
+
+### Thin `~/.gitconfig` include
+The pattern where `~/.gitconfig` is a **real file** (not a symlink) that
+`[include]`s the tracked `home/gitconfig`. This lets `git config --global …` and
+tools like `gh auth setup-git` write into your local file — overriding shared
+defaults on that machine only — without corrupting the tracked repo file. See
+[Architecture](architecture.md#the-thin-gitconfig-include).
+
+### Brewfile drift
+The state where installed Homebrew packages no longer match what the profile's
+Brewfiles declare. `verify.sh` reports it as a warning; reconcile with
+`brew bundle`. See [Troubleshooting](troubleshooting.md#brewfile-drift).
+
+## Tools
+
+### sheldon
+A fast, declarative zsh plugin manager. The plugin list lives in
+`config/sheldon/plugins.toml` (an [SSOT](#ssot-single-source-of-truth)) and is
+loaded from `home/zshrc` via `eval "$(sheldon source)"`.
+
+### mise
+A polyglot runtime/version manager (successor in spirit to asdf) that replaced
+chruby + nvm here. One line — `eval "$(mise activate zsh)"` — manages Ruby, Node,
+Python, Java, and Go with automatic per-project version switching. Versions are
+declared in `config/mise.toml`. See [Shell Performance](performance.md).
+
+### sops / age
+The encrypted-secrets stack. **age** is the encryption backend (a public/private
+key pair); **sops** encrypts only the *values* in structured files and reads
+`.sops.yaml` to decide which files to encrypt and for which recipients. See
+[Encrypted Secrets](secrets.md).
+
+### bats
+Bats (Bash Automated Testing System) is the test framework used for the repo's
+shell helpers. Tests live under `scripts/tests/` and run in CI; the pure helpers
+in `scripts/lib/` are written to be unit-testable. See [Contributing](contributing.md).
+
+### starship
+The cross-shell prompt, configured in `config/starship.toml` (symlinked to
+`~/.config/starship.toml`). Its Ruby module is disabled for startup performance.
+See [Shell Performance](performance.md).
+
+### direnv
+Loads and unloads environment variables per directory from `.envrc` files.
+Configured via `config/direnvrc` (symlinked to `~/.config/direnv/direnvrc`).
+
+### launchd
+macOS's service manager. The repo uses it (via `scripts/setup-scheduler.sh`) to
+run `update.sh` daily. Because launchd does not source your shell rc, scheduled
+runs read defaults from `~/.config/dotfiles/update.conf`. See
+[Troubleshooting](troubleshooting.md#scheduled-updates).
+
+### Corepack
+The Node-bundled shim manager that provides `yarn` (and `pnpm`) without a
+separate Homebrew formula. `bootstrap.sh` runs `corepack enable` so Yarn comes
+"from Node".
+
+### git-lfs
+Git Large File Storage — replaces large files in git with lightweight pointers.
+`bootstrap.sh` runs `git lfs install --skip-repo` to enable it globally; `verify.sh`
+confirms the global init.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -28,14 +28,74 @@ Shell startup time was reduced from ~2.37s to ~0.08s — a 97% improvement — t
 
 ---
 
+## Optimization methodology
+
+Every change above came from the same loop. Use it whenever startup feels slow
+again (a new plugin, a heavy `eval` in `~/.zshrc.local`, etc.):
+
+1. **Measure a baseline** — get a repeatable number before touching anything
+   (see [Measuring startup time](#measuring-startup-time)). Always compare
+   against the same machine and an otherwise-idle system.
+2. **Profile to find the cost** — don't guess. Use `zprof` (below) to rank what
+   actually consumes time during an interactive start.
+3. **Attack the biggest cost first**, using one of three levers in order of
+   preference:
+     - **Eliminate** — remove work that runs on *every* shell. The single
+       biggest win here was deleting a `$(ruby -e 'puts Gem.bindir')` subshell
+       that spawned a full Ruby process per shell.
+     - **Replace** — swap a slow tool for a faster one. chruby + nvm (two sourced
+       scripts, a `brew --prefix` call, and nvm lazy-loaders) became one line:
+       `eval "$(mise activate zsh)"`.
+     - **Cache / defer** — pay a cost once and reuse it, or push it to first use.
+       `compinit -C` skips rebuilding `~/.zcompdump` unless it is older than a
+       day; disabling starship's Ruby module avoids running Ruby on every prompt.
+4. **Re-measure** — confirm the change helped and didn't regress correctness
+   (completions still work, runtimes still switch per project).
+5. **Repeat** until the next-biggest cost isn't worth chasing.
+
+!!! tip "Keep machine-specific weight out of the tracked rc"
+    Slow, machine-only setup (corporate tooling, one-off `eval`s) belongs in
+    `~/.zshrc.local`, not the tracked `home/zshrc`. That keeps the shared
+    baseline fast for every profile and machine.
+
 ## Measuring startup time
+
+Time a full interactive start, averaged over several runs:
 
 ```sh
 # Average of 5 runs
 for i in $(seq 1 5); do /usr/bin/time zsh -i -c exit 2>&1; done
 ```
 
-Or with `hyperfine` (install via `brew install hyperfine`):
+For a tighter, statistically warmed-up number, use `hyperfine`
+(`brew install hyperfine`):
+
 ```sh
 hyperfine --warmup 3 'zsh -i -c exit'
 ```
+
+### Profiling with `zprof`
+
+Timing tells you *how slow*; `zprof` (a zsh builtin module) tells you *what* is
+slow. Enable it at the very top of your rc, start a shell, then read the report:
+
+```sh
+# Temporarily add as the FIRST line of ~/.zshrc (or ~/.zshrc.local):
+zmodload zsh/zprof
+# ...rest of your rc...
+
+# Then open a new shell and run:
+zprof   # prints functions ranked by cumulative time
+```
+
+The top entries are where to focus step 3 above. Remove the `zmodload` line once
+you're done. For a line-by-line view of what runs at startup, you can also trace
+it:
+
+```sh
+zsh -i -x -c exit 2>&1 | less   # every command sourced during an interactive start
+```
+
+The runtime manager (`mise`) and plugin manager (`sheldon`) are the two heaviest
+startup contributors by design — see the [Glossary](glossary.md#mise) for what
+each does and the [Architecture](architecture.md) page for how they're wired in.

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -4,6 +4,12 @@ This repo can store secrets (API tokens, `.env` files, credentials) **encrypted 
 
 The encryption policy lives in [`.sops.yaml`](https://github.com/bradbergeron-us/dotfiles/blob/main/.sops.yaml). A small wrapper, [`scripts/secrets.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/scripts/secrets.sh), provides `edit` / `encrypt` / `decrypt` helpers.
 
+!!! tip "Looking for the quick recipe?"
+    This page is the reference and safety model. For a step-by-step task
+    walkthrough (encrypt → edit → rotate a secret), see the
+    **"Encrypt, edit & rotate a secret"** guide in the **How-to guides**
+    section.
+
 ---
 
 ## How it works
@@ -69,3 +75,40 @@ sops --decrypt secrets/aws.yaml  # print plaintext to stdout
 - **Only commit sops-encrypted files.** Inspect a file before committing — an encrypted sops file contains `sops:` metadata and `ENC[...]` values. If you see raw plaintext secrets, stop and encrypt first.
 - **Defense in depth.** The repo's `gitleaks` pre-commit hook and CI job scan for accidentally committed secrets, but the encryption boundary above is the primary protection.
 - **Rotate on exposure.** If a private key or plaintext secret is ever exposed, rotate the affected credentials and generate a new age key, then `sops updatekeys` all files.
+
+### Why values, not whole files
+
+sops encrypts only the *values* in a structured file, leaving keys (and the
+`sops:` metadata block) in cleartext. This is deliberate: `git diff` still shows
+*which* keys changed without revealing secrets, code review stays meaningful, and
+merge conflicts are tractable. The trade-off — key *names* are visible — is
+acceptable because the sensitive material is the values. Avoid putting secrets in
+key names.
+
+## Rotating and re-keying
+
+Two distinct operations are often conflated:
+
+- **Rotating a secret value** (e.g. a leaked API token): change the secret at the
+  source (revoke + reissue the credential), then update its encrypted value:
+  ```sh
+  bash ~/dotfiles/scripts/secrets.sh edit secrets/aws.yaml   # paste the new value, save
+  ```
+- **Re-keying recipients** (adding/removing a machine or teammate): edit the
+  `age:` recipients under the matching `creation_rules` entry in `.sops.yaml`,
+  commit it, then re-encrypt every existing file to the new recipient set:
+  ```sh
+  sops updatekeys secrets/aws.yaml   # repeat per file, or script across them
+  ```
+  Only recipients listed *before* a file was last re-keyed can decrypt it —
+  removing a recipient from `.sops.yaml` does **not** retroactively lock them out
+  of copies they already pulled, so rotate the underlying secret values too when
+  revoking access.
+
+## Related
+
+- [Architecture](architecture.md#sopsyaml) — where `.sops.yaml` sits in the SSOT model.
+- [Troubleshooting](troubleshooting.md#encrypted-secrets-sops-age) — fixes for
+  missing keys and decryption failures.
+- [Glossary](glossary.md#sops-age) — quick definitions of sops and age.
+- The **How-to guides** section — the task-oriented encrypt/edit/rotate recipe.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,234 @@
+# Troubleshooting
+
+Common failures and how to fix them. Most problems surface through
+[`verify.sh`](architecture.md#verifysh-read-only-health-check) or the summary at
+the end of an `update.sh` run. When in doubt, start with the health check:
+
+```sh
+bash ~/dotfiles/verify.sh
+bash ~/dotfiles/scripts/status.sh   # quick repo + last-update snapshot (dotstatus)
+```
+
+## FAQ
+
+??? question "How do I change my machine's profile without re-bootstrapping?"
+    Use the `dotprofile` alias, then re-apply:
+    ```sh
+    dotprofile set work          # persist the new profile
+    zsh ~/dotfiles/install.sh    # re-link dotfiles for it
+    bash ~/dotfiles/update.sh    # re-run packages + health check
+    ```
+    See [Machine Profiles](profiles.md).
+
+??? question "Is it safe to re-run bootstrap / install / update?"
+    Yes. All of them are idempotent — already-installed tools are skipped and
+    correct symlinks are left alone. Re-running is the normal way to heal a
+    machine.
+
+??? question "Where are my old dotfiles after bootstrap?"
+    `install.sh` backs up any real file it replaces to
+    `~/.dotfiles_backup/<timestamp>/`. `verify.sh` warns when backups are older
+    than 30 days; clear them with `rm -rf ~/.dotfiles_backup`.
+
+??? question "Why didn't my change to ~/.zshrc stick?"
+    `~/.zshrc` is a symlink into the repo. Machine-specific config belongs in
+    `~/.zshrc.local` (seeded from a template on first bootstrap), which is not
+    tracked.
+
+## Failed update or rebase
+
+`update.sh` pulls with `git pull --rebase --autostash`. It is defensive by
+design:
+
+- **Uncommitted changes in the dotfiles repo** → the pull step is **skipped**
+  with a warning so it never starts a rebase it can't finish. Commit or stash
+  your work, or force it:
+  ```sh
+  cd ~/dotfiles && git status        # see what's uncommitted
+  git stash                          # or commit
+  bash ~/dotfiles/update.sh
+  # or, to pull over local changes (autostash):
+  bash ~/dotfiles/update.sh --force-pull
+  ```
+- **A pull that fails mid-rebase** → `update.sh` automatically runs
+  `git rebase --abort`, leaving the repo exactly as it was. Resolve manually:
+  ```sh
+  cd ~/dotfiles
+  git rebase --abort                 # if a rebase is still in progress
+  git pull --rebase --autostash      # re-attempt once the tree is clean
+  ```
+- **A failed step does not abort the run.** `update.sh` collects failures and
+  reports them in the final banner and in `logs/update.status`. Inspect details
+  with:
+  ```sh
+  bash ~/dotfiles/scripts/status.sh  # shows last result + failed steps
+  cat ~/dotfiles/logs/update.log     # full output (rotated, keeps 5 copies)
+  ```
+
+## Broken symlinks
+
+A broken symlink is the only condition `verify.sh` treats as an **error**
+(exit 1). It usually means a file was moved/renamed in the repo, or a link was
+deleted. Re-running the installer heals them:
+
+```sh
+bash ~/dotfiles/verify.sh      # lists each broken link
+zsh ~/dotfiles/install.sh      # re-create links for the active profile
+```
+
+If `verify.sh` flags a link you expected to be **skipped**, check the `tags`
+column in [`config/symlinks.map`](architecture.md#configsymlinksmap) — the link
+only applies to profiles that match its tag, and `verify.sh` filters by the
+active profile, so an intentionally-skipped link is never reported.
+
+## Missing tools
+
+`verify.sh` checks a list of required tools (`brew`, `mise`, `git`, `gh`,
+`delta`, `lazygit`, `rg`, `fd`, `bat`, `fzf`, `zoxide`, `rustup`/`rustc`/`cargo`,
+`jq`, `shellcheck`, `direnv`, `starship`, `pre-commit`, `yarn`). A missing tool
+is a warning, not an error. Re-run bootstrap to install the gaps:
+
+```sh
+bash ~/dotfiles/bootstrap.sh             # re-installs from the profile Brewfiles
+# or install one package directly:
+brew install <tool>
+```
+
+If a command exists but isn't found in a new shell, confirm `mise` is active
+(`eval "$(mise activate zsh)"` runs from `home/zshrc`) and that tool shims are on
+`PATH` — open a fresh shell or `source ~/.zshrc`.
+
+## Brewfile drift
+
+`verify.sh` warns when installed packages no longer match the profile's
+Brewfiles (core + `Brewfile.personal` + `Brewfile.work` as applicable). To
+reconcile:
+
+```sh
+# Install anything declared but missing:
+brew bundle --file=~/dotfiles/Brewfile
+brew bundle --file=~/dotfiles/Brewfile.personal   # GUI profiles
+brew bundle --file=~/dotfiles/Brewfile.work       # work profile
+
+# See exactly what differs (declared vs installed):
+brew bundle check --file=~/dotfiles/Brewfile --verbose
+```
+
+If you installed something you want to keep, add it to the appropriate Brewfile
+so it becomes tracked; otherwise `brew uninstall` it.
+
+## GitHub CLI authentication
+
+`bootstrap.sh` runs `gh auth login` if `gh` is installed but not authenticated.
+If `gh` commands fail later:
+
+```sh
+gh auth status        # check current state
+gh auth login         # re-authenticate (choose SSH for git operations)
+gh auth setup-git     # configure git to use gh credentials
+```
+
+Because `~/.gitconfig` is a real file (a thin include of the tracked config),
+`gh auth setup-git` writes safely into it without touching the repo. If git
+operations break after auth changes, run `bash ~/dotfiles/verify.sh` — the
+"Git config include" check confirms the include is intact and `git config`
+parses cleanly.
+
+## mise runtimes
+
+`verify.sh` warns if a runtime declared in
+[`config/mise.toml`](architecture.md#configmisetoml) isn't installed. Install
+the declared set:
+
+```sh
+mise install               # install everything in config/mise.toml
+mise current               # show active versions
+mise use --global node@22  # pin/switch a global version
+```
+
+Compiling runtimes (especially Ruby) can take several minutes. If a runtime
+isn't picked up, ensure `mise` is activated in your shell and reopen the
+terminal.
+
+## Encrypted secrets (sops + age)
+
+- **`age key not found`** when editing/decrypting → generate or restore your key:
+  ```sh
+  age-keygen -o ~/.config/sops/age/keys.txt
+  ```
+  Then make sure your public key is a recipient in `.sops.yaml`. See
+  [Encrypted Secrets](secrets.md).
+- **`sops` can't decrypt a file** → your public key isn't (or no longer is) a
+  recipient. Have an existing holder add it and re-key:
+  ```sh
+  sops updatekeys <file>
+  ```
+- **Lost private key** → encrypted files are unrecoverable. Rotate the affected
+  credentials and generate a new key. Always back up `keys.txt` to a password
+  manager.
+
+See [Encrypted Secrets](secrets.md) for the full setup and safety model.
+
+## Scheduled updates
+
+Daily updates run via a launchd agent installed by `scripts/setup-scheduler.sh`
+(runs `update.sh` at 9 AM). Because launchd does **not** source your shell rc,
+the job reads `~/.config/dotfiles/update.conf` for defaults like
+`NO_UPGRADE=true`.
+
+```sh
+bash ~/dotfiles/scripts/setup-scheduler.sh              # install (9 AM daily)
+bash ~/dotfiles/scripts/setup-scheduler.sh --no-upgrade # scheduled run skips upgrades
+bash ~/dotfiles/scripts/setup-scheduler.sh --uninstall  # remove the job
+```
+
+If scheduled runs aren't happening:
+
+```sh
+launchctl print gui/$(id -u)/com.dotfiles.update   # is the agent loaded?
+cat ~/dotfiles/logs/update.log                      # what happened last run
+cat ~/dotfiles/logs/update.status                   # last result + failed steps
+```
+
+Re-installing is idempotent (it boots out any existing agent first). For a
+machine-wide default that also applies to manual runs, set `NO_UPGRADE=true` in
+`~/.config/dotfiles/update.conf` rather than only on the scheduled job.
+
+## Pre-flight failures
+
+`bootstrap.sh` runs [`scripts/preflight.sh`](DRY_RUN_AND_PREFLIGHT.md) first.
+Critical errors (not macOS, no internet, <5 GB disk, unwritable `$HOME`,
+conflict markers in tracked dotfiles) abort the run; warnings prompt to
+continue. Run it standalone any time:
+
+```sh
+bash ~/dotfiles/scripts/preflight.sh           # 0 = ok, 2 = warnings, 1 = errors
+bash ~/dotfiles/scripts/preflight.sh --strict  # treat warnings as errors
+```
+
+If you must proceed past pre-flight (not recommended):
+
+```sh
+bash ~/dotfiles/bootstrap.sh --skip-preflight
+```
+
+## Docs / Pages build issues
+
+The docs site is built with MkDocs Material and deployed to GitHub Pages. The
+build runs in **strict** mode, which **fails on any warning** — most commonly a
+page missing from the `nav` in `mkdocs.yml`, or a broken relative link. Build
+locally before pushing:
+
+```sh
+uvx --with mkdocs-material mkdocs build --strict   # must finish with zero warnings
+uvx --with mkdocs-material mkdocs serve             # live preview at localhost:8000
+```
+
+If the build fails:
+
+- **"is not found in the documentation files" / not in nav** → add the new page
+  to `nav:` in `mkdocs.yml`.
+- **"contains a link … that is not found"** → fix the relative link so it
+  resolves to an existing page.
+
+See [Contributing](contributing.md) for the full docs workflow.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,11 @@ markdown_extensions:
   - toc:
       permalink: true
   - pymdownx.details
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.highlight:
       anchor_linenums: true
   - pymdownx.inlinehilite
@@ -68,4 +72,8 @@ nav:
   - Reference:
       - Tool Reference: tools.md
       - Shell Performance: performance.md
+      - Troubleshooting: troubleshooting.md
+  - Explanation:
+      - Architecture: architecture.md
+      - Glossary: glossary.md
   - Contributing: contributing.md


### PR DESCRIPTION
## Summary
Adds the **Reference & Explanation** docs (Area 3 of the Docs Enhancement + Learning Content endeavor) and enriches two thin pages. All content is grounded in the actual repo scripts and SSOT config.

New pages:
- **`docs/architecture.md`** — a Mermaid lifecycle diagram + prose covering `bootstrap.sh`, `install.sh`, `update.sh`, `verify.sh`, `scripts/status.sh`, the profile system, and each single-source-of-truth file (`config/symlinks.map`, `config/mise.toml`, `config/sheldon/plugins.toml`, `Brewfile` overlays, `.sops.yaml`, `~/.config/dotfiles/update.conf`, the thin `~/.gitconfig` include) — showing where each SSOT is consumed.
- **`docs/troubleshooting.md`** — FAQ + common failures and fixes: failed update/rebase, broken symlinks, missing tools, Brewfile drift, `gh` auth, mise runtimes, scheduled updates, pre-flight, and docs/Pages build issues.
- **`docs/glossary.md`** — profile, overlay, SSOT, tag, dry-run, pre-flight, first-run picker, thin `~/.gitconfig` include, Brewfile drift, sheldon, mise, sops/age, bats, starship, direnv, launchd, Corepack, git-lfs.

Enriched:
- **`docs/performance.md`** — startup-optimization methodology (measure → profile → eliminate/replace/cache → re-measure) and `zprof`/trace profiling.
- **`docs/secrets.md`** — deepened workflow (rotating a value vs. re-keying recipients), "why values not whole files" rationale, and cross-links to Architecture/Troubleshooting/Glossary + the How-to recipe.

## Validation
`uvx --with mkdocs-material mkdocs build --strict` → **built in 0.44s with zero warnings/errors** (every new page is in nav; all relative links resolve).

## mkdocs.yml nav note
This PR edits the shared `mkdocs.yml`. My changes are kept together: **Troubleshooting** added under the existing `Reference` section, and a new **Explanation** section (Architecture, Glossary). I also enabled Mermaid rendering via a `pymdownx.superfences` `custom_fences` block (additive) so the architecture diagram renders. The docs-structure PR (Area 4) merges last and owns the final nav reorg — expect a trivial rebase here.

Note: the How-to cross-links are intentionally referenced in prose (not relative links) because the `docs/how-to/**` pages live on the docs-howto branch; a relative link would break `--strict` on this standalone branch. They resolve once that section lands.

_Conversation: https://app.warp.dev/conversation/13616873-6c84-4df2-b9f4-ee3b55c83b08_
_Run: https://oz.warp.dev/runs/019ed143-998a-7c62-8324-9696be7afeaf_
_Plans_:
- _[Docs Enhancement + Learning/Training Content](https://app.warp.dev/conversation/13616873-6c84-4df2-b9f4-ee3b55c83b08)_

_This PR was generated with [Oz](https://warp.dev/oz)._
