### PR TITLE
docs: add task-oriented how-to guides

### DIFF
--- a/docs/how-to/add-a-dotfile.md
+++ b/docs/how-to/add-a-dotfile.md
@@ -1,0 +1,66 @@
+# Add a tracked dotfile
+
+Track a new config file by adding one line to [`config/symlinks.map`](https://github.com/bradbergeron-us/dotfiles/blob/main/config/symlinks.map) — the single source of truth that `install.sh`, `verify.sh`, and `bootstrap.sh --dry-run` all read.
+
+## 1. Put the file in the repo
+
+Move the real file into the repo and reference it by a path relative to the repo root. Home-directory dotfiles live under `home/`; XDG configs live under `config/`.
+
+```sh
+# Example: track a new ~/.ackrc
+mv ~/.ackrc ~/dotfiles/home/ackrc
+```
+
+## 2. Add a record to `symlinks.map`
+
+Each record is whitespace-separated: `<src> <dest> [tags]`.
+
+- **`src`** — path relative to the repo root (`DOTFILES_DIR`).
+- **`dest`** — path relative to `$HOME`.
+- **`tags`** — *optional* comma-separated profile tags (see below). Omit for "all profiles".
+
+```text
+home/ackrc             .ackrc
+```
+
+For a config under `~/.config`:
+
+```text
+config/foo/config.toml  .config/foo/config.toml
+```
+
+`install.sh` runs `mkdir -p` on the destination's parent, so nested paths like `.config/foo/` are created automatically.
+
+### Optional: scope it to a profile
+
+The third column gates which [profiles](../profiles.md) get the link, via `profile_includes`:
+
+- **omit / blank** — link on every profile.
+- **`gui`** — link on `personal` and `work` only (skipped on `minimal`/`server`).
+- **`work`** — link on `work` only.
+- **a profile name** (`personal`, `minimal`, …) — that profile only.
+
+```text
+home/hyper.js          .hyper.js              gui
+```
+
+## 3. Create the symlink
+
+Re-run the installer. It backs up any existing real file to `~/.dotfiles_backup/<timestamp>/`, then links your new entry. It is idempotent — already-correct links report `current`.
+
+```sh
+zsh ~/dotfiles/install.sh
+```
+
+You'll see a line like `✓ linked    ~/.ackrc` and a summary of `linked · current · backed up · skipped` counts.
+
+## 4. Verify and commit
+
+```sh
+bash ~/dotfiles/verify.sh        # confirms the link resolves to the repo
+git -C ~/dotfiles add config/symlinks.map home/ackrc
+git -C ~/dotfiles commit -m "feat: track ~/.ackrc"
+```
+
+!!! tip
+    `~/.gitconfig` is intentionally **not** in `symlinks.map`. It's a real file with a thin `[include]` of the tracked `home/gitconfig`, so `git config --global` and tools never write into the repo. That bespoke setup stays in `install.sh`.

--- a/docs/how-to/add-a-zsh-plugin.md
+++ b/docs/how-to/add-a-zsh-plugin.md
@@ -1,0 +1,49 @@
+# Add a zsh plugin
+
+Zsh plugins are managed declaratively by [sheldon](https://github.com/rossmacarthur/sheldon). Add a plugin by editing [`config/sheldon/plugins.toml`](https://github.com/bradbergeron-us/dotfiles/blob/main/config/sheldon/plugins.toml) — it's symlinked to `~/.config/sheldon/plugins.toml` and sourced from `home/zshrc` via `eval "$(sheldon source)"`.
+
+## 1. Add the plugin
+
+Add a `[plugins.<name>]` table. Most plugins come from GitHub, so use the `github = "owner/repo"` form:
+
+```toml
+[plugins.zsh-history-substring-search]
+github = "zsh-users/zsh-history-substring-search"
+```
+
+sheldon downloads the plugin on the next shell source and generates the source lines automatically — no manual cloning.
+
+!!! note
+    Order matters for some plugins. `fast-syntax-highlighting` and `zsh-autosuggestions` should generally stay last; add ordering-sensitive plugins relative to them.
+
+## 2. Reload the shell
+
+Open a new terminal, or re-source your config in the current one:
+
+```sh
+exec zsh        # replace the current shell
+# or
+source ~/.zshrc
+```
+
+On first source, sheldon clones the new plugin and you'll see it take effect immediately.
+
+## 3. (Optional) Pin / update versions
+
+sheldon records resolved commits in a lock file. Refresh pinned commits with:
+
+```sh
+sheldon lock --update
+```
+
+## 4. Commit
+
+```sh
+git -C ~/dotfiles add config/sheldon/plugins.toml
+git -C ~/dotfiles commit -m "feat: add zsh-history-substring-search plugin"
+```
+
+Because the file is tracked and symlinked, every machine picks up the same plugin set on its next `update.sh` or shell reload.
+
+!!! tip
+    `home/zshrc` only calls sheldon when it's installed (`command -v sheldon`), falling back to manually-cloned plugins under `~/.zsh`. Ensure `sheldon` is present (it's in the core `Brewfile`) so your new entry is picked up.

--- a/docs/how-to/manage-packages.md
+++ b/docs/how-to/manage-packages.md
@@ -1,0 +1,71 @@
+# Manage Homebrew packages
+
+Packages are declared in Brewfiles and installed with `brew bundle`. The core file applies to every machine; profile overlays layer GUI and work-only packages on top.
+
+## The three Brewfiles
+
+- [`Brewfile`](https://github.com/bradbergeron-us/dotfiles/blob/main/Brewfile) — **core CLI** formulae for *all* profiles. Keep GUI/cask entries out of this file.
+- [`Brewfile.personal`](https://github.com/bradbergeron-us/dotfiles/blob/main/Brewfile.personal) — GUI casks, fonts, and apps for profiles **with a desktop** (`personal`, `work`). Skipped on `minimal`/`server`.
+- [`Brewfile.work`](https://github.com/bradbergeron-us/dotfiles/blob/main/Brewfile.work) — **work-only** additions, layered on top for the `work` profile.
+
+`bootstrap.sh` installs the core file plus the active profile's overlays (see [Profiles](../profiles.md)). The same list drives `verify.sh`'s Brewfile-drift check.
+
+## Add a package
+
+Pick the right file for its scope, then add a line. Use `brew "<formula>"` for CLI tools and `cask "<app>"` for GUI apps.
+
+```ruby
+# Brewfile (core CLI — every machine)
+brew "htop"            # short comment explaining the tool
+
+# Brewfile.personal (GUI app — desktop profiles)
+cask "obsidian"
+
+# Brewfile.work (work-only tool)
+brew "awscli"
+```
+
+Install it:
+
+```sh
+brew bundle --file=~/dotfiles/Brewfile            # core
+brew bundle --file=~/dotfiles/Brewfile.personal   # GUI overlay
+brew bundle --file=~/dotfiles/Brewfile.work       # work overlay
+```
+
+`brew bundle` is idempotent — it installs only what's missing, so it's safe to re-run.
+
+## Remove a package
+
+Delete its line from the Brewfile, then uninstall it from the machine (editing the file alone does not remove an installed package):
+
+```sh
+brew uninstall htop
+```
+
+To prune everything **not** listed in a Brewfile, use cleanup (review the dry run first):
+
+```sh
+brew bundle cleanup --file=~/dotfiles/Brewfile            # preview removals
+brew bundle cleanup --file=~/dotfiles/Brewfile --force    # actually remove
+```
+
+## Check for drift
+
+`brew bundle check` reports whether everything in a Brewfile is installed:
+
+```sh
+brew bundle check --file=~/dotfiles/Brewfile
+```
+
+`update.sh` and `verify.sh` already iterate the active profile's Brewfiles, so a routine `bash ~/dotfiles/update.sh` keeps installed packages in sync.
+
+## Commit
+
+```sh
+git -C ~/dotfiles add Brewfile Brewfile.personal Brewfile.work
+git -C ~/dotfiles commit -m "feat: add htop to core Brewfile"
+```
+
+!!! tip
+    Put a tool in the **lowest** scope that needs it. A CLI used on every machine belongs in `Brewfile`; a desktop app belongs in `Brewfile.personal`; keep work-only tooling in `Brewfile.work` so personal machines stay lean.

--- a/docs/how-to/manage-secrets.md
+++ b/docs/how-to/manage-secrets.md
@@ -1,0 +1,68 @@
+# Manage encrypted secrets
+
+Encrypt secrets in git with [sops](https://github.com/getsops/sops) + [age](https://github.com/FiloSottile/age). The policy lives in [`.sops.yaml`](https://github.com/bradbergeron-us/dotfiles/blob/main/.sops.yaml); [`scripts/secrets.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/scripts/secrets.sh) wraps the common operations. For the full safety model, see [Encrypted Secrets](../secrets.md).
+
+## 1. Generate an age key (one time per machine)
+
+`sops` and `age` ship in the core `Brewfile`. Generate your key pair:
+
+```sh
+mkdir -p ~/.config/sops/age
+age-keygen -o ~/.config/sops/age/keys.txt
+```
+
+This prints a `# public key: age1...` line. The file also holds your **private** key — it lives outside the repo and must never be committed.
+
+!!! danger
+    Back up `~/.config/sops/age/keys.txt` somewhere secure (a password manager). If you lose it, every file encrypted to it becomes unrecoverable.
+
+## 2. Register the public key in `.sops.yaml`
+
+Replace the placeholder recipient(s) under `creation_rules` with the `age1...` **public** key from step 1, then commit `.sops.yaml`. Only the public key goes here.
+
+```yaml
+creation_rules:
+  - path_regex: (^|/)secrets/.*\.(ya?ml|json|env|ini|toml|txt)$
+    age: >-
+      age1yourpublickeyhere...
+```
+
+The default rules match files under a `secrets/` directory and files named `*.secret.*` / `*.enc.*`.
+
+## 3. Encrypt, edit, and decrypt
+
+`scripts/secrets.sh` sets `SOPS_AGE_KEY_FILE` to `~/.config/sops/age/keys.txt` and adds guard rails.
+
+Encrypt an existing plaintext file in place:
+
+```sh
+bash ~/dotfiles/scripts/secrets.sh encrypt secrets/aws.yaml
+```
+
+Edit a secret (opens decrypted in `$EDITOR`, re-encrypts on save):
+
+```sh
+bash ~/dotfiles/scripts/secrets.sh edit secrets/aws.yaml
+```
+
+Decrypt to a gitignored `<file>.dec` sibling (delete it when done):
+
+```sh
+bash ~/dotfiles/scripts/secrets.sh decrypt secrets/aws.yaml
+# → writes secrets/aws.yaml.dec
+```
+
+Before committing, confirm the file shows `sops:` metadata and `ENC[...]` values — never raw plaintext.
+
+## 4. Rotate keys / recipients
+
+To add a teammate or a new machine, append their `age1...` public key as another `age:` entry in `.sops.yaml`, then re-key existing files so the new recipient can decrypt:
+
+```sh
+sops updatekeys secrets/aws.yaml
+```
+
+If a private key or a plaintext secret is ever exposed: **rotate the affected credentials**, generate a fresh age key (`age-keygen`), update `.sops.yaml`, and run `sops updatekeys` on every encrypted file.
+
+!!! warning
+    `.gitignore` blocks `keys.txt`, `*.agekey`, `age-key.txt`, and `*.dec`. The `gitleaks` pre-commit hook and CI job are a backstop — the encryption boundary is the primary protection.

--- a/docs/how-to/recover-from-a-failed-update.md
+++ b/docs/how-to/recover-from-a-failed-update.md
@@ -1,0 +1,86 @@
+# Recover from a failed update
+
+`update.sh` is self-healing: individual step failures don't abort the run, every step is attempted, and the outcome is recorded. Use this guide when an update reports issues.
+
+## 1. See what failed
+
+Start with the status snapshot (alias `dotstatus`):
+
+```sh
+dotstatus
+# or: bash ~/dotfiles/scripts/status.sh
+```
+
+It prints the repo's git state and the last update result read from `logs/update.status`. A failure shows the failed step(s) and points you at the log.
+
+Inspect `logs/update.status` directly — it's `key=value`:
+
+```sh
+cat ~/dotfiles/logs/update.status
+# last_run=2026-06-16T09:00:03Z
+# status=failure
+# failed_steps=Homebrew, Health check
+# duration_seconds=87
+```
+
+Then read the full output for the failing step:
+
+```sh
+less ~/dotfiles/logs/update.log         # current run
+ls  ~/dotfiles/logs/update.log.*        # rotated copies (.1 … .5)
+```
+
+## 2. Dirty working tree (pull skipped)
+
+If the dotfiles repo has uncommitted changes to **tracked** files, `update.sh` skips `git pull` to avoid a rebase conflict and warns:
+
+> Uncommitted changes in … — skipping pull to avoid a rebase conflict
+
+Resolve it by committing or stashing your changes, then re-run:
+
+```sh
+git -C ~/dotfiles status
+git -C ~/dotfiles stash          # or: git commit -am "wip"
+bash ~/dotfiles/update.sh
+```
+
+To pull anyway (autostashing local changes), use `--force-pull`:
+
+```sh
+bash ~/dotfiles/update.sh --force-pull
+```
+
+## 3. Failed rebase during pull
+
+`update.sh` pulls with `--rebase --autostash`. If that fails, it **automatically aborts the in-progress rebase** and leaves the repo exactly as it was before the pull, then marks the `Dotfiles` step failed. You won't be left mid-rebase.
+
+Re-sync manually if needed:
+
+```sh
+git -C ~/dotfiles status                       # confirm no rebase in progress
+git -C ~/dotfiles pull --rebase --autostash     # retry once conflicts are understood
+```
+
+If a rebase ever *is* left in progress, abort it explicitly:
+
+```sh
+git -C ~/dotfiles rebase --abort
+```
+
+## 4. A package/runtime step failed
+
+Brew, mise, rustup, or gem failures are isolated and reported but don't stop the rest of the run. Re-run just the upgrades after fixing the underlying issue, or skip them to recover the rest of your environment:
+
+```sh
+bash ~/dotfiles/update.sh --no-upgrade   # pull + re-symlink + verify only
+```
+
+## 5. Re-run and confirm healthy
+
+```sh
+bash ~/dotfiles/update.sh
+dotstatus                       # expect: result: success
+```
+
+!!! tip
+    Use `bash ~/dotfiles/update.sh --dry-run` to preview exactly what the next run will do — including whether it would skip the pull — without changing anything.

--- a/docs/how-to/schedule-updates.md
+++ b/docs/how-to/schedule-updates.md
@@ -1,0 +1,56 @@
+# Schedule automatic updates
+
+Run `update.sh` automatically every day with a launchd job, installed by [`scripts/setup-scheduler.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/scripts/setup-scheduler.sh).
+
+## Install the daily job
+
+```sh
+bash ~/dotfiles/scripts/setup-scheduler.sh
+```
+
+This renders `system/LaunchAgents/com.dotfiles.update.plist` into `~/Library/LaunchAgents/`, loads it with `launchctl`, and schedules `update.sh` to run **daily at 9 AM**. It's idempotent — re-running reloads the job cleanly.
+
+After install it reports the log, status file, plist path, and the uninstall command.
+
+## Skip upgrades or pulls on the schedule
+
+Pass flags to bake them into the scheduled invocation (e.g. the job runs `update.sh --no-upgrade`):
+
+```sh
+bash ~/dotfiles/scripts/setup-scheduler.sh --no-upgrade   # pull + re-symlink + verify only
+bash ~/dotfiles/scripts/setup-scheduler.sh --no-pull      # skip the git pull
+```
+
+`--no-upgrade` is recommended on work machines with version-sensitive tooling.
+
+!!! note
+    These flags affect only the **scheduled** run. For a machine-wide default that also applies to manual `update.sh` runs, set `NO_UPGRADE=true` (or `NO_PULL=true`) in `~/.config/dotfiles/update.conf` instead — `update.sh` reads that file directly, so the launchd job (which never sources `~/.zshrc`) honors it too.
+
+### Set up `update.conf`
+
+```sh
+mkdir -p ~/.config/dotfiles
+cp ~/dotfiles/home/examples/update.conf.example ~/.config/dotfiles/update.conf
+# then edit: NO_UPGRADE=true / NO_PULL=true as desired
+```
+
+Precedence is **config file < environment < command-line flags**.
+
+## Change the schedule
+
+Edit the `StartCalendarInterval` in `system/LaunchAgents/com.dotfiles.update.plist`, then re-run `setup-scheduler.sh` to reload the job with the new time.
+
+## Where to find logs and status
+
+- `~/dotfiles/logs/update.log` — scheduled run output (auto-rotated past ~1 MiB, keeps 5 copies via `DOTFILES_LOG_KEEP`).
+- `~/dotfiles/logs/update.status` — last-run timestamp, success/failure, failed steps, and duration.
+
+Check the last result quickly with the `dotstatus` alias. On failure, `update.sh` also posts a macOS notification (skipped in CI/headless).
+
+## Uninstall
+
+```sh
+bash ~/dotfiles/scripts/setup-scheduler.sh --uninstall
+```
+
+This boots out the launchd job and removes the installed plist.

--- a/docs/how-to/write-a-test.md
+++ b/docs/how-to/write-a-test.md
@@ -1,0 +1,68 @@
+# Write a test
+
+The shell helpers are unit-tested with [bats](https://github.com/bats-core/bats-core). Tests live in [`scripts/tests/`](https://github.com/bradbergeron-us/dotfiles/tree/main/scripts/tests) as `*.bats` files and run in CI. `bats-core` ships in the core `Brewfile`.
+
+## 1. Create a test file
+
+Add `scripts/tests/test_<thing>.bats`. Start by loading the shared helper, which resolves `$LIB_DIR`, `$SCRIPTS_DIR`, and `$REPO_ROOT` so tests don't recompute paths:
+
+```bash
+#!/usr/bin/env bats
+# test_my_helpers.bats — unit tests for scripts/lib/my_helpers.sh
+# Run: bats scripts/tests/test_my_helpers.bats
+
+load 'test_helper'
+
+setup() {
+  # shellcheck source=/dev/null
+  source "$LIB_DIR/my_helpers.sh"
+}
+```
+
+`setup()` runs before every `@test`. Source the library under test there so each case starts clean.
+
+## 2. Add `@test` blocks
+
+Each test is a `@test "name" { ... }` block. A non-zero exit fails the test; use `run <cmd>` to capture `$status` and `$output` without aborting:
+
+```bash
+@test "my_func: returns the trimmed value" {
+  result="$(my_func '  hi  ')"
+  [ "$result" = "hi" ]
+}
+
+@test "my_func: rejects empty input" {
+  run my_func ""
+  [ "$status" -ne 0 ]
+}
+```
+
+bats gives each test a scratch dir at `$BATS_TEST_TMPDIR` (auto-created, auto-removed) — use it for fixtures instead of `mktemp`:
+
+```bash
+@test "reads a config file" {
+  printf 'KEY=value\n' > "$BATS_TEST_TMPDIR/conf"
+  [ "$(read_kv_value "$BATS_TEST_TMPDIR/conf" KEY)" = "value" ]
+}
+```
+
+See [`test_profile_helpers.bats`](https://github.com/bradbergeron-us/dotfiles/blob/main/scripts/tests/test_profile_helpers.bats) for a complete, idiomatic example.
+
+## 3. Run the suite
+
+Run a single file, or the whole directory (what CI does):
+
+```sh
+bats scripts/tests/test_my_helpers.bats   # one file
+bats scripts/tests/                        # full suite
+```
+
+## 4. Commit
+
+```sh
+git -C ~/dotfiles add scripts/tests/test_my_helpers.bats
+git -C ~/dotfiles commit -m "test: cover my_helpers.sh"
+```
+
+!!! tip
+    Keep library helpers side-effect-free (no `exit`, no traps, configuration via globals/arguments) — that's what makes them unit-testable. Mirror the patterns in the existing `scripts/lib/*.sh` files.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,14 @@ nav:
   - Home: index.md
   - Profiles: profiles.md
   - Usage: usage.md
+  - How-to:
+      - Add a tracked dotfile: how-to/add-a-dotfile.md
+      - Manage packages: how-to/manage-packages.md
+      - Manage secrets: how-to/manage-secrets.md
+      - Add a zsh plugin: how-to/add-a-zsh-plugin.md
+      - Write a test: how-to/write-a-test.md
+      - Schedule updates: how-to/schedule-updates.md
+      - Recover from a failed update: how-to/recover-from-a-failed-update.md
   - Setup:
       - Dry-Run & Pre-flight: DRY_RUN_AND_PREFLIGHT.md
       - GPG Commit Signing: GPG_SIGNING.md


### PR DESCRIPTION
## Summary
Adds task-oriented **How-to** documentation (Diátaxis quadrant) under `docs/how-to/`. Seven short, imperative guides, each covering one task and grounded in the actual repo scripts/config:

- **Add a tracked dotfile** — `config/symlinks.map` record format, profile tags, `zsh install.sh`, verify.
- **Manage packages** — core `Brewfile` vs `Brewfile.personal` / `Brewfile.work` overlays, `brew bundle` / `bundle check` / `bundle cleanup`.
- **Manage secrets** — sops+age: `age-keygen`, register a public key in `.sops.yaml`, `scripts/secrets.sh` edit/encrypt/decrypt, `sops updatekeys` rotation.
- **Add a zsh plugin** — `config/sheldon/plugins.toml` `[plugins.*]`, `sheldon lock --update`, shell reload.
- **Write a test** — bats tests in `scripts/tests/*.bats`, `test_helper`, `@test` blocks, `bats scripts/tests/`.
- **Schedule updates** — `scripts/setup-scheduler.sh` launchd daily job, `--no-upgrade`/`--no-pull`, `update.conf`, uninstall.
- **Recover from a failed update** — dirty tree / `--force-pull`, automatic rebase abort, `logs/update.status` + `logs/update.log`, `dotstatus`.

## Validation
`uvx --with mkdocs-material mkdocs build --strict` — **clean, exit 0, zero warnings** (only the unrelated Material 2.0 advisory banner prints). Generated `site/` not committed.

## mkdocs.yml nav note
Adds a single `How-to:` nav section (kept together) after `Usage`. This is the only shared file touched by the parallel docs PRs; later PRs (esp. docs-structure) will rebase the trivial nav conflict.

## Scope
Only `docs/how-to/**` (new) and the `How-to` nav block in `mkdocs.yml`.

_Conversation: https://app.warp.dev/conversation/0538b399-d8c8-494f-8b05-43a3de33b8c8_
_Run: https://oz.warp.dev/runs/019ed143-9991-7b91-859e-f464608d777b_
_Plans_:
- _[Docs Enhancement + Learning/Training Content](https://app.warp.dev/conversation/0538b399-d8c8-494f-8b05-43a3de33b8c8)_

_This PR was generated with [Oz](https://warp.dev/oz)._
