### PR TITLE
docs(update): cross-page footers, Mermaid diagrams, consistency

### DIFF
--- a/docs/claude-code-ssl-fix.md
+++ b/docs/claude-code-ssl-fix.md
@@ -5,7 +5,10 @@ If Claude Code fails with:
 Unable to connect to API: SSL certificate verification failed
 ```
 
-This happens when behind corporate SSL inspection (Zscaler, BlueCoat, etc.).
+This happens when behind corporate SSL inspection (Zscaler, BlueCoat, etc.). The
+fixes below go in `~/.zshrc.local` — your machine-local, un-committed shell
+config — so they never leak into the tracked dotfiles. On a `work` machine the
+certificate is usually set up as part of the [work setup](work-setup-complete.md).
 
 ## Quick Fix
 
@@ -62,3 +65,9 @@ security find-certificate -a -p /Library/Keychains/System.keychain | grep -B 5 Z
 ```
 
 Contact your IT department if you cannot locate the certificate.
+
+## See also
+
+- [Set up a work laptop](tutorials/work-laptop.md) — the full `work`-profile setup flow.
+- [Complete Work Machine Setup Guide](work-setup-complete.md) — corporate certificates and proxy setup in depth.
+- [Troubleshooting](troubleshooting.md) — other common failures and fixes.

--- a/docs/how-to/add-a-dotfile.md
+++ b/docs/how-to/add-a-dotfile.md
@@ -64,3 +64,8 @@ git -C ~/dotfiles commit -m "feat: track ~/.ackrc"
 
 !!! tip
     `~/.gitconfig` is intentionally **not** in `symlinks.map`. It's a real file with a thin `[include]` of the tracked `home/gitconfig`, so `git config --global` and tools never write into the repo. That bespoke setup stays in `install.sh`.
+
+## See also
+
+- [Machine Profiles](../profiles.md) — gate a dotfile to specific profiles with the tag column.
+- [Add a zsh plugin](add-a-zsh-plugin.md) · [Manage packages](manage-packages.md) — other common additions.

--- a/docs/how-to/add-a-zsh-plugin.md
+++ b/docs/how-to/add-a-zsh-plugin.md
@@ -47,3 +47,8 @@ Because the file is tracked and symlinked, every machine picks up the same plugi
 
 !!! tip
     `home/zshrc` only calls sheldon when it's installed (`command -v sheldon`), falling back to manually-cloned plugins under `~/.zsh`. Ensure `sheldon` is present (it's in the core `Brewfile`) so your new entry is picked up.
+
+## See also
+
+- [Shell Performance](../performance.md) — how plugin loading affects shell startup.
+- [Add a tracked dotfile](add-a-dotfile.md) — track other config files.

--- a/docs/how-to/manage-packages.md
+++ b/docs/how-to/manage-packages.md
@@ -69,3 +69,8 @@ git -C ~/dotfiles commit -m "feat: add htop to core Brewfile"
 
 !!! tip
     Put a tool in the **lowest** scope that needs it. A CLI used on every machine belongs in `Brewfile`; a desktop app belongs in `Brewfile.personal`; keep work-only tooling in `Brewfile.work` so personal machines stay lean.
+
+## See also
+
+- [Machine Profiles](../profiles.md) — how the core/personal/work Brewfiles map to profiles.
+- [Usage & lifecycle](../usage.md) — how `update.sh` and `verify.sh` check Brewfile drift.

--- a/docs/how-to/manage-secrets.md
+++ b/docs/how-to/manage-secrets.md
@@ -66,3 +66,8 @@ If a private key or a plaintext secret is ever exposed: **rotate the affected cr
 
 !!! warning
     `.gitignore` blocks `keys.txt`, `*.agekey`, `age-key.txt`, and `*.dec`. The `gitleaks` pre-commit hook and CI job are a backstop — the encryption boundary is the primary protection.
+
+## See also
+
+- [Encrypted Secrets](../secrets.md) — the full reference and safety model.
+- [Troubleshooting](../troubleshooting.md) — fixes for missing keys and decryption errors.

--- a/docs/how-to/recover-from-a-failed-update.md
+++ b/docs/how-to/recover-from-a-failed-update.md
@@ -84,3 +84,8 @@ dotstatus                       # expect: result: success
 
 !!! tip
     Use `bash ~/dotfiles/update.sh --dry-run` to preview exactly what the next run will do — including whether it would skip the pull — without changing anything.
+
+## See also
+
+- [Troubleshooting](../troubleshooting.md) — fixes for specific failures.
+- [Usage & lifecycle](../usage.md) — the update steps and safety flags.

