### PR TITLE
docs(cleanup): learning-path index hub, README list, nav tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ The full documentation site is published at **<https://bradbergeron-us.github.io
 | Doc | Contents |
 |-----|---------|
 | [Home](docs/index.md) | Documentation landing page and site overview |
+| [Tutorials](docs/tutorials/getting-started.md) | Guided walkthroughs — your first hour, work laptop, adopting a profile |
+| [How-to Guides](docs/how-to/add-a-dotfile.md) | Task recipes — dotfiles, packages, secrets, zsh plugins, tests, scheduling, recovery |
 | [Dry-Run & Pre-flight](docs/DRY_RUN_AND_PREFLIGHT.md) | Previewing changes and read-only system checks before bootstrap |
 | [GPG Commit Signing](docs/GPG_SIGNING.md) | SSH/GPG signing, per-organization configs, uploading keys, troubleshooting |
 | [Encrypted Secrets](docs/secrets.md) | sops + age workflow for encrypting and managing secrets |
@@ -416,4 +418,7 @@ The full documentation site is published at **<https://bradbergeron-us.github.io
 | [Claude Code SSL Fix](docs/claude-code-ssl-fix.md) | Resolving Claude Code SSL/certificate issues behind a corporate proxy |
 | [Tool Reference](docs/tools.md) | Full descriptions, rationale, and commands for every tool |
 | [Shell Performance](docs/performance.md) | Shell startup optimization history and benchmarks |
