### PR TITLE
fix(verify): missing-only Brewfile drift check + flux-app rename

### DIFF
--- a/Brewfile.personal
+++ b/Brewfile.personal
@@ -24,4 +24,4 @@ cask "dbeaver-community"   # universal database GUI (Postgres, MySQL, SQLite, et
 cask "ghostty"             # preferred terminal — GPU-accelerated, native macOS (config in config/ghostty/config)
 cask "hyper"               # fallback terminal built on web technologies (Tokyo Night theme configured in hyper.js)
 cask "github"              # GitHub Desktop — GUI for Git and GitHub
-cask "flux"                # f.lux — adjusts screen color temperature based on time of day to reduce eye strain
+cask "flux-app"            # f.lux — adjusts screen color temperature based on time of day to reduce eye strain

--- a/scripts/lib/verify_helpers.sh
+++ b/scripts/lib/verify_helpers.sh
@@ -265,11 +265,15 @@ check_dotfiles_git_health() {
 }
 
 # check_brewfile_drift BREWFILE
-# Detects divergence between installed Homebrew packages and the Brewfile via
-# `brew bundle check`. Silently skips when brew is not on PATH (check_required_tools
-# already reports a missing brew).
+# Reports packages declared in BREWFILE that are *not installed at all*. This is
+# intentionally presence-based rather than `brew bundle check`: that command also
+# flags installed-but-outdated entries, which is noise for a health check
+# (upgrades are handled by update.sh / `brew upgrade`). Each brew/cask entry is
+# checked with `brew list` at any version; tap/mas/vscode lines and comments are
+# ignored. Silently skips when brew is not on PATH (check_required_tools already
+# reports a missing brew).
 # Sets:
-#   BREWFILE_DRIFT_OK      — true when packages match the Brewfile (or skipped)
+#   BREWFILE_DRIFT_OK      — true when every brew/cask entry is installed (or skipped)
 #   BREWFILE_DRIFT_SKIPPED — true when brew is unavailable
 #   BREWFILE_DRIFT_ISSUE   — human-readable problem description (empty when OK)
 check_brewfile_drift() {
@@ -289,11 +293,32 @@ check_brewfile_drift() {
     return 0
   fi
 
-  if brew bundle check --file="$brewfile" &>/dev/null; then
+  local line kind name leaf
+  local -a missing=()
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    line="${line#"${line%%[![:space:]]*}"}"   # strip leading whitespace
+    case "$line" in
+      brew\ *) kind="formula" ;;
+      cask\ *) kind="cask" ;;
+      *) continue ;;                            # comments, taps, mas, vscode, blanks
+    esac
+    name="${line#* }"                           # text after 'brew '/'cask '
+    name="${name#[\"\']}"                       # strip the opening quote
+    name="${name%%[\"\']*}"                     # keep up to the closing quote
+    [[ -n "$name" ]] || continue
+    leaf="${name##*/}"                          # drop any tap prefix for the lookup
+    if [[ "$kind" == "formula" ]]; then
+      brew list --formula "$leaf" &>/dev/null || missing+=("$name")
+    else
+      brew list --cask "$leaf" &>/dev/null || missing+=("$name")
+    fi
+  done < "$brewfile"
+
+  if [[ "${#missing[@]}" -eq 0 ]]; then
     BREWFILE_DRIFT_OK=true
   else
     BREWFILE_DRIFT_OK=false
-    BREWFILE_DRIFT_ISSUE="installed packages diverge from Brewfile — run: brew bundle install --file=$brewfile"
+    BREWFILE_DRIFT_ISSUE="not installed: ${missing[*]} — run: brew bundle install --file=$brewfile"
   fi
 }
 

--- a/scripts/tests/test_verify_helpers.bats
+++ b/scripts/tests/test_verify_helpers.bats
@@ -412,20 +412,20 @@ setup_gci_dotfiles() {
 }
 
 # ── check_brewfile_drift ──────────────────────────────────────────────────────
-# Fake brew stub: `brew bundle check --file=F` exits 0 iff F contains IN_SYNC.
+# Fake brew stub: `brew list --formula|--cask NAME` exits 0 iff NAME is listed in
+# $FAKE_INSTALLED (space-separated); any other subcommand exits 0. This models
+# "installed (any version)" vs "not installed" without touching real packages.
 setup_fake_brew() {
   FAKE_BIN="$BATS_TEST_TMPDIR/fakebin"
   mkdir -p "$FAKE_BIN"
   cat > "$FAKE_BIN/brew" << 'EOF'
 #!/usr/bin/env bash
-f=""
-for a in "$@"; do
-  case "$a" in
-    --file=*) f="${a#--file=}" ;;
-  esac
-done
-if [[ "${1:-}" == "bundle" ]]; then
-  if [[ -f "$f" ]] && grep -q IN_SYNC "$f"; then exit 0; else exit 1; fi
+if [[ "${1:-}" == "list" ]]; then
+  name="${@: -1}"
+  for p in $FAKE_INSTALLED; do
+    [[ "$p" == "$name" ]] && exit 0
+  done
+  exit 1
 fi
 exit 0
 EOF
