### PR TITLE
fix(install): make VS Code extension install best-effort (don't abort)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -150,9 +150,13 @@ if [[ -d "$VSCODE_DIR" ]]; then
     if (( ${#_code_missing[@]} > 0 )); then
       info "Installing ${#_code_missing[@]} missing VS Code extension(s)..."
       for _ext in "${_code_missing[@]}"; do
-        code --install-extension "$_ext" --force >/dev/null 2>&1
+        # `|| info ...` keeps a single failed extension (e.g. transient network or
+        # an unavailable id) from aborting install.sh under `set -e`; extension
+        # installs are best-effort.
+        code --install-extension "$_ext" --force >/dev/null 2>&1 \
+          || info "could not install VS Code extension: $_ext (skipped)"
       done
-      success "VS Code extensions installed (${#_code_missing[@]} new)"
+      success "VS Code extensions up to date"
     else
       success "VS Code extensions already present"
     fi


### PR DESCRIPTION
## Summary
Hotfix for a regression introduced by the previous VS Code extension change (#82-era / on `main`): `install.sh` could exit non-zero under `set -euo pipefail`, which surfaced as **"Symlink install failed"** during `dotfiles update`.

## Cause
The extension-install loop ran `code --install-extension <id> --force` unguarded. Some extensions — notably `github.copilot` / `github.copilot-chat` — return non-zero from the CLI (they generally require sign-in), and that non-zero status tripped `set -e`, aborting `install.sh` mid-run (after installing some extensions).

## Fix
Make each install best-effort:

```sh
code --install-extension "$_ext" --force >/dev/null 2>&1 \
  || info "could not install VS Code extension: $_ext (skipped)"
```

A failing extension is now logged and skipped instead of killing the run.

## Validation
- `zsh -n install.sh` clean
- `zsh install.sh` → **exit 0** (was 1); installs missing extensions **headlessly** (no editor tabs), and skips `github.copilot` / `github.copilot-chat` with a note. Only those two remain "missing" (install them from the VS Code Extensions UI — they need Copilot auth).

Follow-up to the missing-only / correct-flag-order install fix.

## Conversation
https://app.warp.dev/conversation/8e883199-3e15-49df-bcb6-d1cb4568a7c4

Co-Authored-By: Oz <oz-agent@warp.dev>
