### PR TITLE
feat: revive uninstaller (mirror of install.sh, profile-aware)

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Stored at `~/.config/dotfiles/profile`; precedence is `--profile` flag > `DOTFIL
 | `home/npmrc` | `~/.npmrc` | npm defaults — `save-exact`, no fund/update noise |
 | `update.sh` | _(run to update)_ | Upgrade all packages, runtimes, and gems; runs health check at end |
 | `verify.sh` | _(run to verify)_ | Health check — symlinks, missing tools, installed runtimes, stale backups |
+| `uninstall.sh` | _(run to uninstall)_ | Reverse `install.sh` — remove tracked symlinks, restore backed-up originals (`--dry-run` to preview) |
 | `scripts/setup-scheduler.sh` | _(run once)_ | Install launchd job to run `update.sh` daily at 9 AM |
 | `scripts/status.sh` | _(run / `dotstatus`)_ | Quick read-only health snapshot — repo git state + last `update.sh` result |
 | `scripts/profile.sh` | _(run / `dotprofile`)_ | Show or set this machine's profile (`personal`/`work`/`minimal`/`server`) |
@@ -387,6 +388,23 @@ Or for additional work-specific topics: [docs/work-machine.md](docs/work-machine
 
 ---
 
+## Uninstall
+Reverse `install.sh` when you want to step a machine off the dotfiles. It is the mirror image of install — driven by the same `config/symlinks.map` SSOT and honoring the active [profile](#machine-profile).
+
+```sh
+bash ~/dotfiles/uninstall.sh --dry-run   # preview everything; change nothing
+bash ~/dotfiles/uninstall.sh             # remove symlinks + restore backups (asks to confirm)
+bash ~/dotfiles/uninstall.sh --yes       # skip the confirmation prompt (for non-interactive use)
+```
+
+What it does:
+- **Removes** the tracked dotfile symlinks for the active profile — but only links that actually point into the repo. Symlinks that point elsewhere, and plain (non-symlink) files, are left alone.
+- **Restores** the most recent `~/.dotfiles_backup/<timestamp>/` entry for each destination it clears (best effort, matched by filename), so any original file `install.sh` moved aside comes back.
+- **Removes** the thin `~/.gitconfig` include that `install.sh` writes (a real file, not a symlink — removed only when it includes `home/gitconfig`), then restores any backed-up `~/.gitconfig`.
+
+What it deliberately leaves alone (safe by design): it never deletes the dotfiles repo or your `~/.dotfiles_backup`, never uninstalls Homebrew/`mise`/Rust packages, and never touches untracked local config such as `~/.zshrc.local` or `~/.config/git/local.gitconfig`. Removing a symlink only unlinks it; the tracked file in the repo is untouched. The script is idempotent — running it again is a no-op — and `--dry-run` prints exactly what a real run would remove and restore without changing anything. Re-link any time with `zsh ~/dotfiles/install.sh`.
+
+---
 ## Making changes
 
 Because most dotfiles are symlinked, editing `~/.zshrc` edits `~/dotfiles/home/zshrc` directly. (Exception: `~/.gitconfig` is a thin _include_, not a symlink — edit `home/gitconfig` for shared settings; machine-specific or tool-written git config stays in `~/.gitconfig` / `~/.config/git/local.gitconfig`.)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# uninstall.sh — reverse install.sh: remove tracked dotfile symlinks and restore
+# the files they replaced. The mirror image of install.sh, sharing its single
+# source of truth (config/symlinks.map) and profile model (profile_helpers.sh).
+#
+# What it does:
+#   • Removes only symlinks listed in config/symlinks.map that point into this
+#     repo and apply to the active profile (current_profile / profile_includes).
+#   • Restores the most recent ~/.dotfiles_backup/<timestamp>/ entry for each
+#     destination it clears, when one exists (best effort, by basename).
+#   • Removes the thin ~/.gitconfig include (a real file, not a symlink) that
+#     install.sh writes, and restores any backed-up ~/.gitconfig.
+#
+# What it deliberately does NOT do (safety): it never deletes the dotfiles repo,
+# never uninstalls Homebrew/mise/Rust packages, and never touches untracked user
+# data such as ~/.zshrc.local or ~/.config/git/local.gitconfig. Removing a
+# symlink only unlinks it — the tracked file in the repo is left intact.
+#
+# Usage:
+#   bash uninstall.sh [--dry-run] [--yes] [--help]
+#   --dry-run   Show what would be removed/restored; change nothing.
+#   --yes, -y   Skip the confirmation prompt (required for non-interactive runs).
+#   --help, -h  Show this help and exit.
+#
+# Re-runnable: a second run finds nothing left to remove and is a no-op.
+
+set -euo pipefail
+
+DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
+BACKUP_ROOT="$HOME/.dotfiles_backup"
+
+DRY_RUN=false
+ASSUME_YES=false
+
+usage() {
+  sed -n '2,25p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)   DRY_RUN=true ;;
+    --yes|-y)    ASSUME_YES=true ;;
+    --help|-h)   usage; exit 0 ;;
+    *)
+      printf 'uninstall.sh: unknown option: %s\n\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+  shift
+done
+
+# ── Shared helpers ────────────────────────────────────────────────────────────
+# shellcheck source=scripts/lib/bootstrap_helpers.sh
+source "$DOTFILES_DIR/scripts/lib/bootstrap_helpers.sh"
+# shellcheck source=scripts/lib/profile_helpers.sh
+source "$DOTFILES_DIR/scripts/lib/profile_helpers.sh"
+setup_colors
+
+PROFILE="$(current_profile)"
+
+# Most recent timestamped backup directory (names sort chronologically), or "".
+latest_backup_dir() {
+  local d last=""
+  [[ -d "$BACKUP_ROOT" ]] || return 0
+  for d in "$BACKUP_ROOT"/*/; do
+    [[ -d "$d" ]] || continue
+    last="${d%/}"
+  done
+  printf '%s' "$last"
+}
+
+LATEST_BACKUP="$(latest_backup_dir)"
+
+removed=0
+skipped=0
+restored=0
+
+# Restore the most recent backup for a destination, if one exists and the slot
+# is now free. Best effort: install.sh backs files up by basename, so that is
+# the key we look up here.
+restore_backup() {
+  local dest="$1"
+  local short="${dest/$HOME/\~}"
+  local base backup
+  [[ -n "$LATEST_BACKUP" ]] || return 0
+  base="$(basename "$dest")"
+  backup="$LATEST_BACKUP/$base"
+  [[ -e "$backup" || -L "$backup" ]] || return 0
+  if [[ "$DRY_RUN" == true ]]; then
+    info "would restore  $short  (from ${LATEST_BACKUP/$HOME/\~}/$base)"
+    restored=$(( restored + 1 ))
+    return 0
+  fi
+  # Never clobber something that already lives at the destination.
+  [[ -e "$dest" || -L "$dest" ]] && return 0
+  mkdir -p "$(dirname "$dest")"
+  mv "$backup" "$dest"
+  success "restored   $short  (from ${LATEST_BACKUP/$HOME/\~}/$base)"
+  restored=$(( restored + 1 ))
+}
+
+# Remove a symlink only when it points into this repo; then try to restore.
+remove_link() {
+  local dest="$1"
+  local short="${dest/$HOME/\~}"
+  local target
+
+  if [[ -L "$dest" ]]; then
+    target="$(readlink "$dest")"
+    if [[ "$target" == "$DOTFILES_DIR"/* ]]; then
+      if [[ "$DRY_RUN" == true ]]; then
+        info "would remove   $short"
+      else
+        rm "$dest"
+        success "removed    $short"
+      fi
+      removed=$(( removed + 1 ))
+      restore_backup "$dest"
+    else
+      info "skipped    $short  (points elsewhere: $target)"
+      skipped=$(( skipped + 1 ))
+    fi
+  elif [[ -e "$dest" ]]; then
+    info "skipped    $short  (not a symlink)"
+    skipped=$(( skipped + 1 ))
+  fi
+  # Missing destinations are silently ignored — nothing to undo.
+}
+
+# ── Banner ────────────────────────────────────────────────────────────────────
+echo ""
+printf "${BOLD}  🗑️  dotfiles uninstall${RESET}  —  remove tracked symlinks\n"
+echo "  ─────────────────────────────────────────────────"
+printf "  ${DIM}Machine${RESET}  %s\n" "$(scutil --get ComputerName 2>/dev/null || hostname)"
+printf "  ${DIM}Profile${RESET}  %s\n" "$PROFILE"
+if [[ "$DRY_RUN" == true ]]; then
+  printf "  ${DIM}Mode${RESET}     dry-run (no changes)\n"
+fi
+echo "  ─────────────────────────────────────────────────"
+
+# ── Confirmation ──────────────────────────────────────────────────────────────
+if [[ "$DRY_RUN" != true && "$ASSUME_YES" != true ]]; then
+  if [[ -t 0 ]]; then
+    echo ""
+    warn "This removes dotfile symlinks and restores backed-up originals."
+    read -rp "  Continue? [y/N] " confirm
+    if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+      echo ""
+      info "Uninstall cancelled"
+      exit 0
+    fi
+  else
+    warn "Refusing to run non-interactively without --yes (use --dry-run to preview)."
+    exit 1
+  fi
+fi
+
+# ── Step 1: Remove tracked dotfile symlinks (config/symlinks.map SSOT) ─────────
+echo ""
+printf "${BOLD}  1. Removing dotfile symlinks${RESET}  (profile: %s)\n" "$PROFILE"
+echo ""
+
+SYMLINK_MAP="$DOTFILES_DIR/config/symlinks.map"
+if [[ -r "$SYMLINK_MAP" ]]; then
+  while read -r src_rel dest_rel tags_rel; do
+    [[ -z "$src_rel" || "$src_rel" == \#* ]] && continue
+    if ! profile_includes "$PROFILE" "${tags_rel:-}"; then
+      continue
+    fi
+    remove_link "$HOME/$dest_rel"
+  done < "$SYMLINK_MAP"
+else
+  warn "symlink manifest not found: $SYMLINK_MAP"
+fi
+
+# ── Step 2: Git config thin include ────────────────────────────────────────────
+# install.sh writes ~/.gitconfig as a REAL file containing an [include] of the
+# tracked home/gitconfig. Remove only that managed include (verified by content),
+# then restore any backed-up original. Older installs may have symlinked it.
+echo ""
+printf "${BOLD}  2. Git config thin include${RESET}\n"
+echo ""
+
+GITCONFIG_DEST="$HOME/.gitconfig"
+GITCONFIG_SRC="$DOTFILES_DIR/home/gitconfig"
+GITCONFIG_SHORT="${GITCONFIG_DEST/$HOME/\~}"
+
+if [[ -L "$GITCONFIG_DEST" ]]; then
+  # Legacy: a symlink into the repo. Reuse the same safe removal path.
+  remove_link "$GITCONFIG_DEST"
+elif [[ -f "$GITCONFIG_DEST" ]] && grep -qF "path = $GITCONFIG_SRC" "$GITCONFIG_DEST"; then
+  if [[ "$DRY_RUN" == true ]]; then
+    info "would remove   $GITCONFIG_SHORT  (managed thin include)"
+  else
+    rm "$GITCONFIG_DEST"
+    success "removed    $GITCONFIG_SHORT  (managed thin include)"
+  fi
+  removed=$(( removed + 1 ))
+  restore_backup "$GITCONFIG_DEST"
+else
+  info "skipped    $GITCONFIG_SHORT  (not a managed thin include)"
+  skipped=$(( skipped + 1 ))
+fi
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+echo ""
+echo "  ─────────────────────────────────────────────────"
+if [[ "$DRY_RUN" == true ]]; then
+  printf "${BOLD}  ✅  dry-run: %d would remove · %d would restore · %d skipped${RESET}\n" \
+    "$removed" "$restored" "$skipped"
+else
+  printf "${GREEN}${BOLD}  ✅  Uninstall complete${RESET}  —  %d removed · %d restored · %d skipped\n" \
+    "$removed" "$restored" "$skipped"
+fi
+echo "  ─────────────────────────────────────────────────"
+echo ""
+printf "  ${BOLD}Notes${RESET}\n"
+printf "  • The dotfiles repo and your backups were left untouched.\n"
+printf "  • Untracked local config (~/.zshrc.local, ~/.config/git/local.gitconfig) was kept.\n"
+printf "  • Re-install any time with: ${CYAN}zsh %s/install.sh${RESET}\n" "${DOTFILES_DIR/$HOME/\~}"
+echo ""


### PR DESCRIPTION
## Summary
Revives the uninstaller (Phase 4, item 12), completing the install ↔ uninstall lifecycle. The stale `feature/uninstall-script` branch (~134 commits behind, hardcoded symlink list + interactive package/runtime/Homebrew teardown) predated today's layout, so this is a ground-up rewrite aligned to current conventions rather than a cherry-pick.

`uninstall.sh` is the mirror image of `install.sh`:
- **Symlink removal driven by `config/symlinks.map`** (the SSOT) and **profile-aware** via `scripts/lib/profile_helpers.sh` (`current_profile` / `profile_includes`), exactly like `install.sh` and `verify.sh`.
- Removes **only symlinks that point into the repo**; foreign symlinks and plain files are skipped, never touched.
- **Restores** the most recent `~/.dotfiles_backup/<timestamp>/` entry for each cleared destination (best effort, by basename).
- Handles the **thin `~/.gitconfig` include** (a real file, not a symlink): removed only when it includes `home/gitconfig`, then restores any backed-up original.
- Sources `scripts/lib/bootstrap_helpers.sh` (`setup_colors`/`info`/`success`/`warn`); `#!/usr/bin/env bash` + `set -euo pipefail`; supports `--dry-run`, `--help`, and `--yes`; `chmod +x`; idempotent.
- **Safe by design:** never deletes the repo, `~/.dotfiles_backup`, Homebrew/`mise`/Rust packages, or untracked user data (`~/.zshrc.local`, `~/.config/git/local.gitconfig`). The old script's package/runtime/Homebrew teardown was intentionally dropped.