@@ -442,27 +442,55 @@ EOF
   )
 }
 
-@test "check_brewfile_drift: in sync → OK=true" {
+@test "check_brewfile_drift: all entries installed → OK=true" {
   setup_fake_brew
   local bf="$BATS_TEST_TMPDIR/Brewfile_sync"
-  echo "# IN_SYNC marker" > "$bf"
+  printf 'brew "git"\ncask "ghostty"\n' > "$bf"
   ( set -e
     export PATH="$FAKE_BIN:$PATH"
+    export FAKE_INSTALLED="git ghostty"
     check_brewfile_drift "$bf"
     [ "$BREWFILE_DRIFT_SKIPPED" = "false" ]
     [ "$BREWFILE_DRIFT_OK" = "true" ]
   )
 }
 
-@test "check_brewfile_drift: drift detected → OK=false, issue set" {
+@test "check_brewfile_drift: installed but outdated → OK=true (only missing counts)" {
+  # Presence-based: an installed package is OK regardless of version, so the
+  # check never warns merely because something is outdated.
   setup_fake_brew
-  local bf="$BATS_TEST_TMPDIR/Brewfile_drift"
-  echo "brew \"git\"" > "$bf"
+  local bf="$BATS_TEST_TMPDIR/Brewfile_outdated"
+  printf 'cask "dbeaver-community"\n' > "$bf"
   ( set -e
     export PATH="$FAKE_BIN:$PATH"
+    export FAKE_INSTALLED="dbeaver-community"
+    check_brewfile_drift "$bf"
+    [ "$BREWFILE_DRIFT_OK" = "true" ]
+  )
+}
+
+@test "check_brewfile_drift: a not-installed entry → OK=false, issue names it" {
+  setup_fake_brew
+  local bf="$BATS_TEST_TMPDIR/Brewfile_missing"
+  printf 'brew "git"\nbrew "definitely-not-installed"\n' > "$bf"
+  ( set -e
+    export PATH="$FAKE_BIN:$PATH"
+    export FAKE_INSTALLED="git"
     check_brewfile_drift "$bf"
     [ "$BREWFILE_DRIFT_OK" = "false" ]
-    [ -n "$BREWFILE_DRIFT_ISSUE" ]
+    echo "$BREWFILE_DRIFT_ISSUE" | grep -q "definitely-not-installed"
+  )
+}
+
+@test "check_brewfile_drift: comments and non-brew/cask lines are ignored" {
+  setup_fake_brew
+  local bf="$BATS_TEST_TMPDIR/Brewfile_comments"
+  printf '# a comment\ntap "homebrew/cask"\nvscode "some.extension"\nbrew "git"\n' > "$bf"
+  ( set -e
+    export PATH="$FAKE_BIN:$PATH"
+    export FAKE_INSTALLED="git"
+    check_brewfile_drift "$bf"
+    [ "$BREWFILE_DRIFT_OK" = "true" ]
   )
 }
 


### PR DESCRIPTION
## Summary
Two follow-up fixes that quiet false-positive warnings in `dotfiles doctor` / `verify`.

## Changes
- **fix(verify)** — `check_brewfile_drift` is now **presence-based**: it parses each `brew`/`cask` entry and checks `brew list`, reporting only packages that aren't installed *at all*. Installed-but-**outdated** packages no longer trigger a drift warning (upgrades are `update.sh` / `brew upgrade`'s job). Comments and `tap`/`mas`/`vscode` lines are ignored. `scripts/tests/test_verify_helpers.bats` is reworked for the new semantics, including an installed-but-outdated regression test.
- **fix(brewfile)** — `Brewfile.personal`: `cask "flux"` → `cask "flux-app"` (the cask was renamed), removing the `flux was renamed to flux-app` notice.

## Why
`brew bundle check` also flags merely-outdated packages, so the drift warning recurred as apps age (e.g. an outdated-but-installed DBeaver showed as drift even though it's present). The health check now reports genuine drift (missing packages) only.

## Validation
- `shellcheck -S warning` clean
- Full bats suite: **212 tests, 0 failures** (includes the new drift tests)
- Functional check against the real `Brewfile` and `Brewfile.personal`: both report in sync

## Conversation
https://app.warp.dev/conversation/8e883199-3e15-49df-bcb6-d1cb4568a7c4

Co-Authored-By: Oz <oz-agent@warp.dev>
