### PR TITLE
feat(docs): Tokyo Night theme for the docs site

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,74 @@
+/* Tokyo Night theme for the dotfiles docs site.
+   Enabled by `primary: custom` / `accent: custom` in mkdocs.yml; these
+   variables restyle Material's `slate` (dark, shown by default) and `default`
+   (light) colour schemes to the enkia Tokyo Night palette — matching the
+   Ghostty / Hyper terminal theme this repo ships. */
+
+/* ---------- Tokyo Night (dark) — the `slate` scheme, default ---------- */
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color:           #1a1b26;
+  --md-default-bg-color--light:    #24283b;
+  --md-default-bg-color--lighter:  #292e42;
+  --md-default-bg-color--lightest: #1f2335;
+  --md-default-fg-color:           #c0caf5;
+  --md-default-fg-color--light:    #a9b1d6;
+  --md-default-fg-color--lighter:  #565f89;
+  --md-default-fg-color--lightest: #414868;
+
+  /* header + nav bar */
+  --md-primary-fg-color:        #16161e;
+  --md-primary-fg-color--light: #24283b;
+  --md-primary-fg-color--dark:  #16161e;
+  --md-primary-bg-color:        #c0caf5;
+  --md-primary-bg-color--light: #a9b1d6;
+
+  /* links + interactive accent */
+  --md-accent-fg-color:         #7dcfff;
+  --md-typeset-a-color:         #7aa2f7;
+
+  /* code + syntax highlighting */
+  --md-code-bg-color:             #16161e;
+  --md-code-fg-color:             #c0caf5;
+  --md-code-hl-color:             #283457;
+  --md-code-hl-comment-color:     #565f89;
+  --md-code-hl-keyword-color:     #bb9af7;
+  --md-code-hl-function-color:    #7aa2f7;
+  --md-code-hl-string-color:      #9ece6a;
+  --md-code-hl-number-color:      #ff9e64;
+  --md-code-hl-constant-color:    #ff9e64;
+  --md-code-hl-special-color:     #f7768e;
+  --md-code-hl-operator-color:    #89ddff;
+  --md-code-hl-punctuation-color: #89ddff;
+  --md-code-hl-name-color:        #c0caf5;
+  --md-code-hl-variable-color:    #e0af68;
+
+  /* footer */
+  --md-footer-bg-color:       #16161e;
+  --md-footer-bg-color--dark: #101014;
+}
+
+/* ---------- Tokyo Night Day (light) — the `default` scheme ---------- */
+[data-md-color-scheme="default"] {
+  --md-default-bg-color:        #e1e2e7;
+  --md-default-fg-color:        #343b58;
+  --md-default-fg-color--light: #4c505e;
+  --md-primary-fg-color:        #34548a;
+  --md-primary-fg-color--dark:  #1a4ba8;
+  --md-primary-bg-color:        #ffffff;
+  --md-accent-fg-color:         #007197;
+  --md-typeset-a-color:         #2e7de9;
+  --md-code-bg-color:           #d4d6e4;
+  --md-code-fg-color:           #343b58;
+}
+
+/* ---------- Small cross-scheme polish ---------- */
+.md-typeset pre > code,
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: 8px;
+}
+
+.md-nav__link:focus,
+.md-nav__link:hover {
+  color: var(--md-accent-fg-color);
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,30 +8,52 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  icon:
+    logo: material/console
+    repo: fontawesome/brands/github
+  font:
+    text: Inter
+    code: JetBrains Mono
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: indigo
-      accent: indigo
+    # Tokyo Night (dark) — shown by default
+    - scheme: slate
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-night
-        name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: indigo
-      accent: indigo
+        name: Switch to light mode
+    # Tokyo Night Day (light)
+    - scheme: default
+      primary: custom
+      accent: custom
       toggle:
         icon: material/weather-sunny
-        name: Switch to light mode
+        name: Switch to dark mode
   features:
     - navigation.instant
     - navigation.tracking
     - navigation.sections
     - navigation.top
+    - navigation.footer
+    - toc.follow
     - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - content.action.view
     - search.suggest
     - search.highlight
-    - toc.follow
+    - search.share
+
+extra_css:
+  - stylesheets/extra.css
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/bradbergeron-us/dotfiles
+      name: dotfiles on GitHub
+
+copyright: Copyright &copy; Brad Bergeron
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
Reskins the docs site from the default Material indigo to a **Tokyo Night** theme — matching the Ghostty/Hyper terminal theme this repo already ships.

- **`docs/stylesheets/extra.css`** (new): custom colour variables for the `slate` (dark, default) scheme — `#1a1b26` background, `#c0caf5` text, `#7aa2f7` links, `#7dcfff` accent, and Tokyo Night syntax highlighting (purple keywords, green strings, orange numbers). The light scheme is recoloured to **Tokyo Night Day**. Minor polish: rounded code blocks/admonitions, accent hover.
- **`mkdocs.yml`**: palette switched to `primary/accent: custom` with the **dark scheme first (default)** + a light toggle; **JetBrains Mono** code font + **Inter** text; `console` logo + GitHub repo icon; layout features — `navigation.footer`, `content.code.annotate`, `content.action.edit`/`view`, `search.share`; social link + copyright.

No new build dependencies (Material 9.7.6 supports `custom` colours).

## Preview the colours
PR docs CI builds but only deploys on merge, so to see it live first:
```sh
uvx --with mkdocs-material mkdocs serve   # then open http://127.0.0.1:8000/
```
Tweak any hex values in `extra.css` to taste.

## Validation
`mkdocs build --strict` → clean; `extra.css` is bundled and the default scheme renders as `slate` (Tokyo Night dark).

Co-Authored-By: Oz <oz-agent@warp.dev>