+| [Architecture](docs/architecture.md) | How bootstrap, install, update, verify, status, and the SSOT files fit together |
+| [Troubleshooting](docs/troubleshooting.md) | FAQ and fixes for common failures (updates, symlinks, tools, secrets, docs) |
+| [Glossary](docs/glossary.md) | Definitions of terms used across the docs |
 | [Contributing](docs/contributing.md) | Contribution workflow — bats-core tests, shellcheck, CI jobs, and conventional commits |

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,66 +13,52 @@ git clone https://github.com/bradbergeron-us/dotfiles.git ~/dotfiles
 bash ~/dotfiles/bootstrap.sh
 ```
 
-`bootstrap.sh` runs once on a fresh Mac and handles everything: Homebrew, all
-packages, runtimes (Ruby, Node, Java, Python, Go, Rust), dotfile symlinks, and
-macOS defaults. Open a new terminal when it finishes.
+`bootstrap.sh` runs once on a fresh Mac: Homebrew, all packages, runtimes (Ruby,
+Node, Java, Python, Go, Rust), dotfile symlinks, and — on a first interactive
+run — a prompt for this machine's [profile](profiles.md). Open a new terminal
+when it finishes.
 
-Preview what would happen without changing anything:
+Preview without changing anything: `bash ~/dotfiles/bootstrap.sh --dry-run`
+(see [Dry-Run & Pre-flight](DRY_RUN_AND_PREFLIGHT.md)).
 
-```sh
-bash ~/dotfiles/bootstrap.sh --dry-run
-```
+**New here?** Walk through the [Getting Started tutorial](tutorials/getting-started.md)
+for a guided first hour.
 
-See [Dry-Run & Pre-flight](DRY_RUN_AND_PREFLIGHT.md) for details.
+## Find your way around
 
-## Machine profiles
+This documentation follows the [Diátaxis](https://diataxis.fr) model — pick the
+lane that matches what you need.
 
-Each machine has a **profile** that selects which packages, dotfiles, and steps
-apply:
+### Tutorials — learn by doing
 
-- **`personal`** (default) — full GUI Mac: core CLI + GUI casks/fonts/apps + macOS defaults.
-- **`work`** — `personal` plus the work overlay (extra tooling, work git/signing).
-- **`minimal`** — core CLI toolchain + runtimes + core dotfiles only.
-- **`server`** — headless macOS: core CLI + runtimes + core dotfiles, no GUI, no macOS defaults.
+- [Getting started: your first hour](tutorials/getting-started.md)
+- [Set up a work laptop](tutorials/work-laptop.md)
+- [Adopt a profile on an existing machine](tutorials/adopt-profile.md)
 
-Show or set a machine's profile without re-bootstrapping:
+### How-to guides — accomplish a task
 
-```sh
-bash ~/dotfiles/scripts/profile.sh           # show the active profile (aliased: dotprofile)
-bash ~/dotfiles/scripts/profile.sh set work  # persist this machine's profile
-```
+- [Add a tracked dotfile](how-to/add-a-dotfile.md)
+- [Manage packages](how-to/manage-packages.md)
+- [Manage secrets](how-to/manage-secrets.md)
+- [Add a zsh plugin](how-to/add-a-zsh-plugin.md)
+- [Write a test](how-to/write-a-test.md)
+- [Schedule updates](how-to/schedule-updates.md)
+- [Recover from a failed update](how-to/recover-from-a-failed-update.md)
 
-The profile is stored at `~/.config/dotfiles/profile`. Precedence is
-`--profile` flag > `DOTFILES_PROFILE` env > that file > `personal`.
+### Reference — look something up
 
-## Keeping everything current
+- [Machine profiles](profiles.md) and [Usage & lifecycle](usage.md)
+- [Tool reference](tools.md) and [Shell performance](performance.md)
+- [Troubleshooting](troubleshooting.md)
+- Setup: [Dry-run & pre-flight](DRY_RUN_AND_PREFLIGHT.md) · [GPG commit signing](GPG_SIGNING.md) · [Encrypted secrets](secrets.md)
+- Work machine: [Overview](work-machine.md) · [Complete setup guide](work-setup-complete.md) · [Claude Code SSL fix](claude-code-ssl-fix.md)
 
-```sh
-bash ~/dotfiles/update.sh              # pull, re-symlink, upgrade packages, health check
-bash ~/dotfiles/update.sh --dry-run    # preview everything; change nothing
-bash ~/dotfiles/update.sh --no-upgrade # pull + re-symlink + verify only
-```
+### Explanation — understand how it fits
 
-Other handy commands:
+- [Architecture](architecture.md) — how bootstrap, install, update, verify, status, and profiles fit together.
+- [Glossary](glossary.md) — terms used across these docs.
 
-- `bash ~/dotfiles/verify.sh` — standalone health check.
-- `bash ~/dotfiles/scripts/status.sh` — quick read-only snapshot (aliased `dotstatus`).
-- `zsh ~/dotfiles/install.sh` — re-symlink without upgrading packages.
+## Contributing
 
-## Documentation
-
-- **Guides**
-    - [Profiles](profiles.md) — `minimal` / `personal` / `work` / `server` and how each is applied.
-    - [Usage & Lifecycle](usage.md) — clone, bootstrap, update, verify, status, and scheduling.
-    - [Contributing](contributing.md) — conventions, the bats-core test workflow, and CI.
-- **Setup**
-    - [Dry-Run & Pre-flight](DRY_RUN_AND_PREFLIGHT.md) — preview and validate before installing.
-    - [GPG Commit Signing](GPG_SIGNING.md) — set up signed Git commits.
-    - [Encrypted Secrets](secrets.md) — commit secrets safely with sops + age.
-- **Work machine**
-    - [Work Machine Setup](work-machine.md) — the layered work overlay approach.
-    - [Complete Work Setup Guide](work-setup-complete.md) — full corporate-environment walkthrough.
-    - [Claude Code SSL Fix](claude-code-ssl-fix.md) — corporate certificate workaround.
-- **Reference**
-    - [Tool Reference](tools.md) — every tool in the Brewfile, with rationale and usage.
-    - [Shell Performance](performance.md) — how shell startup was cut by ~97%.
+See [Contributing](contributing.md) for repo conventions, the bats-core test
+workflow, and CI.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,8 +63,6 @@ nav:
       - Getting Started (Your First Hour): tutorials/getting-started.md
       - Set Up a Work Laptop: tutorials/work-laptop.md
       - Adopt a Profile: tutorials/adopt-profile.md
-  - Profiles: profiles.md
-  - Usage: usage.md
   - How-to:
       - Add a tracked dotfile: how-to/add-a-dotfile.md
       - Manage packages: how-to/manage-packages.md
@@ -73,6 +71,8 @@ nav:
       - Write a test: how-to/write-a-test.md
       - Schedule updates: how-to/schedule-updates.md
       - Recover from a failed update: how-to/recover-from-a-failed-update.md
+  - Profiles: profiles.md
+  - Usage: usage.md
   - Setup:
       - Dry-Run & Pre-flight: DRY_RUN_AND_PREFLIGHT.md
       - GPG Commit Signing: GPG_SIGNING.md


### PR DESCRIPTION
## Summary
Post-merge cleanup of the docs site now that the tutorials / how-to / reference pages have landed.

- **`docs/index.md`** → a Diátaxis **learning-path hub** that routes by intent (Tutorials / How-to / Reference / Explanation / Contributing), removing the inline Profiles and "Keeping everything current" sections that duplicated the dedicated pages.
- **README** Documentation table refreshed to include the new pages (Tutorials, How-to, Architecture, Troubleshooting, Glossary).
- **`mkdocs.yml`** nav lightly reordered so **How-to follows Tutorials** (Tutorials → How-to → Profiles → Usage → Setup → Work Machine → Reference → Explanation → Contributing); the mermaid `custom_fences` config is preserved.

De-dup note: the secrets reference ↔ how-to pages were already cross-linked by the content PRs, so this focuses on the index duplication + navigation.

## Validation
`uvx --with mkdocs-material mkdocs build --strict` → clean (built in ~0.5s, zero warnings).

Co-Authored-By: Oz <oz-agent@warp.dev>