### PR TITLE
test+ci: install.sh bats coverage, actionlint + shellcheck pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,8 @@ jobs:
           }
 
           # --- Default profile (personal): full set, same as before profiles ---
-          export HOME=$(mktemp -d)
+          HOME="$(mktemp -d)"
+          export HOME
           echo "Isolated HOME: $HOME"
           zsh install.sh
           echo ""
@@ -181,3 +182,20 @@ jobs:
         uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ------------------------------------------------------------------
+  # 5. actionlint — lint the workflow files themselves. Catches invalid
+  #    workflow syntax / bad expressions, and (via the bundled shellcheck)
+  #    issues in `run:` blocks the shellcheck job above does not cover.
+  #    Pinned to match the pre-commit hook and `brew install actionlint`.
+  # ------------------------------------------------------------------
+  actionlint:
+    name: Lint GitHub Actions workflows (actionlint)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run actionlint
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,28 @@ repos:
         language: script
         pass_filenames: false
         files: '\.template$'
+
+  # ------------------
+  # Workflow linting — actionlint validates .github/workflows/*.yml (and lints
+  # the embedded run: scripts via shellcheck). pre-commit builds it in an
+  # isolated golang env, like gitleaks above.
+  # ------------------
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12  # pin to a version; update with: pre-commit autoupdate
+    hooks:
+      - id: actionlint
+        name: actionlint (GitHub Actions workflow lint)
+
+  # ------------------
+  # Shell static analysis — parity with the shellcheck CI job. Uses the locally
+  # installed shellcheck (Brewfile) and lints bash *.sh only; install.sh and
+  # setup_gpg_signing.sh are zsh, which shellcheck cannot parse.
+  # ------------------
+  - repo: local
+    hooks:
+      - id: shellcheck
+        name: shellcheck (bash static analysis)
+        entry: shellcheck -S warning
+        language: system
+        files: '\.sh$'
+        exclude: '^(install\.sh|scripts/setup_gpg_signing\.sh)$'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,12 +60,17 @@ Convention (see `scripts/tests/test_verify_helpers.bats` for the reference imple
 - Add new tests as `@test` blocks in the `*.bats` file next to the helper they cover; both CI and `bats scripts/tests/` auto-discover them, so no workflow edits are needed.
 
 Because the helpers are side-effect-free, tests exercise them directly against temporary `$HOME` / fixture directories.
+`scripts/tests/test_install.bats` is the exception — an integration test rather than a helper unit test. `install.sh` is a zsh entry-point with no extractable pure functions, so it runs the real script against an isolated `$HOME` (like the CI install-smoke job) and asserts on the resulting symlinks, the thin `~/.gitconfig` include, seeded files, backups, idempotency, and profile gating.
 
 ## CI
 
-- **`.github/workflows/ci.yml`** — three jobs: `shellcheck` (bash scripts, `-S warning`), `zsh-syntax` (`zsh -n` on the zsh files plus a `Brewfile` parse check), and `install-smoke` (runs `zsh install.sh` against a throwaway `$HOME` and asserts every expected symlink exists).
+- **`.github/workflows/ci.yml`** — five jobs: `shellcheck` (bash scripts, `-S warning`), `zsh-syntax` (`zsh -n` on the zsh files plus a `Brewfile` parse check), `install-smoke` (runs `zsh install.sh` against a throwaway `$HOME` and asserts every expected symlink exists), `secret-scan` (gitleaks on new commits), and `actionlint` (lints the workflow files themselves, including `run:` blocks via the bundled shellcheck).
 - **`.github/workflows/test-bootstrap.yml`** — installs bats-core and runs the full `scripts/tests/*.bats` suite (auto-discovered via `bats scripts/tests/`), plus `bash -n` syntax checks on the scripts under test and a `bats --count` parse-check of every `.bats` file, when the relevant scripts change.
 - **`.github/workflows/release.yml`** — release automation (see [Releasing](#releasing)).
+
+### Pre-commit hooks
+
+`.pre-commit-config.yaml` runs on `git commit` once `pre-commit` is installed (it's in the `Brewfile`, and `install.sh` wires the global hook). Hooks: `gitleaks` (secret scanning), `validate-templates` (no real secrets in `*.template`), `actionlint` (workflow lint), and `shellcheck` (bash static analysis, mirroring the CI job). Run every hook on demand with `pre-commit run --all-files`, and bump pinned versions with `pre-commit autoupdate`.
 
 ## Releasing
 
@@ -110,6 +115,7 @@ Add a side-effect-free `check_*` function to `scripts/lib/verify_helpers.sh` tha
 
 - Run `shellcheck -S warning <script>` on any bash you touched, and `zsh -n <file>` on zsh files (`install.sh`, `scripts/setup_gpg_signing.sh`, `home/zshrc`, `home/zprofile`).
 - Run the bats suite with `bats scripts/tests/` (install via `brew install bats-core` if needed).
+- Run `pre-commit run --all-files` to apply every hook at once (gitleaks, template check, actionlint, shellcheck); after editing any `.github/workflows/*.yml`, run `actionlint` to lint the workflow.
 - For changes to install/verify behavior, exercise them against an isolated `HOME=$(mktemp -d)`.
 - New bash scripts start with `#!/usr/bin/env bash` and `set -euo pipefail`, and reuse `scripts/lib/bootstrap_helpers.sh` for output.
 - A repo-local pre-commit hook runs when `pre-commit` is installed and a `.pre-commit-config.yaml` is present.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -220,7 +220,7 @@ code --list-extensions
 
 ## Tests (`tests/`)
 
-[bats-core](https://github.com/bats-core/bats-core) unit tests (`test_*.bats`), auto-discovered and run by `.github/workflows/test-bootstrap.yml`. Current files: `test_bootstrap_helpers.bats`, `test_verify_helpers.bats`, `test_dryrun_helpers.bats`, `test_update_helpers.bats`, `test_status_helpers.bats`, `test_profile_helpers.bats`, and `test_validate_templates.bats`.
+[bats-core](https://github.com/bats-core/bats-core) tests (`test_*.bats`), auto-discovered and run by `.github/workflows/test-bootstrap.yml`. Helper unit tests: `test_bootstrap_helpers.bats`, `test_verify_helpers.bats`, `test_dryrun_helpers.bats`, `test_update_helpers.bats`, `test_status_helpers.bats`, `test_profile_helpers.bats`, and `test_validate_templates.bats`. Plus `test_install.bats`, an integration test that runs the real `install.sh` against an isolated `$HOME`.
 
 **Install bats** (already in the `Brewfile`):
 ```bash

--- a/scripts/tests/test_install.bats
+++ b/scripts/tests/test_install.bats
@@ -1,0 +1,87 @@
+#!/usr/bin/env bats
+# test_install.bats — integration tests for the top-level install.sh symlinker.
+# Run: bats scripts/tests/test_install.bats
+#
+# Unlike the helper-library suites (which source a side-effect-free *_helpers.sh
+# and assert on result globals), install.sh is a zsh entry-point with no
+# extractable pure functions. So these tests run the *real* script against an
+# isolated $HOME — the same approach as the CI install-smoke job — and assert on
+# its observable effects. install.sh derives DOTFILES_DIR from its own path, so
+# it always links the repo's real files; pointing $HOME at the per-test scratch
+# dir keeps every change contained (and auto-removed) by bats.
+
+load 'test_helper'
+
+setup() {
+  if ! command -v zsh >/dev/null 2>&1; then
+    skip "zsh not available"
+  fi
+  INSTALL="$REPO_ROOT/install.sh"
+  # Isolated fake HOME; install.sh links the real repo files into here.
+  TEST_HOME="$BATS_TEST_TMPDIR/home"
+  mkdir -p "$TEST_HOME"
+}
+
+# Run install.sh against the isolated HOME under an explicit profile. The VS Code
+# block is skipped automatically because $TEST_HOME has no Code/User dir, so no
+# extensions are ever installed.
+run_install() {
+  local profile="${1:-personal}"
+  run env HOME="$TEST_HOME" DOTFILES_PROFILE="$profile" zsh "$INSTALL"
+}
+
+# ── linking ───────────────────────────────────────────────────────────────────
+@test "install.sh: personal profile links core + gui dotfiles into HOME" {
+  run_install personal
+  [ "$status" -eq 0 ]
+  # A core (untagged) record …
+  [ -L "$TEST_HOME/.zshrc" ]
+  [[ "$(readlink "$TEST_HOME/.zshrc")" == *"/home/zshrc" ]]
+  # … and a gui-tagged record (gui applies to personal).
+  [ -L "$TEST_HOME/.hyper.js" ]
+}
+
+@test "install.sh: ~/.gitconfig is a real thin include, not a symlink" {
+  run_install personal
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_HOME/.gitconfig" ]
+  [ ! -L "$TEST_HOME/.gitconfig" ]
+  grep -q "home/gitconfig" "$TEST_HOME/.gitconfig"
+}
+
+@test "install.sh: seeds local.gitconfig and the global pre-commit hook" {
+  run_install personal
+  [ "$status" -eq 0 ]
+  [ -f "$TEST_HOME/.config/git/local.gitconfig" ]
+  [ -x "$TEST_HOME/.config/git/hooks/pre-commit" ]
+}
+
+# ── idempotency / backups ───────────────────────────────────────────────────
+@test "install.sh: a second run is idempotent (reports 0 backed up)" {
+  run_install personal
+  [ "$status" -eq 0 ]
+  run_install personal
+  [ "$status" -eq 0 ]
+  echo "$output" | grep -q "0 backed up"
+}
+
+@test "install.sh: backs up a pre-existing real dotfile before linking" {
+  echo "pre-existing" > "$TEST_HOME/.zshrc"   # a real file, not a symlink
+  run_install personal
+  [ "$status" -eq 0 ]
+  # Original is replaced by the managed symlink …
+  [ -L "$TEST_HOME/.zshrc" ]
+  echo "$output" | grep -q "backed up"
+  # … and the old file is preserved under the timestamped backup dir.
+  run find "$TEST_HOME/.dotfiles_backup" -name '.zshrc' -type f
+  [ -n "$output" ]
+}
+
+# ── profile gating ──────────────────────────────────────────────────────────
+@test "install.sh: minimal profile skips gui-tagged links" {
+  run_install minimal
+  [ "$status" -eq 0 ]
+  [ -L "$TEST_HOME/.zshrc" ]                        # core link still created
+  [ ! -e "$TEST_HOME/.hyper.js" ]                   # gui-tagged → skipped
+  [ ! -e "$TEST_HOME/.config/ghostty/config" ]      # gui-tagged → skipped
+}


### PR DESCRIPTION
## Summary
Final Phase 4 workstream — **script coverage + developer hygiene**. Closes the remaining gaps: the one top-level script without tests (`install.sh`), workflow linting, and local pre-commit parity with CI.

## Changes
- **`scripts/tests/test_install.bats`** (new) — integration coverage for `install.sh`, the only top-level script lacking tests. It's a zsh entry-point with no extractable pure functions, so the test runs the real script against an isolated `$HOME` (mirroring the install-smoke job) and asserts on: core + gui symlinks, the thin `~/.gitconfig` include (real file, not a symlink), seeded `local.gitconfig` + global pre-commit hook, idempotency (`0 backed up` on re-run), backup of a pre-existing file, and `minimal` profile gating. Auto-discovered by `test-bootstrap.yml`.
- **`.github/workflows/ci.yml`** — new `actionlint` job that lints the workflow files themselves (and `run:` blocks via the bundled shellcheck). Also fixes a real `SC2155` it surfaced in the install-smoke job (`export HOME=$(mktemp -d)` → declare/assign separately).
- **`.pre-commit-config.yaml`** — add `actionlint` (golang, isolated) and `shellcheck` (local, bash `*.sh` only — `install.sh` / `setup_gpg_signing.sh` are zsh) hooks alongside the existing gitleaks + template checks.
- **`CONTRIBUTING.md` / `scripts/README.md`** — document the integration test, the actionlint job, and the pre-commit workflow (`pre-commit run --all-files`).

## Validation
- `actionlint` — clean
- `bats scripts/tests/` — **168/168** (162 existing + 6 new)
- `pre-commit validate-config` — valid; gitleaks + actionlint hooks pass on commit

[Warp conversation](https://app.warp.dev/conversation/506da428-e423-49a0-aa5b-c240ff2f199e)

Co-Authored-By: Oz <oz-agent@warp.dev>