### PR TITLE
chore: remove Docker and OrbStack references from documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,6 @@ Quick reference — [full descriptions, rationale, and usage in docs/tools.md](d
 | [Hyper](https://hyper.is) | Fallback terminal — kept installed during the Ghostty transition (`home/hyper.js`) |
 | [Raycast](https://raycast.com) | Launcher, clipboard history, window management — replaces Spotlight |
 | [Insomnia](https://insomnia.rest) | GUI REST/GraphQL client — API design, collections, team sharing |
-| [OrbStack](https://orbstack.dev) | Docker Desktop replacement — starts in <1s, lower RAM/CPU |
 | [VS Code](https://code.visualstudio.com) | Editor — settings and extensions tracked in `vscode/` |
 | [Neovim](https://neovim.io) | Terminal editor — dependency-free baseline in `config/nvim/init.lua` |
 | [Postgres.app](https://postgresapp.com) | PostgreSQL with a macOS GUI |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -344,9 +344,6 @@ A GUI REST and GraphQL API client — a solid replacement for Postman. Best for 
 
 **Insomnia vs HTTPie:** they serve different purposes and complement each other. Use Insomnia for organized API collections, complex auth flows, and team sharing. Use HTTPie for quick terminal one-liners, scripting, and piping responses. Exploring a single endpoint? HTTPie. Managing a suite across dev/staging/prod environments? Insomnia.
 
-### [OrbStack](https://orbstack.dev)
-A fast, lightweight replacement for Docker Desktop on macOS. Starts in under a second (vs Docker Desktop's 10–30s), uses significantly less RAM and CPU, and runs Linux VMs natively on Apple Silicon. The CLI is fully compatible with Docker (`docker`, `docker-compose`) so no workflow changes are needed. Free for personal use.
-
 ### [Raycast](https://raycast.com)
 Replaces macOS Spotlight as your primary launcher and desktop control layer. Everything is keyboard-driven: press the hotkey, type what you want, press `Enter`.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -402,9 +402,6 @@ bash scripts/setup_work_configs.sh
 # Test with shellcheck
 shellcheck scripts/setup_work_configs.sh
 
-# Test in a clean environment
-docker run -it --rm -v ~/dotfiles:/dotfiles ubuntu:22.04 bash
-cd /dotfiles && bash scripts/setup_work_configs.sh
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Remove all Docker Desktop and OrbStack references from documentation
- Eliminates confusion on work machines where Docker Desktop is not supported

## Changes
- **README.md**: Removed OrbStack from tools table
- **docs/tools.md**: Removed OrbStack section with Docker Desktop comparison
- **scripts/README.md**: Removed docker run testing example

## Context
Docker Desktop and OrbStack are **not** installed by the dotfiles (not present in any Brewfile). However, documentation previously mentioned them as recommended tools. Since Docker Desktop doesn't work on work machines and can cause confusion, all references have been removed.

## Test plan
- [x] Verified no references to "docker" or "orbstack" remain in documentation
- [x] Confirmed Brewfiles don't contain Docker/OrbStack installations
- [x] Checked bootstrap/install scripts have no Docker setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)