### PR TITLE
perf(verify): snapshot installed packages for the Brewfile drift check

### DIFF
--- a/scripts/lib/verify_helpers.sh
+++ b/scripts/lib/verify_helpers.sh
@@ -265,13 +265,14 @@ check_dotfiles_git_health() {
 }
 
 # check_brewfile_drift BREWFILE
-# Reports packages declared in BREWFILE that are *not installed at all*. This is
-# intentionally presence-based rather than `brew bundle check`: that command also
-# flags installed-but-outdated entries, which is noise for a health check
-# (upgrades are handled by update.sh / `brew upgrade`). Each brew/cask entry is
-# checked with `brew list` at any version; tap/mas/vscode lines and comments are
-# ignored. Silently skips when brew is not on PATH (check_required_tools already
-# reports a missing brew).
+# Reports packages declared in BREWFILE that are *not installed at all* (missing),
+# tolerating installed-but-outdated entries — upgrades are update.sh / `brew
+# upgrade`'s job, and flagging them here is noise. To stay fast it snapshots the
+# installed formulae and casks in two `brew list` calls and matches each entry
+# against them in-shell (calling `brew` once per package spawns Ruby dozens of
+# times and makes the check take tens of seconds). tap/mas/vscode lines and
+# comments are ignored. Silently skips when brew is not on PATH
+# (check_required_tools already reports a missing brew).
 # Sets:
 #   BREWFILE_DRIFT_OK      — true when every brew/cask entry is installed (or skipped)
 #   BREWFILE_DRIFT_SKIPPED — true when brew is unavailable
@@ -293,6 +294,12 @@ check_brewfile_drift() {
     return 0
   fi
 
+  # Snapshot installed formulae and casks once (two brew calls total), each
+  # space-wrapped so membership can be tested with *" $leaf "*.
+  local installed_formulae installed_casks
+  installed_formulae=" $(brew list --formula 2>/dev/null | tr '\n' ' ') "
+  installed_casks=" $(brew list --cask 2>/dev/null | tr '\n' ' ') "
+
   local line kind name leaf
   local -a missing=()
   while IFS= read -r line || [[ -n "$line" ]]; do
@@ -308,9 +315,9 @@ check_brewfile_drift() {
     [[ -n "$name" ]] || continue
     leaf="${name##*/}"                          # drop any tap prefix for the lookup
     if [[ "$kind" == "formula" ]]; then
-      brew list --formula "$leaf" &>/dev/null || missing+=("$name")
+      [[ "$installed_formulae" == *" $leaf "* ]] || missing+=("$name")
     else
-      brew list --cask "$leaf" &>/dev/null || missing+=("$name")
+      [[ "$installed_casks" == *" $leaf "* ]] || missing+=("$name")
     fi
   done < "$brewfile"
 

--- a/scripts/tests/test_verify_helpers.bats
+++ b/scripts/tests/test_verify_helpers.bats
@@ -412,20 +412,17 @@ setup_gci_dotfiles() {
 }
 
 # ── check_brewfile_drift ──────────────────────────────────────────────────────
-# Fake brew stub: `brew list --formula|--cask NAME` exits 0 iff NAME is listed in
-# $FAKE_INSTALLED (space-separated); any other subcommand exits 0. This models
-# "installed (any version)" vs "not installed" without touching real packages.
+# Fake brew stub: `brew list --formula|--cask` prints the names in $FAKE_INSTALLED
+# (space-separated), so the helper's snapshot sees them as installed; any other
+# subcommand exits 0. Models "installed (any version)" vs "not installed".
 setup_fake_brew() {
   FAKE_BIN="$BATS_TEST_TMPDIR/fakebin"
   mkdir -p "$FAKE_BIN"
   cat > "$FAKE_BIN/brew" << 'EOF'
 #!/usr/bin/env bash
 if [[ "${1:-}" == "list" ]]; then
-  name="${@: -1}"
-  for p in $FAKE_INSTALLED; do
-    [[ "$p" == "$name" ]] && exit 0
-  done
-  exit 1
+  for p in $FAKE_INSTALLED; do echo "$p"; done
+  exit 0
 fi
 exit 0
 EOF

--- a/verify.sh
+++ b/verify.sh
@@ -174,6 +174,8 @@ fi
 
 # ── 8. Brewfile drift ───────────────────────────────────
 step "🍺  Brewfile drift"
+# Immediate feedback — the installed-package snapshot below can take a moment.
+command -v brew &>/dev/null && info "checking installed formulae & casks…"
 # Check the core Brewfile plus the active profile's overlays.
 _drift_warn=0
 _drift_skipped=true


### PR DESCRIPTION
## Summary
Fixes a performance regression that made `dotfiles doctor` appear frozen on the Brewfile-drift step (8/9).

## Problem
The presence-based `check_brewfile_drift` (added in #80 / v1.4.0) ran `brew list` **once per declared package** (~50 invocations across `Brewfile` + `Brewfile.personal`), each spawning Homebrew/Ruby. On a cold cache that's tens of seconds of silent work, so `doctor` looked stuck.

## Fix
- **`scripts/lib/verify_helpers.sh`** — snapshot installed formulae and casks in **two `brew list` calls**, then match each Brewfile entry in-shell. Same "missing-only" semantics (outdated-but-installed is still tolerated); ~**0.13s** vs tens of seconds locally.
- **`verify.sh`** — step 8 prints an immediate `→ checking installed formulae & casks…` cue for visible feedback.
- **`scripts/tests/test_verify_helpers.bats`** — fake-brew stub updated to the snapshot model.

## Validation
- `shellcheck -S warning` clean (`verify_helpers.sh`, `verify.sh`)
- Full bats suite: **212 tests, 0 failures**
- Timed against the real Brewfiles: `core: OK=true`, `personal: OK=true` in ~0.13s

## Conversation
https://app.warp.dev/conversation/8e883199-3e15-49df-bcb6-d1cb4568a7c4

Co-Authored-By: Oz <oz-agent@warp.dev>
