### PR TITLE
feat: dotfiles platform roadmap (unified CLI, doctor, modular zsh, Ghostty)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,16 @@ jobs:
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
 
-      # Lint every top-level *.sh plus scripts/, scripts/lib/, and scripts/tests/
-      # in one pass so new scripts are covered automatically. zsh files
-      # (install.sh, scripts/setup_gpg_signing.sh) are detected by shebang and
-      # routed to the zsh-syntax job instead, since shellcheck only understands
-      # sh/bash/dash/ksh.
+      # Lint every top-level *.sh plus scripts/, scripts/lib/, scripts/tests/,
+      # and bin/dotfiles in one pass so new scripts are covered automatically.
+      # zsh files (install.sh, scripts/setup_gpg_signing.sh) are detected by
+      # shebang and routed to the zsh-syntax job instead, since shellcheck only
+      # understands sh/bash/dash/ksh.
       - name: shellcheck all bash scripts
         run: |
           fail=0
           shopt -s nullglob
-          for script in *.sh scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh; do
+          for script in *.sh scripts/*.sh scripts/lib/*.sh scripts/tests/*.sh bin/dotfiles; do
             if head -1 "$script" | grep -q 'zsh'; then
               echo "SKIP (zsh, see zsh-syntax job): $script"
               continue
@@ -63,7 +63,7 @@ jobs:
         # install.sh and scripts/setup_gpg_signing.sh are zsh (skipped by the
         # shellcheck job), so they are syntax-checked here with a real zsh.
         run: |
-          for f in home/zshrc home/zprofile install.sh bootstrap.sh scripts/macos.sh scripts/setup_gpg_signing.sh; do
+          for f in home/zshrc home/zsh/*.zsh home/zprofile install.sh bootstrap.sh scripts/macos.sh scripts/setup_gpg_signing.sh; do
             echo "zsh -n $f"
             zsh -n "$f"
           done

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ bash ~/dotfiles/bootstrap.sh
 
 `bootstrap.sh` runs once on a fresh Mac and handles everything: Homebrew, all packages, runtimes (Ruby, Node, Java, Python, Go, Rust), dotfile symlinks, and macOS defaults. Open a new terminal when it finishes.
 
+### Common commands
+
+Day-to-day tasks run through one command, `dotfiles` (added to your `PATH` from `~/dotfiles/bin`):
+
+```bash
+dotfiles status     # repo state + last update
+dotfiles doctor     # read-only health check (status + verify + shell/terminal)
+dotfiles update     # pull, re-symlink, upgrade packages/runtimes, verify
+dotfiles profile    # show or set this machine's profile
+dotfiles cleanup    # remove backups, cache, and legacy configs
+```
+
+It's a thin wrapper over the scripts below — same flags, same behavior. See [docs/cli.md](docs/cli.md). Equivalent direct form: `bash ~/dotfiles/scripts/dotfiles.sh <command>`.
+
 ### Preview changes before running
 
 ```sh
@@ -169,12 +183,12 @@ Stored at `~/.config/dotfiles/profile`; precedence is `--profile` flag > `DOTFIL
 
 | File | Symlinked to | What it does |
 |------|-------------|--------------|
-| `home/zshrc` | `~/.zshrc` | Shell config — mise, PATH, aliases, plugins |
+| `home/zshrc` + `home/zsh/*.zsh` | `~/.zshrc` | Modular shell config — PATH, aliases, functions, plugins, integrations ([docs](docs/zsh.md)) |
 | `home/zprofile` | `~/.zprofile` | Login profile — Homebrew PATH setup |
 | `home/gitconfig` | `~/.gitconfig` _(include)_ | Git defaults, delta pager, SSH signing — loaded via a thin `~/.gitconfig` (not a symlink) so `git config --global` / tool writes stay out of the repo |
 | `home/gitignore_global` | `~/.gitignore_global` | Global ignores — macOS, editors, Java, Go |
 | `home/tmux.conf` | `~/.tmux.conf` | tmux — `C-a` prefix, vim keys, TPM plugins |
-| `config/ghostty/config` | `~/.config/ghostty/config` | **Ghostty (preferred terminal)** — Tokyo Night, JetBrains Mono Nerd Font |
+| `config/ghostty/config` | `~/.config/ghostty/config` | **Ghostty (preferred terminal)** — Tokyo Night, JetBrains Mono Nerd Font ([setup](docs/ghostty.md)) |
 | `home/hyper.js` | `~/.hyper.js` | Hyper _(fallback terminal)_ — Tokyo Night theme, JetBrains Mono |
 | `config/starship.toml` | `~/.config/starship.toml` | Starship prompt config |
 | `config/mise.toml` | `~/.config/mise/config.toml` | Global runtime versions (Ruby, Node, Java, Python, Go) |
@@ -195,6 +209,7 @@ Stored at `~/.config/dotfiles/profile`; precedence is `--profile` flag > `DOTFIL
 | `verify.sh` | _(run to verify)_ | Health check — symlinks, missing tools, installed runtimes, stale backups |
 | `uninstall.sh` | _(run to uninstall)_ | Reverse `install.sh` — remove tracked symlinks, restore backed-up originals (`--dry-run` to preview) |
 | `scripts/setup-scheduler.sh` | _(run once)_ | Install launchd job to run `update.sh` daily at 9 AM |
+| `scripts/dotfiles.sh` · `bin/dotfiles` | _(run / `dotfiles`)_ | Unified CLI — `status`, `verify`, `doctor`, `update`, `profile`, `cleanup` ([docs](docs/cli.md)) |
 | `scripts/status.sh` | _(run / `dotstatus`)_ | Quick read-only health snapshot — repo git state + last `update.sh` result |
 | `scripts/profile.sh` | _(run / `dotprofile`)_ | Show or set this machine's profile (`personal`/`work`/`minimal`/`server`) |
 | `scripts/macos.sh` | _(run once)_ | macOS developer defaults |
@@ -431,6 +446,9 @@ The full documentation site is published at **<https://bradbergeron-us.github.io
 | [Encrypted Secrets](docs/secrets.md) | sops + age workflow for encrypting and managing secrets |
 | [Machine Profiles](docs/profiles.md) | `personal`/`work`/`minimal`/`server` profiles, selection precedence, and how they drive packages, symlinks, and bootstrap steps |
 | [Usage & Lifecycle](docs/usage.md) | Day-to-day lifecycle — bootstrap, dry-run, update, verify, status, and scheduling |
+| [dotfiles CLI](docs/cli.md) | The unified `dotfiles` command — subcommands, delegation, and `doctor` |
+| [Zsh Configuration](docs/zsh.md) | Modular zsh layout — `home/zsh/` modules, loading, local overrides, validation |
+| [Ghostty](docs/ghostty.md) | Preferred terminal — install, validation, Hyper fallback, local overrides |
 | [Work Machine](docs/work-machine.md) | Additional work topics — Brewfile.work, zshrc.local, direnv, NVM migration |
 | [Complete Work Setup Guide](docs/work-setup-complete.md) | **End-to-end work machine setup** — from fresh macOS to production-ready |
 | [Claude Code SSL Fix](docs/claude-code-ssl-fix.md) | Resolving Claude Code SSL/certificate issues behind a corporate proxy |
@@ -439,4 +457,5 @@ The full documentation site is published at **<https://bradbergeron-us.github.io
 | [Architecture](docs/architecture.md) | How bootstrap, install, update, verify, status, and the SSOT files fit together |
 | [Troubleshooting](docs/troubleshooting.md) | FAQ and fixes for common failures (updates, symlinks, tools, secrets, docs) |
 | [Glossary](docs/glossary.md) | Definitions of terms used across the docs |
+| [Personal Workstation Roadmap](docs/roadmap-personal-workstation.md) | Future backlog for the `dotfiles` CLI (not yet implemented) |
 | [Contributing](docs/contributing.md) | Contribution workflow — bats-core tests, shellcheck, CI jobs, and conventional commits |

--- a/bin/dotfiles
+++ b/bin/dotfiles
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# bin/dotfiles — thin shim so `dotfiles <command>` works when ~/dotfiles/bin is
+# on PATH (added by home/zsh/path.zsh). Delegates to scripts/dotfiles.sh.
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec bash "$ROOT_DIR/scripts/dotfiles.sh" "$@"

--- a/config/ghostty/config
+++ b/config/ghostty/config
@@ -55,3 +55,10 @@ macos-option-as-alt = left
 # ── Shell ──────────────────────────────────────────────────────────────────────
 # Default shell is zsh on this machine; Ghostty auto-detects shell integration.
 shell-integration = zsh
+
+# ── Local overrides ─────────────────────────────────────────────────────────────
+# Per-machine, untracked tweaks live in ~/.config/ghostty/ghostty.local (next to
+# this file once symlinked). The path is relative to this config file and the
+# leading `?` means Ghostty won't error if it doesn't exist. Kept last so its
+# values override everything above. See docs/ghostty.md.
+config-file = ?ghostty.local

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,69 @@
+# dotfiles CLI
+
+`scripts/dotfiles.sh` is a single, memorable entry point for the most common
+dotfiles operations. It is a thin wrapper: most subcommands just delegate to the
+existing scripts (forwarding every argument and the exit code), so nothing about
+the underlying behavior changes — you simply have one command to remember.
+
+## Running it
+
+Two equivalent ways:
+
+```bash
+dotfiles <command> [args...]                  # when ~/dotfiles/bin is on PATH
+bash ~/dotfiles/scripts/dotfiles.sh <command> # always works
+```
+
+The bare `dotfiles` command works because `home/zsh/path.zsh` adds
+`~/dotfiles/bin` to your `PATH`, and `bin/dotfiles` is a small shim that calls
+`scripts/dotfiles.sh`. If `dotfiles` is not found, open a new shell (or
+`source ~/.zshrc`) so the updated `PATH` takes effect, or use the full
+`bash ~/dotfiles/scripts/dotfiles.sh` form.
+
+## Commands
+
+| Command | What it does | Delegates to |
+|---------|--------------|--------------|
+| `help` | Show usage (also the default with no command) | — |
+| `status` | Repo git state + last `update.sh` result | `scripts/status.sh` |
+| `verify` | Full environment health check | `verify.sh` |
+| `doctor` | Read-only health check: status + verify + shell & terminal config | _(built-in)_ |
+| `update` | Pull, re-symlink, upgrade packages/runtimes, verify | `update.sh` |
+| `profile` | Show or set this machine's profile | `scripts/profile.sh` |
+| `cleanup` | Remove common dotfile cruft (backups, cache, legacy configs) | `scripts/cleanup.sh` |
+
+Arguments are passed straight through to the underlying script, so every flag the
+delegated script supports still works:
+
+```bash
+dotfiles status --verify      # status.sh --verify
+dotfiles update --dry-run     # update.sh --dry-run
+dotfiles update --no-upgrade  # update.sh --no-upgrade
+dotfiles cleanup --dry-run    # cleanup.sh --dry-run
+dotfiles profile set work     # profile.sh set work
+```
+
+An unknown command prints a helpful message and exits non-zero.
+
+## `doctor`
+
+`doctor` is a read-only snapshot of dotfiles health. It never changes your
+system; it runs a few checks and exits non-zero if any of them fail, so it is
+safe to use in scripts and CI. The flow is:
+
+1. **Repository status** — `status.sh --exit-code` (repo git state + last update).
+2. **Verification** — `verify.sh` (symlinks, required tools, runtimes, git health, …).
+3. **Shell configuration** — `zsh -n` on `home/zshrc` and every `home/zsh/*.zsh` module.
+4. **Terminal configuration** — validates `config/ghostty/config` with
+   `ghostty +validate-config` when Ghostty is installed (otherwise confirms the
+   config is present); notes the Hyper fallback.
+
+```bash
+dotfiles doctor
+```
+
+## See also
+
+- [Usage & Lifecycle](usage.md) — bootstrap, update, verify, status, scheduling
+- [Zsh configuration](zsh.md) — the module layout `doctor` syntax-checks
+- [Ghostty](ghostty.md) — terminal config `doctor` validates

--- a/docs/ghostty.md
+++ b/docs/ghostty.md
@@ -1,0 +1,63 @@
+# Ghostty (preferred terminal)
+
+[Ghostty](https://ghostty.org) is the preferred terminal for these dotfiles: it
+is fast (GPU-accelerated), native on macOS, and configured with zero required
+options. [Hyper](https://hyper.is) is kept as a fallback during the transition.
+
+## Why Ghostty
+
+- GPU-accelerated rendering and native macOS UI (tabs, splits, window restore).
+- Simple text config that is easy to track and validate in CI/`doctor`.
+- Matches the rest of the toolchain's look: Tokyo Night + JetBrains Mono Nerd Font.
+
+## How the config is installed
+
+The tracked config lives at `config/ghostty/config` and is symlinked to
+`~/.config/ghostty/config` by `install.sh`. Like every tracked symlink, the
+mapping is declared once in `config/symlinks.map`:
+
+```text
+config/ghostty/config  .config/ghostty/config  gui
+```
+
+The `gui` tag means the link is created on the `personal` and `work` profiles and
+skipped on `minimal`/`server`. Re-link any time with `zsh ~/dotfiles/install.sh`.
+
+## Validating
+
+Ghostty ships a validator that checks for syntax errors and invalid keys/values:
+
+```bash
+ghostty +validate-config                         # validate the installed config
+ghostty +validate-config --config-file=config/ghostty/config  # validate the repo file
+```
+
+`dotfiles doctor` runs this automatically (when Ghostty is installed) as part of
+its terminal-configuration check, and falls back to confirming the config file
+exists otherwise. Reload a running Ghostty with **⌘+Shift+,**.
+
+## Local customization (untracked)
+
+Per-machine tweaks go in `~/.config/ghostty/ghostty.local`, which the tracked
+config pulls in via an optional include at the end:
+
+```ini
+config-file = ?ghostty.local
+```
+
+The path is relative to the config file, and the leading `?` means Ghostty does
+not error if the file is absent. Because the include is last, anything you set
+there overrides the tracked defaults. Create it only when you need to:
+
+```bash
+printf 'font-size = 16\n' > ~/.config/ghostty/ghostty.local
+```
+
+This keeps machine-specific preferences out of the tracked `config/ghostty/config`.
+
+## Hyper fallback
+
+Hyper remains available so you always have a working terminal. Its config is
+tracked at `home/hyper.js` → `~/.hyper.js` (also `gui`-tagged) and uses the same
+Tokyo Night theme and JetBrains Mono font. Nothing here removes or replaces
+Hyper; Ghostty is simply the default going forward.

--- a/docs/roadmap-personal-workstation.md
+++ b/docs/roadmap-personal-workstation.md
@@ -1,0 +1,102 @@
+# Personal Workstation Roadmap
+
+!!! note "Status: future ideas — not implemented"
+    This page is a **backlog**. Nothing here is built yet, and none of it should
+    be implemented as a side effect of other work. It captures directions the
+    `dotfiles` CLI could grow in, so ideas are not lost. Each item is a sketch of
+    a possible future command, not a committed design.
+
+The unified [`dotfiles` CLI](cli.md) gives us one place to add higher-level
+workflows over time. The themes below are candidate subcommands; they would be
+added incrementally, each behind its own review, with the same guardrails the
+rest of the repo follows (no secrets, prefer wrapping existing tools, keep
+behavior reversible and previewable).
+
+## Project bootstrap
+
+Scaffold sensible per-project defaults so new repos start consistent.
+
+Possible commands:
+
+```bash
+dotfiles project init rails
+dotfiles project init node
+dotfiles project init python
+dotfiles project init va-gov
+```
+
+Possible generated files: `.envrc`, `.mise.toml`, `.editorconfig`,
+`.pre-commit-config.yaml`, `.vscode/settings.json`, `.gitignore`.
+
+## AI workstation support
+
+Manage local AI tooling (Claude Code, Continue, model/cert config) coherently.
+
+Possible commands:
+
+```bash
+dotfiles ai status
+dotfiles ai setup
+dotfiles ai doctor
+```
+
+Possible prompt templates: `templates/prompts/code-review.md`,
+`templates/prompts/refactor-plan.md`, `templates/prompts/debugging.md`,
+`templates/prompts/pr-description.md`.
+
+## Security scan
+
+A convenience wrapper over existing security checks.
+
+Possible command:
+
+```bash
+dotfiles security scan
+```
+
+Possible checks: gitleaks, unsafe file permissions, accidental `.env` commits,
+SSH config issues, missing Git signing config.
+
+## Backup and restore
+
+Capture and restore the *unmanaged* parts of a machine (the managed dotfiles are
+already reproducible from the repo).
+
+Possible commands:
+
+```bash
+dotfiles backup create
+dotfiles backup restore
+dotfiles backup list
+```
+
+Safe default backup candidates: `~/.zshrc.local`, `~/.config/git/*.gitconfig`,
+the VS Code extension list, `brew leaves`, mise-installed runtimes, Ghostty local
+overrides. **Never** back up private SSH keys by default.
+
+## Package / profile management
+
+Make Brewfile and profile drift easy to inspect and explain.
+
+Possible commands:
+
+```bash
+dotfiles packages list
+dotfiles packages missing
+dotfiles packages outdated
+dotfiles packages explain ghostty
+```
+
+## Neovim improvements
+
+Keep this conservative. Future direction:
+
+- Preserve the dependency-free baseline (`config/nvim/init.lua`).
+- Organize config into modules only if it earns its keep.
+- Add optional local overrides.
+- Avoid turning it into a heavy plugin distribution unless there is a real need.
+
+## Definition of done (for this page)
+
+- The roadmap exists and clearly separates future ideas from current behavior.
+- No future feature is implemented just because it is listed here.

--- a/docs/roadmap-quick-reference.md
+++ b/docs/roadmap-quick-reference.md
@@ -157,4 +157,4 @@ scripts/check-compliance.sh --policy company-policy.yml
 
 - **Full Details**: See [roadmap-work-laptop-management.md](roadmap-work-laptop-management.md)
 - **Current Features**: See [work-machine.md](work-machine.md)
-- **How to Contribute**: See [CONTRIBUTING.md](../CONTRIBUTING.md)
+- **How to Contribute**: See [CONTRIBUTING.md](https://github.com/bradbergeron-us/dotfiles/blob/main/CONTRIBUTING.md)

--- a/docs/roadmap-work-laptop-management.md
+++ b/docs/roadmap-work-laptop-management.md
@@ -584,7 +584,7 @@ scripts/check-drift.sh --baseline team-configs/platform-team/baseline.yml
 - [Work Machine Setup Guide](work-machine.md)
 - [Profiles Documentation](profiles.md)
 - [Secrets Management](secrets.md)
-- [Contributing Guidelines](../CONTRIBUTING.md)
+- [Contributing Guidelines](https://github.com/bradbergeron-us/dotfiles/blob/main/CONTRIBUTING.md)
 - [Architecture Overview](architecture.md)
 
 ---

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -1,0 +1,79 @@
+# Zsh configuration
+
+The shell config is split into small, focused modules so each concern is easy to
+find and edit. `~/.zshrc` is a symlink to `home/zshrc`, which is a **thin loader**
+that sources the modules in `home/zsh/`.
+
+## How loading works
+
+`home/zshrc` resolves its own real path — even though it is reached through the
+`~/.zshrc` symlink — and derives the module directory from it:
+
+```bash
+_zshrc_self="${${(%):-%x}:A}"                 # ~/.zshrc -> ~/dotfiles/home/zshrc
+DOTFILES_DIR="${DOTFILES_DIR:-${_zshrc_self:h:h}}"
+DOTFILES_ZSH_DIR="${DOTFILES_ZSH_DIR:-${_zshrc_self:h}/zsh}"
+```
+
+This means the modules are sourced **straight from the repo** — they are not
+symlinked individually, so there is nothing extra to add to
+`config/symlinks.map`. You can override the location by exporting
+`DOTFILES_ZSH_DIR` before the shell starts, and there is a fallback to
+`~/dotfiles/home/zsh` if resolution ever fails.
+
+Modules are sourced with a small `source_if_exists` helper, in the same order
+their settings ran in the original monolithic `zshrc`.
+
+## Modules
+
+| Module | Responsibility |
+|--------|----------------|
+| `home/zsh/path.zsh` | `PATH` and core environment: `EDITOR`, `~/dotfiles/bin`, NVM guard, mise, cargo, Go, `~/.local/bin`, fzf |
+| `home/zsh/functions.zsh` | Shell functions + zsh hooks: Claude-session detection, terminal tab-title, git rebase helpers (`grn`, `grbic`) |
+| `home/zsh/aliases.zsh` | All aliases (git, navigation, editor, `bat` as `cat`, …) |
+| `home/zsh/prompt.zsh` | Starship prompt initialization |
+| `home/zsh/plugins.zsh` | sheldon plugin manager (with manual fallback) + completion init (`compinit`) |
+| `home/zsh/integrations.zsh` | Third-party hooks: zoxide, direnv |
+
+Machine-local files keep their original positions in `home/zshrc`:
+`~/afs_localprops.sh`, then `~/.zshrc.local`, and finally uv's
+`~/.local/bin/env`.
+
+## Where things go
+
+- **A new alias** → `home/zsh/aliases.zsh`
+- **A new function** → `home/zsh/functions.zsh`
+- **A new tool integration** (`eval "$(tool init zsh)"`) → `home/zsh/integrations.zsh`
+- **A `PATH` or environment entry** → `home/zsh/path.zsh`
+- **A whole new module** → create `home/zsh/<name>.zsh` and add a
+  `source_if_exists "$DOTFILES_ZSH_DIR/<name>.zsh"` line to `home/zshrc`
+
+## Local overrides
+
+Per-machine configuration is **not** committed. Put it in `~/.zshrc.local`,
+which `home/zshrc` sources last so it can override anything above:
+
+```bash
+cp ~/dotfiles/home/examples/zshrc.local.example ~/.zshrc.local
+```
+
+The template covers Go/Rust overrides, Java switching, corporate proxy, work git
+email, Claude Code SSL, and more. Keep secrets out of tracked files — they belong
+only in `~/.zshrc.local`.
+
+## Validating
+
+Syntax-check everything (no execution):
+
+```bash
+zsh -n home/zshrc
+find home/zsh -name "*.zsh" -print0 | xargs -0 -n1 zsh -n
+```
+
+Or let the CLI do it as part of the broader health check:
+
+```bash
+dotfiles doctor
+```
+
+CI also runs `zsh -n` on `home/zshrc` and every `home/zsh/*.zsh` module.

--- a/home/zsh/aliases.zsh
+++ b/home/zsh/aliases.zsh
@@ -1,0 +1,52 @@
+# aliases.zsh — command aliases.
+# Git rebase helper functions (grn/grbic) live in functions.zsh.
+
+alias gcm="git commit -m"
+alias gcam='git commit -a -m'
+alias gca="git commit --amend --no-edit"
+alias gcae="git commit --amend"
+alias gcaa="git add --all && git commit --amend --no-edit"
+alias gcaae="git add --all && git commit --amend"
+alias gap="git add -p"
+alias gnope="git checkout ."
+alias gwait="git reset HEAD"
+alias gundo="git reset --soft HEAD^"
+alias greset="git clean -f && git reset --hard HEAD"
+alias gl="git log --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
+alias glb='git log --oneline --decorate --graph --all'
+alias gst='git status -s'
+alias gpl="git pull --rebase"
+alias gps="git push"
+alias gpsf="git push --force-with-lease"
+alias grb="git rebase"
+alias grbi='git rebase -i'
+alias grba='git rebase --abort'
+alias grbc='git rebase --continue'
+alias gcmb="git branch --merged | grep -Ev '(^\\*|master)' | xargs git branch -d"
+alias gset='git branch --set-upstream-to=origin/`git symbolic-ref --short HEAD`'
+
+alias gp='git pull'
+alias gco='git checkout'
+alias glog='git log --oneline --decorate --color --graph'
+
+alias src='source ~/.zshrc'
+alias dotstatus='bash ~/dotfiles/scripts/status.sh'  # dotfiles health: repo git state + last update
+alias dotprofile='bash ~/dotfiles/scripts/profile.sh'  # show/set this machine's dotfiles profile
+alias c='clear'
+alias edithost='sudo nano /etc/hosts'
+
+alias ..='../..'
+alias ...='../../..'
+alias ....='../../../..'
+alias .....='../../../../..'
+alias ls='lsd --group-dirs first'
+alias la='lsd -A'
+alias l='lsd -A --group-dirs first'
+alias ll='lsd -lA --group-dirs first'
+alias lc='lsd -lA --group-dirs first --sort date'
+alias change="code ~/.zshrc"
+alias update="source ~/.zshrc"
+alias history='history 0'
+
+# bat (syntax-highlighted cat)
+command -v bat &>/dev/null && alias cat='bat --paging=never'

--- a/home/zsh/functions.zsh
+++ b/home/zsh/functions.zsh
@@ -1,0 +1,88 @@
+# functions.zsh — shell functions and zsh hooks.
+# Sourced before aliases (matching the original zshrc order).
+
+# ------------------
+# Zsh hooks
+# ------------------
+
+autoload -U add-zsh-hook
+
+# Check if Claude Code is active (cached for performance)
+# Only checks once per shell session to avoid slowdown
+__DOTFILES_CLAUDE_SESSION_CACHED=""
+function _is_claude_session() {
+  # Return cached result if already checked
+  [[ -n "$__DOTFILES_CLAUDE_SESSION_CACHED" ]] && return $__DOTFILES_CLAUDE_SESSION_CACHED
+
+  # Fast checks first (environment variables - nearly free)
+  if [[ -n "$CLAUDE_CODE_ENTRYPOINT" ]] || [[ -n "$CLAUDE_CODE_SESSION_ID" ]] || \
+     [[ -n "$CLAUDE_CODE_USE_BEDROCK" ]] || [[ -n "$ANTHROPIC_MODEL" ]] || \
+     [[ "$TERM_PROGRAM" == *"claude"* ]]; then
+    __DOTFILES_CLAUDE_SESSION_CACHED=0
+    return 0
+  fi
+
+  # Quick parent process check (avoid expensive tree walk)
+  if pgrep -P $$ claude &>/dev/null; then
+    __DOTFILES_CLAUDE_SESSION_CACHED=0
+    return 0
+  fi
+
+  # Not in Claude Code session
+  __DOTFILES_CLAUDE_SESSION_CACHED=1
+  return 1
+}
+
+# Format current directory for tab title display
+# Shows last 3 directory components (or full path if shorter)
+# Appends indicator if Claude Code is running
+function _format_tab_title() {
+  local short_path="${1:-$PWD}"
+  local show_claude="${2:-no}"
+
+  # Replace home directory with tilde
+  short_path="${short_path/#$HOME/~}"
+
+  # Handle root directory edge case
+  if [[ "$short_path" == "/" ]]; then
+    short_path="/"
+  else
+    local path_parts=(${(s:/:)short_path})
+    if (( ${#path_parts} > 3 )); then
+      short_path=".../${path_parts[-3]}/${path_parts[-2]}/${path_parts[-1]}"
+    fi
+  fi
+
+  # Append Claude Code indicator if requested
+  if [[ "$show_claude" == "yes" ]]; then
+    echo "${short_path} ⚡"
+  else
+    echo "$short_path"
+  fi
+}
+
+# Update terminal tab title with current directory
+# Simplified version without background updater for performance
+function _set_terminal_title() {
+  local show_claude="no"
+  _is_claude_session && show_claude="yes"
+
+  local title="$(_format_tab_title "$PWD" "$show_claude")"
+  print -Pn "\e]0;${title}\a"
+}
+
+# Register hooks to update title on:
+# - precmd: before each prompt
+# - chpwd: when directory changes
+add-zsh-hook precmd _set_terminal_title
+add-zsh-hook chpwd _set_terminal_title
+
+# Set initial title on shell startup
+_set_terminal_title
+
+# ------------------
+# Git helper functions
+# ------------------
+
+grn() { git rebase -i HEAD~"$1"; }
+grbic() { git rebase -i "$1"; }

--- a/home/zsh/integrations.zsh
+++ b/home/zsh/integrations.zsh
@@ -1,0 +1,16 @@
+# integrations.zsh — third-party tool integrations.
+
+# zoxide — smarter cd (`z <dir>` jumps to frecent directories)
+if command -v zoxide >/dev/null 2>&1; then
+  eval "$(zoxide init zsh)"
+fi
+
+# direnv — per-directory environment variables (.envrc files)
+if command -v direnv >/dev/null 2>&1; then
+  eval "$(direnv hook zsh)"
+fi
+
+# Angular CLI autocompletion (disabled for performance - enable if needed)
+# if command -v node &>/dev/null && command -v ng &>/dev/null; then
+#   source <(ng completion script)
+# fi

--- a/home/zsh/path.zsh
+++ b/home/zsh/path.zsh
@@ -1,0 +1,50 @@
+# path.zsh — PATH and environment setup.
+# Sourced first by home/zshrc so later modules (and the prompt) see the full
+# PATH and core environment.
+
+# ------------------
+# Shell Variables
+# ------------------
+
+export EDITOR=code
+
+# ------------------
+# PATH Manipulations
+# ------------------
+
+# dotfiles CLI — put the repo's bin/ on PATH so `dotfiles <command>` works.
+# DOTFILES_DIR is resolved in home/zshrc from this file's real location.
+[[ -n "${DOTFILES_DIR:-}" && -d "$DOTFILES_DIR/bin" ]] && export PATH="$DOTFILES_DIR/bin:$PATH"
+
+# NVM conflict guard: if NVM is still installed on this machine but empty
+# (no versions), suppress it so mise owns Node cleanly.
+# NVM has been removed from this machine; this guard is a safety net for
+# any env that still has a ghost NVM_DIR set (e.g. .zshrc.local, /etc/zshenv).
+if [[ -n "${NVM_DIR:-}" ]]; then
+  _nvm_node_dir="${NVM_DIR}/versions/node"
+  if [[ ! -d "$_nvm_node_dir" ]] || [[ -z "$(ls -A "$_nvm_node_dir" 2>/dev/null)" ]]; then
+    unset NVM_DIR  # ghost install — mise owns Node, nothing is lost
+  fi
+  unset _nvm_node_dir
+fi
+
+# mise — polyglot version manager (replaces chruby + nvm + pyenv)
+# Reads .ruby-version, .nvmrc, .python-version automatically per project
+if command -v mise &>/dev/null; then
+  eval "$(mise activate zsh)"
+fi
+
+# Rust (cargo) — add to PATH if rustup is installed
+[[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+
+# Go — tools installed via `go install` land in ~/go/bin
+export GOPATH="${GOPATH:-$HOME/go}"
+[[ -d "$GOPATH/bin" ]] && export PATH="$PATH:$GOPATH/bin"
+
+# Local binaries (Claude Code, pipx, etc.)
+[[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"
+
+export PATH="$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+# fzf (fuzzy finder — Ctrl+R history, Ctrl+T file picker)
+[[ -f ~/.fzf.zsh ]] && source ~/.fzf.zsh

--- a/home/zsh/plugins.zsh
+++ b/home/zsh/plugins.zsh
@@ -1,0 +1,24 @@
+# plugins.zsh — shell plugins and completion initialization.
+
+# Zsh plugins — managed declaratively by sheldon (config: ~/.config/sheldon/plugins.toml).
+# Falls back to manually-cloned plugins under ~/.zsh so a machine without sheldon
+# (e.g. before bootstrap installs it) still gets highlighting + autosuggestions.
+if command -v sheldon &>/dev/null; then
+  eval "$(sheldon source)"
+else
+  [ -f "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh" ] && \
+    source "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
+  [ -f "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" ] && \
+    source "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
+fi
+
+# Enable enhanced menu selection in completions
+zmodload -i zsh/complist 2>/dev/null || true
+
+autoload -Uz compinit
+# Only rebuild completion dump once per day — saves ~30-50ms per shell start
+if [[ -n ~/.zcompdump(#qN.mh+24) ]]; then
+  compinit
+else
+  compinit -C
+fi

--- a/home/zsh/prompt.zsh
+++ b/home/zsh/prompt.zsh
@@ -1,0 +1,5 @@
+# prompt.zsh — prompt setup.
+# Starship is a fast, cross-shell prompt configured in config/starship.toml
+# (symlinked to ~/.config/starship.toml).
+
+eval "$(starship init zsh)"

--- a/home/zshrc
+++ b/home/zshrc
@@ -1,223 +1,36 @@
-# ------------------
-# Shell Variables
-# ------------------
+# zshrc — interactive shell configuration.
+#
+# Intentionally thin: it resolves the dotfiles location (works even though
+# ~/.zshrc is a symlink into the repo) and sources focused modules from
+# home/zsh/. See docs/zsh.md for the layout. Machine-specific overrides go in
+# ~/.zshrc.local (template: home/examples/zshrc.local.example) — never here.
 
-export EDITOR=code
+# Resolve this file's real path so modules can be sourced straight from the repo
+# with no extra symlinks. %x is the file being sourced; :A resolves any symlinks
+# and makes it absolute (e.g. ~/.zshrc -> ~/dotfiles/home/zshrc).
+_zshrc_self="${${(%):-%x}:A}"
+DOTFILES_DIR="${DOTFILES_DIR:-${_zshrc_self:h:h}}"
+DOTFILES_ZSH_DIR="${DOTFILES_ZSH_DIR:-${_zshrc_self:h}/zsh}"
+unset _zshrc_self
+# Fall back to the conventional clone location if resolution didn't find modules.
+[[ -d "$DOTFILES_ZSH_DIR" ]] || DOTFILES_ZSH_DIR="$HOME/dotfiles/home/zsh"
 
-# ------------------
-# PATH Manipulations
-# ------------------
+# Source a file only when it exists and is readable.
+source_if_exists() { [[ -r "$1" ]] && source "$1"; }
 
-# NVM conflict guard: if NVM is still installed on this machine but empty
-# (no versions), suppress it so mise owns Node cleanly.
-# NVM has been removed from this machine; this guard is a safety net for
-# any env that still has a ghost NVM_DIR set (e.g. .zshrc.local, /etc/zshenv).
-if [[ -n "${NVM_DIR:-}" ]]; then
-  _nvm_node_dir="${NVM_DIR}/versions/node"
-  if [[ ! -d "$_nvm_node_dir" ]] || [[ -z "$(ls -A "$_nvm_node_dir" 2>/dev/null)" ]]; then
-    unset NVM_DIR  # ghost install — mise owns Node, nothing is lost
-  fi
-  unset _nvm_node_dir
-fi
+# Modules are sourced in the same order their settings ran in the original zshrc.
+source_if_exists "$DOTFILES_ZSH_DIR/path.zsh"          # PATH + core environment
+source_if_exists "$DOTFILES_ZSH_DIR/functions.zsh"     # functions + zsh hooks
+source_if_exists "$DOTFILES_ZSH_DIR/aliases.zsh"       # aliases
+source_if_exists "$DOTFILES_ZSH_DIR/prompt.zsh"        # starship prompt
 
-# mise — polyglot version manager (replaces chruby + nvm + pyenv)
-# Reads .ruby-version, .nvmrc, .python-version automatically per project
-if command -v mise &>/dev/null; then
-  eval "$(mise activate zsh)"
-fi
-
-# Rust (cargo) — add to PATH if rustup is installed
-[[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
-
-# Go — tools installed via `go install` land in ~/go/bin
-export GOPATH="${GOPATH:-$HOME/go}"
-[[ -d "$GOPATH/bin" ]] && export PATH="$PATH:$GOPATH/bin"
-
-# Local binaries (Claude Code, pipx, etc.)
-[[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"
-
-export PATH="$PATH:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-
-# fzf (fuzzy finder — Ctrl+R history, Ctrl+T file picker)
-[[ -f ~/.fzf.zsh ]] && source ~/.fzf.zsh
-
-# ------------------
-# Zsh hooks
-# ------------------
-
-autoload -U add-zsh-hook
-
-# Check if Claude Code is active (cached for performance)
-# Only checks once per shell session to avoid slowdown
-__DOTFILES_CLAUDE_SESSION_CACHED=""
-function _is_claude_session() {
-  # Return cached result if already checked
-  [[ -n "$__DOTFILES_CLAUDE_SESSION_CACHED" ]] && return $__DOTFILES_CLAUDE_SESSION_CACHED
-
-  # Fast checks first (environment variables - nearly free)
-  if [[ -n "$CLAUDE_CODE_ENTRYPOINT" ]] || [[ -n "$CLAUDE_CODE_SESSION_ID" ]] || \
-     [[ -n "$CLAUDE_CODE_USE_BEDROCK" ]] || [[ -n "$ANTHROPIC_MODEL" ]] || \
-     [[ "$TERM_PROGRAM" == *"claude"* ]]; then
-    __DOTFILES_CLAUDE_SESSION_CACHED=0
-    return 0
-  fi
-
-  # Quick parent process check (avoid expensive tree walk)
-  if pgrep -P $$ claude &>/dev/null; then
-    __DOTFILES_CLAUDE_SESSION_CACHED=0
-    return 0
-  fi
-
-  # Not in Claude Code session
-  __DOTFILES_CLAUDE_SESSION_CACHED=1
-  return 1
-}
-
-# Format current directory for tab title display
-# Shows last 3 directory components (or full path if shorter)
-# Appends indicator if Claude Code is running
-function _format_tab_title() {
-  local short_path="${1:-$PWD}"
-  local show_claude="${2:-no}"
-
-  # Replace home directory with tilde
-  short_path="${short_path/#$HOME/~}"
-
-  # Handle root directory edge case
-  if [[ "$short_path" == "/" ]]; then
-    short_path="/"
-  else
-    local path_parts=(${(s:/:)short_path})
-    if (( ${#path_parts} > 3 )); then
-      short_path=".../${path_parts[-3]}/${path_parts[-2]}/${path_parts[-1]}"
-    fi
-  fi
-
-  # Append Claude Code indicator if requested
-  if [[ "$show_claude" == "yes" ]]; then
-    echo "${short_path} ⚡"
-  else
-    echo "$short_path"
-  fi
-}
-
-# Update terminal tab title with current directory
-# Simplified version without background updater for performance
-function _set_terminal_title() {
-  local show_claude="no"
-  _is_claude_session && show_claude="yes"
-
-  local title="$(_format_tab_title "$PWD" "$show_claude")"
-  print -Pn "\e]0;${title}\a"
-}
-
-# Register hooks to update title on:
-# - precmd: before each prompt
-# - chpwd: when directory changes
-add-zsh-hook precmd _set_terminal_title
-add-zsh-hook chpwd _set_terminal_title
-
-# Set initial title on shell startup
-_set_terminal_title
-
-# ------------------
-# Aliases
-# ------------------
-
-alias gcm="git commit -m"
-alias gcam='git commit -a -m'
-alias gca="git commit --amend --no-edit"
-alias gcae="git commit --amend"
-alias gcaa="git add --all && git commit --amend --no-edit"
-alias gcaae="git add --all && git commit --amend"
-alias gap="git add -p"
-alias gnope="git checkout ."
-alias gwait="git reset HEAD"
-alias gundo="git reset --soft HEAD^"
-alias greset="git clean -f && git reset --hard HEAD"
-alias gl="git log --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
-alias glb='git log --oneline --decorate --graph --all'
-alias gst='git status -s'
-alias gpl="git pull --rebase"
-alias gps="git push"
-alias gpsf="git push --force-with-lease"
-alias grb="git rebase"
-alias grbi='git rebase -i'
-alias grba='git rebase --abort'
-alias grbc='git rebase --continue'
-alias gcmb="git branch --merged | grep -Ev '(^\\*|master)' | xargs git branch -d"
-alias gset='git branch --set-upstream-to=origin/`git symbolic-ref --short HEAD`'
-grn() { git rebase -i HEAD~"$1"; }
-grbic() { git rebase -i "$1"; }
-
-alias gp='git pull'
-alias gco='git checkout'
-alias glog='git log --oneline --decorate --color --graph'
-
-alias src='source ~/.zshrc'
-alias dotstatus='bash ~/dotfiles/scripts/status.sh'  # dotfiles health: repo git state + last update
-alias dotprofile='bash ~/dotfiles/scripts/profile.sh'  # show/set this machine's dotfiles profile
-alias c='clear'
-alias edithost='sudo nano /etc/hosts'
-
-alias ..='../..'
-alias ...='../../..'
-alias ....='../../../..'
-alias .....='../../../../..'
-alias ls='lsd --group-dirs first'
-alias la='lsd -A'
-alias l='lsd -A --group-dirs first'
-alias ll='lsd -lA --group-dirs first'
-alias lc='lsd -lA --group-dirs first --sort date'
-alias change="code ~/.zshrc"
-alias update="source ~/.zshrc"
-alias history='history 0'
-
-# bat (syntax-highlighted cat)
-command -v bat &>/dev/null && alias cat='bat --paging=never'
-
-eval "$(starship init zsh)"
+# Local AFS properties (machine-specific, not tracked) — original position.
 test -f ~/afs_localprops.sh && source ~/afs_localprops.sh
 
-# Zsh plugins — managed declaratively by sheldon (config: ~/.config/sheldon/plugins.toml).
-# Falls back to manually-cloned plugins under ~/.zsh so a machine without sheldon
-# (e.g. before bootstrap installs it) still gets highlighting + autosuggestions.
-if command -v sheldon &>/dev/null; then
-  eval "$(sheldon source)"
-else
-  [ -f "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh" ] && \
-    source "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
-  [ -f "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" ] && \
-    source "$HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh"
-fi
+source_if_exists "$DOTFILES_ZSH_DIR/plugins.zsh"       # sheldon + completion
+source_if_exists "$DOTFILES_ZSH_DIR/integrations.zsh"  # zoxide, direnv
 
-# Enable enhanced menu selection in completions
-zmodload -i zsh/complist 2>/dev/null || true
-
-autoload -Uz compinit
-# Only rebuild completion dump once per day — saves ~30-50ms per shell start
-if [[ -n ~/.zcompdump(#qN.mh+24) ]]; then
-  compinit
-else
-  compinit -C
-fi
-
-# zoxide
-if command -v zoxide >/dev/null 2>&1; then
-  eval "$(zoxide init zsh)"
-fi
-
-# direnv — per-directory environment variables (.envrc files)
-if command -v direnv >/dev/null 2>&1; then
-  eval "$(direnv hook zsh)"
-fi
-
-# Angular CLI autocompletion (disabled for performance - enable if needed)
-# if command -v node &>/dev/null && command -v ng &>/dev/null; then
-#   source <(ng completion script)
-# fi
-
-# Machine-specific overrides (not committed to dotfiles)
-[[ -f ~/.zshrc.local ]] && source ~/.zshrc.local
-# uv (Python package manager) shell integration — only if installed
+# Machine-specific overrides (not committed to dotfiles) — sourced last so they win.
+source_if_exists "$HOME/.zshrc.local"
+# uv (Python package manager) shell integration — kept last to match prior order.
 [[ -f "$HOME/.local/bin/env" ]] && . "$HOME/.local/bin/env"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,9 @@ nav:
       - Complete Setup Guide: work-setup-complete.md
       - Claude Code SSL Fix: claude-code-ssl-fix.md
   - Reference:
+      - dotfiles CLI: cli.md
+      - Zsh Configuration: zsh.md
+      - Ghostty: ghostty.md
       - Tool Reference: tools.md
       - Shell Performance: performance.md
       - Troubleshooting: troubleshooting.md
@@ -113,5 +116,6 @@ nav:
       - Glossary: glossary.md
   - Roadmap:
       - Quick Reference: roadmap-quick-reference.md
+      - Personal Workstation: roadmap-personal-workstation.md
       - Work Laptop Management: roadmap-work-laptop-management.md
   - Contributing: contributing.md

--- a/scripts/dotfiles.sh
+++ b/scripts/dotfiles.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# dotfiles.sh — unified entry point for common dotfiles operations.
+#
+# A thin, memorable wrapper around the existing scripts so you can run
+# `dotfiles status` / `dotfiles doctor` instead of remembering each script path.
+# Most subcommands simply delegate (forwarding all arguments and the exit code)
+# to the underlying script; `doctor` aggregates a few read-only health checks.
+#
+# Usage:
+#   bash scripts/dotfiles.sh <command> [args...]
+#   dotfiles <command> [args...]   # when ~/dotfiles/bin is on PATH (see home/zsh/path.zsh)
+#
+# Commands: help · status · verify · doctor · update · profile · cleanup
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Colored output helpers (setup_colors, info/success/warn, step) — the same
+# library every other script uses, so output stays consistent.
+# shellcheck source=scripts/lib/bootstrap_helpers.sh
+source "$ROOT_DIR/scripts/lib/bootstrap_helpers.sh"
+setup_colors
+
+usage() {
+  cat <<'USAGE'
+Usage: dotfiles <command> [args...]
+
+Commands:
+  help       Show this help message
+  status     Show dotfiles status (repo state + last update)
+  verify     Run the full health check (verify.sh)
+  doctor     Read-only health check: status + verify + shell & terminal config
+  update     Update dotfiles, packages, and runtimes (update.sh)
+  profile    Show or set this machine's profile
+  cleanup    Remove common dotfile cruft (backups, cache, legacy configs)
+
+Most commands forward their arguments to the underlying script, e.g.:
+  dotfiles status --verify
+  dotfiles update --dry-run
+  dotfiles cleanup --dry-run
+
+Examples:
+  dotfiles status
+  dotfiles doctor
+  dotfiles update
+
+Run via `dotfiles <command>` (when ~/dotfiles/bin is on PATH) or
+`bash ~/dotfiles/scripts/dotfiles.sh <command>`.
+USAGE
+}
+
+# doctor — read-only snapshot of dotfiles health. Delegates to the existing
+# status/verify scripts and adds light shell + terminal config checks. It never
+# modifies the system; it aggregates failures and returns non-zero if any check
+# fails so it is usable in scripts and CI.
+doctor() {
+  local fails=0 f
+  # shellcheck disable=SC2034  # STEP/TOTAL_STEPS are read by step() in bootstrap_helpers.sh
+  STEP=0
+  # shellcheck disable=SC2034
+  TOTAL_STEPS=4
+
+  echo ""
+  printf "${BOLD}  🩺  dotfiles doctor${RESET}  —  read-only health check\n"
+  echo "  ─────────────────────────────────────────────────"
+
+  # [1/4] Repository status (repo git state + last update.sh result)
+  step "📦  Repository status"
+  if bash "$ROOT_DIR/scripts/status.sh" --exit-code; then
+    success "Repository status OK"
+  else
+    warn "Repository status reported issues (see above)"
+    fails=$(( fails + 1 ))
+  fi
+
+  # [2/4] Full verification (symlinks, tools, runtimes, git health, ...)
+  step "🔍  Verification (verify.sh)"
+  if bash "$ROOT_DIR/verify.sh"; then
+    success "Verification passed"
+  else
+    warn "verify.sh reported errors (see above)"
+    fails=$(( fails + 1 ))
+  fi
+
+  # [3/4] Shell configuration — syntax-check zshrc + every module
+  step "🐚  Shell configuration"
+  if command -v zsh >/dev/null 2>&1; then
+    local shell_ok=true
+    if ! zsh -n "$ROOT_DIR/home/zshrc" 2>/dev/null; then
+      warn "syntax error: home/zshrc"
+      shell_ok=false
+    fi
+    for f in "$ROOT_DIR"/home/zsh/*.zsh; do
+      [[ -e "$f" ]] || continue
+      if ! zsh -n "$f" 2>/dev/null; then
+        warn "syntax error: ${f#"$ROOT_DIR"/}"
+        shell_ok=false
+      fi
+    done
+    if [[ "$shell_ok" == true ]]; then
+      success "zsh config parses cleanly (home/zshrc + modules)"
+    else
+      fails=$(( fails + 1 ))
+    fi
+  else
+    info "zsh not found — skipping shell syntax check"
+  fi
+
+  # [4/4] Terminal configuration — Ghostty preferred, Hyper fallback
+  step "🖥️   Terminal configuration"
+  local ghostty_cfg="$ROOT_DIR/config/ghostty/config"
+  if [[ ! -f "$ghostty_cfg" ]]; then
+    warn "Ghostty config missing: config/ghostty/config"
+    fails=$(( fails + 1 ))
+  elif command -v ghostty >/dev/null 2>&1; then
+    if ghostty +validate-config --config-file="$ghostty_cfg" >/dev/null 2>&1; then
+      success "Ghostty config valid (ghostty +validate-config)"
+    else
+      warn "ghostty +validate-config reported errors for config/ghostty/config"
+      fails=$(( fails + 1 ))
+    fi
+  else
+    success "Ghostty config present (install ghostty to validate automatically)"
+  fi
+  [[ -f "$ROOT_DIR/home/hyper.js" ]] && info "Hyper fallback config present (home/hyper.js)"
+
+  echo ""
+  echo "  ─────────────────────────────────────────────────"
+  if (( fails > 0 )); then
+    printf "${BOLD}${YELLOW}  ⚠   Doctor finished with %d issue(s)${RESET}\n" "$fails"
+    echo "  ─────────────────────────────────────────────────"
+    return 1
+  fi
+  printf "${GREEN}${BOLD}  ✅  Doctor complete — no issues found${RESET}\n"
+  echo "  ─────────────────────────────────────────────────"
+  return 0
+}
+
+cmd="${1:-help}"
+if [[ $# -gt 0 ]]; then shift; fi
+
+case "$cmd" in
+  help|-h|--help) usage ;;
+  status)  exec bash "$ROOT_DIR/scripts/status.sh" "$@" ;;
+  verify)  exec bash "$ROOT_DIR/verify.sh" "$@" ;;
+  update)  exec bash "$ROOT_DIR/update.sh" "$@" ;;
+  profile) exec bash "$ROOT_DIR/scripts/profile.sh" "$@" ;;
+  cleanup) exec bash "$ROOT_DIR/scripts/cleanup.sh" "$@" ;;
+  doctor)  doctor "$@" ;;
+  *)
+    printf "Unknown command: %s\n\n" "$cmd" >&2
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/scripts/tests/test_dotfiles_cli.bats
+++ b/scripts/tests/test_dotfiles_cli.bats
@@ -1,0 +1,54 @@
+#!/usr/bin/env bats
+# test_dotfiles_cli.bats — smoke tests for the unified CLI (scripts/dotfiles.sh)
+# and the bin/dotfiles shim. Run: bats scripts/tests/test_dotfiles_cli.bats
+
+load 'test_helper'
+
+CLI() { bash "$REPO_ROOT/scripts/dotfiles.sh" "$@"; }
+
+# ── syntax ────────────────────────────────────────────────────────────────────
+@test "dotfiles.sh passes bash -n" {
+  run bash -n "$REPO_ROOT/scripts/dotfiles.sh"
+  [ "$status" -eq 0 ]
+}
+
+@test "bin/dotfiles shim passes bash -n" {
+  run bash -n "$REPO_ROOT/bin/dotfiles"
+  [ "$status" -eq 0 ]
+}
+
+# ── help / default ────────────────────────────────────────────────────────────
+@test "help: exits 0 and prints usage" {
+  run CLI help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: dotfiles"* ]]
+}
+
+@test "no args: prints usage and exits 0" {
+  run CLI
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: dotfiles"* ]]
+}
+
+@test "help lists the core subcommands" {
+  run CLI help
+  [ "$status" -eq 0 ]
+  for sub in status verify doctor update profile cleanup; do
+    [[ "$output" == *"$sub"* ]]
+  done
+}
+
+# ── unknown command ───────────────────────────────────────────────────────────
+@test "unknown command: exits non-zero with a helpful message" {
+  run CLI does-not-exist
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown command: does-not-exist"* ]]
+  [[ "$output" == *"Usage: dotfiles"* ]]
+}
+
+# ── shim parity ───────────────────────────────────────────────────────────────
+@test "bin/dotfiles shim forwards to the CLI (help)" {
+  run bash "$REPO_ROOT/bin/dotfiles" help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: dotfiles"* ]]
+}


### PR DESCRIPTION
## Summary
Implements the dotfiles platform roadmap (from `dotfiles-warp-plan.md`) as targeted, behavior-preserving improvements: a unified CLI, a `doctor` health check, modular zsh, first-class Ghostty, refreshed docs, smoke tests, and a future roadmap.

## What's included
- **Unified CLI** (`scripts/dotfiles.sh` + `bin/dotfiles` shim): `status` / `verify` / `doctor` / `update` / `profile` / `cleanup`. Subcommands delegate to the existing scripts (args + exit codes pass through); `bin/dotfiles` is added to `PATH` via `home/zsh/path.zsh` so `dotfiles <cmd>` works.
- **`doctor`**: read-only health check — repo status + `verify.sh` + `zsh -n` of the shell config + Ghostty `+validate-config`. Exits non-zero on any failure.
- **Modular zsh**: `home/zshrc` is now a thin loader that resolves the repo through the `~/.zshrc` symlink and sources `home/zsh/{path,functions,aliases,prompt,plugins,integrations}.zsh` in the original order. Behavior preserved; no new symlinks needed.
- **Ghostty**: optional `config-file = ?ghostty.local` include for untracked per-machine overrides.
- **Docs**: new `docs/cli.md`, `docs/zsh.md`, `docs/ghostty.md`; README "Common commands" section + links; mkdocs nav.
- **Smoke tests + CI**: `scripts/tests/test_dotfiles_cli.bats`; CI now `zsh -n`s the modules and shellchecks `bin/dotfiles`.
- **Roadmap**: `docs/roadmap-personal-workstation.md` (future ideas only; nothing implemented).

## Key adaptations from the source plan
- CLI delegates to root-level `verify.sh` / `update.sh` (not `scripts/`).
- Modules are sourced straight from the repo — `config/symlinks.map` is unchanged.
- Kept `~/.zshrc.local` as the local-override mechanism (dropped the plan's competing `local.zsh.example`).
- Ghostty validation lives in `doctor` (not the unit-tested `verify.sh`).

## Validation
- `bash -n` + `zsh -n` on all new/changed scripts and modules
- `shellcheck -S warning` clean; `actionlint` clean
- **206 bats tests pass**
- `ghostty +validate-config` exit 0
- Real `~/.zshrc` loads the modular config (functions, aliases, `dotfiles` command all resolve)

Hyper is retained as a fallback; no Neovim changes; no secrets.

## Artifacts
- Plan: https://app.warp.dev/drive/notebook/rnGWHOAh8d2vwZDjYKiPZP
- Conversation: https://app.warp.dev/conversation/8e883199-3e15-49df-bcb6-d1cb4568a7c4

Co-Authored-By: Oz <oz-agent@warp.dev>