--- a/docs/how-to/schedule-updates.md
+++ b/docs/how-to/schedule-updates.md
@@ -54,3 +54,8 @@ bash ~/dotfiles/scripts/setup-scheduler.sh --uninstall
 ```
 
 This boots out the launchd job and removes the installed plist.
+
+## See also
+
+- [Usage & lifecycle](../usage.md) — `update.sh`, its flags, and `update.conf`.
+- [Recover from a failed update](recover-from-a-failed-update.md) — when a scheduled run reports failures.

--- a/docs/how-to/write-a-test.md
+++ b/docs/how-to/write-a-test.md
@@ -66,3 +66,8 @@ git -C ~/dotfiles commit -m "test: cover my_helpers.sh"
 
 !!! tip
     Keep library helpers side-effect-free (no `exit`, no traps, configuration via globals/arguments) — that's what makes them unit-testable. Mirror the patterns in the existing `scripts/lib/*.sh` files.
+
+## See also
+
+- [Contributing](../contributing.md) — the full test, lint, and CI workflow.
+- [Architecture](../architecture.md) — where the helper libraries fit.

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -56,6 +56,16 @@ Higher sources win, so a `--profile` flag overrides everything. An unrecognized
 value at any level is ignored and falls through to the next source, so a typo can
 never select an invalid profile — `resolve_profile` always echoes a valid name.
 
+```mermaid
+flowchart TD
+  Flag{"--profile flag<br/>valid?"} -->|yes| UseFlag["Active: flag value"]
+  Flag -->|no| Env{"DOTFILES_PROFILE<br/>env valid?"}
+  Env -->|yes| UseEnv["Active: env value"]
+  Env -->|no| File{"persisted file<br/>valid?"}
+  File -->|yes| UseFile["Active: persisted value"]
+  File -->|no| Default["Active: personal (default)"]
+```
+
 ### `scripts/profile.sh` and the `dotprofile` alias
 
 Use [`scripts/profile.sh`](https://github.com/bradbergeron-us/dotfiles/blob/main/scripts/profile.sh)
@@ -158,3 +168,9 @@ scripts honor it too:
 Because they all read `current_profile`, switching a machine's profile with
 `dotprofile set <name>` (followed by `install.sh` + `update.sh`) is enough to
 re-shape what the repo manages on that device — no re-bootstrap required.
+
+## See also
+
+- [Adopt a profile on an existing machine](tutorials/adopt-profile.md) — switch a machine's profile in place.
+- [Architecture](architecture.md) — where the profile system fits in the overall design.
+- [Usage & lifecycle](usage.md) — the lifecycle commands that read the active profile.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,16 @@ bash ~/dotfiles/verify.sh           # on demand: full health check
 bash ~/dotfiles/scripts/status.sh   # quick read-only snapshot (alias: dotstatus)
 ```
 
+```mermaid
+flowchart LR
+  Clone(["git clone"]) --> Bootstrap["bootstrap.sh<br/>(one-time)"]
+  Bootstrap --> Daily(["Daily use"])
+  Daily --> Update["update.sh<br/>pull · re-symlink · upgrade"]
+  Update --> Verify["verify.sh<br/>health check"]
+  Verify --> Daily
+  Daily -.-> Status["status.sh<br/>quick snapshot"]
+```
+
 | Stage | Script | When |
 |-------|--------|------|
 | Bootstrap | `bootstrap.sh` | Once, on a fresh Mac |
@@ -295,3 +305,5 @@ contexts).
 - [Dry-Run & Pre-flight](DRY_RUN_AND_PREFLIGHT.md) — previewing and validating before installing.
 - [Encrypted Secrets](secrets.md) — managing secrets with sops + age.
 - [Tool Reference](tools.md) — every tool in the Brewfile, with rationale.
+- [Troubleshooting](troubleshooting.md) — fixes for failed updates, broken symlinks, and more.
+- [Recover from a failed update](how-to/recover-from-a-failed-update.md) — the step-by-step recovery guide.


### PR DESCRIPTION
## Summary
A docs polish + flow pass over the now-complete site (no new pages).

- **Diagrams** (Mermaid, already enabled via `pymdownx.superfences`): a profile-selection precedence flow on `profiles.md` and a daily-lifecycle flow on `usage.md`.
- **Cross-page flow**: added "See also" footers to the pages that lacked them — `profiles.md`, `claude-code-ssl-fix.md`, and all seven `how-to/*` guides. (The three tutorials and `usage.md`/`secrets.md` already had footers.)
- **Enrich / consistency**: connected `claude-code-ssl-fix.md` to the `~/.zshrc.local` / work-setup pattern, and gave the touched pages consistent "See also" sections so readers no longer hit dead ends.

## Validation
`uvx --with mkdocs-material mkdocs build --strict` → clean (built in ~0.5s, zero warnings; diagrams parse, all relative links resolve).

Co-Authored-By: Oz <oz-agent@warp.dev>