### PR TITLE
feat(cli): add dotfiles man page and verify/doctor --help

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -62,6 +62,27 @@ safe to use in scripts and CI. The flow is:
 dotfiles doctor
 ```
 
+## Help & man page
+
+Every command has help text:
+
+- **Top-level usage**: `dotfiles`, `dotfiles help`, `dotfiles -h`, or `dotfiles --help`.
+- **Per-command help**: `dotfiles <command> --help`. For delegating commands this
+  is forwarded to the underlying script — e.g. `dotfiles status --help`,
+  `dotfiles update --help`, `dotfiles cleanup --help`, `dotfiles profile --help`.
+  `dotfiles verify --help` and `dotfiles doctor --help` also print command-specific
+  usage (without running the checks).
+
+A man page is bundled at `man/man1/dotfiles.1`:
+
+```bash
+man dotfiles                 # works in a new shell (MANPATH is set by path.zsh)
+man ./man/man1/dotfiles.1    # or view the file directly, from the repo
+```
+
+`home/zsh/path.zsh` adds `~/dotfiles/man` to `MANPATH`, so `man dotfiles` works
+after opening a new shell — nothing needs to be installed.
+
 ## See also
 
 - [Usage & Lifecycle](usage.md) — bootstrap, update, verify, status, scheduling

--- a/home/zsh/path.zsh
+++ b/home/zsh/path.zsh
@@ -16,6 +16,10 @@ export EDITOR=code
 # DOTFILES_DIR is resolved in home/zshrc from this file's real location.
 [[ -n "${DOTFILES_DIR:-}" && -d "$DOTFILES_DIR/bin" ]] && export PATH="$DOTFILES_DIR/bin:$PATH"
 
+# dotfiles man page — make `man dotfiles` work (man/man1/dotfiles.1). The
+# trailing colon (when MANPATH is empty) keeps the system man paths searched.
+[[ -n "${DOTFILES_DIR:-}" && -d "$DOTFILES_DIR/man" ]] && export MANPATH="$DOTFILES_DIR/man:${MANPATH:-}"
+
 # NVM conflict guard: if NVM is still installed on this machine but empty
 # (no versions), suppress it so mise owns Node cleanly.
 # NVM has been removed from this machine; this guard is a safety net for

--- a/man/man1/dotfiles.1
+++ b/man/man1/dotfiles.1
@@ -1,0 +1,142 @@
+.\" man page for the dotfiles CLI. View with: man dotfiles
+.\" (MANPATH is extended by home/zsh/path.zsh) or: man ./man/man1/dotfiles.1
+.TH DOTFILES 1 "2026-06-20" "dotfiles" "User Commands"
+.SH NAME
+dotfiles \- unified entry point for common dotfiles operations
+.SH SYNOPSIS
+.B dotfiles
+.I command
+.RI [ arguments ...]
+.SH DESCRIPTION
+.B dotfiles
+is a thin wrapper around the scripts in the dotfiles repository. Most
+subcommands delegate to an existing script, forwarding all arguments and the
+exit code; the
+.B doctor
+subcommand runs a read\-only aggregate health check.
+.PP
+The command is available on
+.B PATH
+through the
+.I bin/dotfiles
+shim, which is added to
+.B PATH
+by
+.IR home/zsh/path.zsh .
+It can also be run directly as
+.IR "bash ~/dotfiles/scripts/dotfiles.sh <command>" .
+.SH COMMANDS
+.TP
+.B help
+Show the usage message. This is also the default when no command is given, and
+is equivalent to
+.B \-h
+and
+.BR \-\-help .
+.TP
+.B status
+Print a read\-only snapshot of dotfiles health: the repository git state and the
+result of the last
+.I update.sh
+run. Delegates to
+.IR scripts/status.sh .
+.TP
+.B verify
+Run the full environment health check (symlinks, required tools, runtimes, git
+health, Brewfile drift, and more). Delegates to
+.IR verify.sh .
+Exits non\-zero when there are errors such as broken symlinks.
+.TP
+.B doctor
+Read\-only aggregate health check. Runs
+.B status
+.RB ( \-\-exit\-code ),
+then
+.BR verify ,
+then a
+.B zsh \-n
+syntax check of
+.I home/zshrc
+and the
+.I home/zsh/*.zsh
+modules, and finally a Ghostty configuration check. It makes no changes and
+exits non\-zero if any check fails.
+.TP
+.B update
+Pull the latest dotfiles, re\-symlink, upgrade packages and runtimes, then run
+the health check. Delegates to
+.IR update.sh .
+.TP
+.B profile
+Show or set this machine's profile
+.RB ( personal ,
+.BR work ,
+.BR minimal ,
+or
+.BR server ).
+Delegates to
+.IR scripts/profile.sh .
+.TP
+.B cleanup
+Remove common dotfile cruft (backups, cache, legacy configs). Delegates to
+.IR scripts/cleanup.sh .
+.SH OPTIONS
+Options are command\-specific and forwarded to the underlying script. Run
+.B dotfiles
+.I command
+.B \-\-help
+to see the options a given command accepts. For example:
+.PP
+.RS
+.nf
+dotfiles status \-\-verify
+dotfiles update \-\-dry\-run
+dotfiles cleanup \-\-dry\-run
+.fi
+.RE
+.SH EXAMPLES
+.TP
+.B dotfiles doctor
+Run the full read\-only health check.
+.TP
+.B dotfiles update \-\-dry\-run
+Preview an update without changing anything.
+.TP
+.B dotfiles profile set work
+Switch this machine to the
+.I work
+profile.
+.SH EXIT STATUS
+.TP
+.B 0
+The command succeeded.
+.TP
+.B non\-zero
+A command failed, one of
+.BR doctor 's
+checks failed, or an unknown command was given.
+.SH FILES
+.TP
+.I ~/dotfiles/scripts/dotfiles.sh
+The CLI implementation.
+.TP
+.I ~/dotfiles/bin/dotfiles
+PATH shim that delegates to the CLI.
+.TP
+.I ~/dotfiles/home/zsh/path.zsh
+Adds the repository
+.I bin
+directory to
+.B PATH
+and the
+.I man
+directory to
+.BR MANPATH .
+.SH SEE ALSO
+.BR git (1),
+.BR zsh (1).
+Project documentation lives in
+.I ~/dotfiles/docs/cli.md
+and on the documentation site.
+.SH AUTHOR
+Brad Bergeron.

--- a/scripts/dotfiles.sh
+++ b/scripts/dotfiles.sh
@@ -45,6 +45,9 @@ Examples:
   dotfiles doctor
   dotfiles update
 
+Command-specific help:  dotfiles <command> --help
+Full manual:            man dotfiles
+
 Run via `dotfiles <command>` (when ~/dotfiles/bin is on PATH) or
 `bash ~/dotfiles/scripts/dotfiles.sh <command>`.
 USAGE
@@ -55,6 +58,20 @@ USAGE
 # modifies the system; it aggregates failures and returns non-zero if any check
 # fails so it is usable in scripts and CI.
 doctor() {
+  if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    cat <<'USAGE'
+Usage: dotfiles doctor
+
+Read-only aggregate health check (makes no changes). Runs:
+  1. Repository status   status.sh --exit-code (repo git state + last update)
+  2. Verification        verify.sh (symlinks, tools, runtimes, git health, ...)
+  3. Shell configuration zsh -n on home/zshrc + home/zsh/*.zsh modules
+  4. Terminal config     Ghostty +validate-config (or presence check); Hyper note
+
+Takes no options. Exit status: non-zero if any check fails, otherwise 0.
+USAGE
+    return 0
+  fi
   local fails=0 f
   # shellcheck disable=SC2034  # STEP/TOTAL_STEPS are read by step() in bootstrap_helpers.sh
   STEP=0

--- a/scripts/tests/test_dotfiles_cli.bats
+++ b/scripts/tests/test_dotfiles_cli.bats
@@ -52,3 +52,25 @@ CLI() { bash "$REPO_ROOT/scripts/dotfiles.sh" "$@"; }
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage: dotfiles"* ]]
 }
+
+# ── per-command help ──────────────────────────────────────────────────────────
+@test "verify --help: exits 0, prints usage, does not run the checks" {
+  run CLI verify --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: bash verify.sh"* ]]
+  [[ "$output" != *"[1/9]"* ]]   # the step banner only appears on a real run
+}
+
+@test "doctor --help: exits 0, prints usage, does not run the checks" {
+  run CLI doctor --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: dotfiles doctor"* ]]
+  [[ "$output" != *"[1/4]"* ]]   # the step banner only appears on a real run
+}
+
+@test "help mentions per-command help and the man page" {
+  run CLI help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"--help"* ]]
+  [[ "$output" == *"man dotfiles"* ]]
+}

--- a/verify.sh
+++ b/verify.sh
@@ -17,6 +17,33 @@
 
 set -euo pipefail
 
+# --help/-h: verify.sh takes no options; print what it checks and exit early
+# (before any work). Other arguments are ignored, as before.
+for _arg in "$@"; do
+  case "$_arg" in
+    -h|--help)
+      cat <<'USAGE'
+Usage: bash verify.sh
+
+Full, read-only environment health check. Reports:
+  1. Symlinks             broken/missing tracked links      (errors -> exit 1)
+  2. Required tools       tools missing from PATH           (warnings)
+  3. Stale backups        old ~/.dotfiles_backup entries    (warnings)
+  4. SSH key              present and loaded in the agent    (warnings)
+  5. git-lfs              initialized globally               (warnings)
+  6. mise runtimes        declared runtimes installed        (warnings)
+  7. Dotfiles git health  no conflict markers; config parses (warnings)
+  8. Brewfile drift       installed packages vs Brewfile(s)  (warnings)
+  9. Git config include   ~/.gitconfig thin include present  (warnings)
+
+This command takes no options. Exit status: 1 if any errors, otherwise 0.
+Run via: dotfiles verify   (or: bash ~/dotfiles/verify.sh)
+USAGE
+      exit 0
+      ;;
+  esac
+done
+
 DOTFILES_DIR="$(cd "$(dirname "$0")" && pwd)"
 VERIFY_START=$SECONDS
 ERRORS=0


### PR DESCRIPTION
## Summary
Adds a `man` page for the `dotfiles` CLI and gives the `verify` and `doctor` subcommands their own `--help` output. Follow-up to #78.

## Changes
- **Man page** (`man/man1/dotfiles.1`): NAME / SYNOPSIS / DESCRIPTION / COMMANDS / OPTIONS / EXAMPLES / EXIT STATUS / FILES. Viewable via `man dotfiles` — `home/zsh/path.zsh` adds `~/dotfiles/man` to `MANPATH` (trailing-colon-safe), so it works in a new shell with nothing to install. Also `man ./man/man1/dotfiles.1`.
- **`verify --help`**: `verify.sh` now handles `-h`/`--help`, printing what it checks plus exit semantics before doing any work. No-arg runs and internal callers (update/status/doctor) are unaffected.
- **`doctor --help`**: the built-in `doctor` prints its 4-step usage without running the checks.
- **Top-level help**: now points to `dotfiles <command> --help` and `man dotfiles`.
- **Docs**: new "Help & man page" section in `docs/cli.md`.
- **Tests**: bats coverage for `verify --help`, `doctor --help`, and the help hints.

## Validation
- shellcheck clean; `zsh -n` clean; `mandoc -T lint` clean and `man dotfiles` renders
- `dotfiles verify --help` / `dotfiles doctor --help` print usage without running checks
- 209 bats tests, 0 failures
- `mkdocs build --strict` clean

## Conversation
https://app.warp.dev/conversation/8e883199-3e15-49df-bcb6-d1cb4568a7c4

Co-Authored-By: Oz <oz-agent@warp.dev>