Also adds a README "Uninstall" section and a `uninstall.sh` row in the Dotfiles table.

## Validation
- `shellcheck -S warning uninstall.sh` — clean
- `bash -n uninstall.sh` — clean
- `bats scripts/tests/` — all 162 tests green
- Seeded a fake `$HOME` (repo-pointing symlinks, a foreign symlink, a managed thin-include gitconfig, a backup dir, an untracked `~/.zshrc.local`):
  - `bash uninstall.sh --dry-run` reports `4 would remove · 1 would restore · 1 skipped` and **changes nothing** (asserted every link/file unchanged).
  - `bash uninstall.sh --yes` removes the repo links, restores `~/.zshrc` from backup, removes the managed `~/.gitconfig`, preserves the foreign `~/.gemrc` and untracked `~/.zshrc.local`; a second run is a no-op (`0 removed`).
- Worktree contains only the owned files; the user's checkout stays clean.

## Shared-file note
Only files owned by this item changed: new `uninstall.sh` and an append-only `README.md` "Uninstall" section + table row — disjoint from the other Phase 4 PRs.

_Conversation: https://app.warp.dev/conversation/c552bf38-dca6-4ba2-a9a9-3603b39f0f40_
_Run: https://oz.warp.dev/runs/019ed1ab-9da3-7aea-b0fe-adf1e2edc9e3_

_This PR was generated with [Oz](https://warp.dev/oz)._
