### PR TITLE
fix(rust): support Homebrew's keg-only rustup on PATH and in bootstrap

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -40,7 +40,7 @@ brew "mise"           # polyglot version manager (Ruby, Node, Python, Java, Go)
 brew "openssl@3"      # required for building Ruby via mise
 brew "maven"          # Java build tool — required for Maven projects
 brew "uv"             # fast Python package and project manager (replaces pip + virtualenv)
-brew "rustup"         # Rust toolchain manager — bootstrap.sh runs rustup-init automatically
+brew "rustup"         # Rust toolchain manager — bootstrap.sh installs the stable toolchain
 brew "ruff"           # extremely fast Python linter and formatter (from Astral, same team as uv)
 
 # ------------------

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -417,19 +417,24 @@ else
     warn "rustup (installed via Brewfile) manages the Rust toolchain from here."
   fi
   if ! command -v rustup &>/dev/null; then
-    if command -v rustup-init &>/dev/null; then
-      info "Initializing Rust toolchain via rustup..."
-      # --no-modify-path: zshrc sources ~/.cargo/env directly
-      rustup-init -y --no-modify-path
-      # shellcheck source=/dev/null
-      . "$HOME/.cargo/env"
-      rustup component add rustfmt clippy
-      success "Rust installed via rustup (stable + rustfmt + clippy)"
-    else
-      warn "rustup-init not found — skipping Rust installation (install it later with: brew install rustup)"
-    fi
+    warn "rustup not found — install it with: brew install rustup, then re-run bootstrap"
   else
-    success "rustup already installed: $(rustc --version 2>/dev/null || echo 'rustc not yet in PATH')"
+    # Homebrew's rustup is keg-only: its cargo/rustc proxies live under
+    # <brew prefix>/opt/rustup/bin (not on PATH by default), and `brew install
+    # rustup` does NOT install a toolchain. Put the proxies on PATH for this
+    # session, then ensure a stable toolchain exists so rustc/cargo work.
+    if _brew_rustup="$(brew --prefix rustup 2>/dev/null)" && [[ -d "$_brew_rustup/bin" ]]; then
+      export PATH="$_brew_rustup/bin:$PATH"
+    fi
+    unset _brew_rustup
+    # shellcheck source=/dev/null
+    [[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+    if ! rustc --version &>/dev/null; then
+      info "Installing the Rust stable toolchain via rustup (first run)..."
+      rustup default stable || warn "rustup default stable failed — run it manually later"
+      rustup component add rustfmt clippy &>/dev/null || true
+    fi
+    success "Rust ready: $(rustc --version 2>/dev/null || echo 'toolchain pending — run: rustup default stable')"
   fi
 fi
 

--- a/home/zsh/path.zsh
+++ b/home/zsh/path.zsh
@@ -38,8 +38,18 @@ if command -v mise &>/dev/null; then
   eval "$(mise activate zsh)"
 fi
 
-# Rust (cargo) — add to PATH if rustup is installed
-[[ -f "$HOME/.cargo/env" ]] && . "$HOME/.cargo/env"
+# Rust — the official rustup installer writes ~/.cargo/env; Homebrew's keg-only
+# rustup instead keeps its proxies (cargo, rustc, ...) under
+# <brew prefix>/opt/rustup/bin and does NOT put them on PATH. Handle both,
+# without shelling out to `brew` (HOMEBREW_PREFIX is exported by zprofile).
+if [[ -f "$HOME/.cargo/env" ]]; then
+  . "$HOME/.cargo/env"
+else
+  for _rustup_bin in "${HOMEBREW_PREFIX:-/opt/homebrew}/opt/rustup/bin" /usr/local/opt/rustup/bin; do
+    [[ -d "$_rustup_bin" ]] && { export PATH="$_rustup_bin:$PATH"; break; }
+  done
+  unset _rustup_bin
+fi
 
 # Go — tools installed via `go install` land in ~/go/bin
 export GOPATH="${GOPATH:-$HOME/go}"


### PR DESCRIPTION
## Summary
Makes the Rust setup work with **Homebrew's keg-only `rustup`** (what the Brewfile installs), so `rustc`/`cargo` are on PATH reproducibly — no machine-local workaround needed.

## Problem
Homebrew's `rustup` is keg-only: its `cargo`/`rustc` proxies live under `$(brew --prefix rustup)/bin` and aren't on PATH, and `brew install rustup` doesn't install a toolchain. But:
- `home/zsh/path.zsh` only sourced `~/.cargo/env` (the *official* installer's layout, which keg-only rustup never creates) → `rustc`/`cargo` missing on PATH.
- `bootstrap.sh` assumed `rustup-init` (no longer shipped by the formula) and, when `rustup` was already present, did nothing — leaving a machine with rustup but no toolchain.

## Fix
- **`home/zsh/path.zsh`** — source `~/.cargo/env` if present; otherwise add `${HOMEBREW_PREFIX:-/opt/homebrew}/opt/rustup/bin` (or `/usr/local/opt/rustup/bin`) to PATH. No `brew` shell-out (uses `HOMEBREW_PREFIX` from zprofile).
- **`bootstrap.sh`** — when `rustup` exists, put its proxies on PATH and run `rustup default stable` (+ `rustfmt`/`clippy`) if no toolchain is installed; removed the dead `rustup-init` branch.
- **`Brewfile`** — corrected the stale "runs rustup-init" comment.

This removes the need for the machine-local `~/.zshrc.local` PATH hack (deleted locally).

## Validation
- `zsh -n` (path.zsh + bootstrap.sh) and `shellcheck -S warning bootstrap.sh` clean
- Fresh interactive shell resolves `rustc`/`cargo` via `path.zsh` (on PATH exactly once)
- `code`/extension flow untouched

## Conversation
https://app.warp.dev/conversation/8e883199-3e15-49df-bcb6-d1cb4568a7c4

Co-Authored-By: Oz <oz-agent@warp.dev>
