### PR TITLE
Add vets-website development workflow scripts

### DIFF
--- a/docs/vets-website.md
+++ b/docs/vets-website.md
@@ -1,0 +1,471 @@
+# Vets-Website Development Scripts
+
+Automated workflow scripts for the VA.gov vets-website project with jfrog proxy support.
+
+---
+
+## Overview
+
+The vets-website project has migrated from webpack to esbuild, requiring updated workflow scripts. These scripts handle the complete development lifecycle from dependency installation through dev server startup, with built-in support for corporate jfrog proxy.
+
+**Location**: `~/dotfiles/scripts/vets-website/`
+
+---
+
+## Prerequisites
+
+Before using these scripts, ensure you have:
+
+- **Node.js** 22.x (required by vets-website)
+- **Yarn** 1.19.1 (pinned version)
+- **jfrog proxy configured** in `~/.npmrc`
+- **vets-website repository** cloned to `~/Code/va.gov/vets-website`
+
+### JFrog Proxy Configuration
+
+Your `~/.npmrc` should contain:
+
+```ini
+registry=https://jfrog.accenturefederaldev.com/artifactory/api/npm/afs-npm-proxy/
+//jfrog.accenturefederaldev.com/artifactory/api/npm/afs-npm-proxy/:_authToken=<your-token>
+```
+
+---
+
+## Available Scripts
+
+### `start-vets-website.sh` - Full Setup
+
+The comprehensive "Monday morning" script that syncs everything.
+
+**What it does:**
+
+1. Checks git status and branch
+2. **Pulls latest from `origin/main`** (if on main with no uncommitted changes)
+3. Validates Node.js and Yarn versions
+4. **Installs/updates dependencies** via jfrog proxy
+5. Starts the dev server with default applications
+
+**Time**: 3-5 minutes
+
+**Use when:**
+
+- Starting your week (Monday morning routine)
+- After being away from the project for several days
+- When you see "Cannot find module" errors
+- After `package.json` or `yarn.lock` changes
+- First time setup
+
+**Example:**
+
+```bash
+vets-start
+# Or: ~/dotfiles/scripts/vets-website/start-vets-website.sh
+```
+
+---
+
+### `dev.sh` - Quick Daily Start
+
+Fast startup for active development. Assumes dependencies are current.
+
+**What it does:**
+
+1. Navigates to vets-website directory
+2. Starts the dev server immediately
+
+**Time**: 5-15 seconds
+
+**Use when:**
+
+- Daily development (Tuesday-Friday)
+- Restarting the dev server during work
+- Dependencies haven't changed
+- You want to start coding immediately
+
+**Example:**
+
+```bash
+# Start with default apps
+vets-dev
+
+# Start with specific apps
+vets-dev --entry=auth,profile,static-pages
+
+# Start with remote API
+vets-dev --entry=auth,profile --api=https://dev-api.va.gov
+```
+
+---
+
+## Setup
+
+### 1. Clone the Scripts (Via Dotfiles)
+
+These scripts are included in your dotfiles repository. After cloning or updating your dotfiles:
+
+```bash
+cd ~/dotfiles
+git pull origin main
+```
+
+The scripts will be available at `~/dotfiles/scripts/vets-website/`.
+
+### 2. Configure Shell Aliases
+
+Add these aliases to `~/.zshrc.local` for quick access:
+
+```bash
+# Vets-website development workflow
+alias vets-start="~/dotfiles/scripts/vets-website/start-vets-website.sh"
+alias vets-dev="~/dotfiles/scripts/vets-website/dev.sh"
+alias vets-cd="cd ~/Code/va.gov/vets-website"
+```
+
+Then reload your shell:
+
+```bash
+source ~/.zshrc
+```
+
+### 3. Customize Default Applications (Optional)
+
+Both scripts load a default set of applications. To customize, edit the `--entry` parameter in the scripts:
+
+**Default apps:**
+```
+auth, login-page, profile, static-pages, terms-of-use, verify, virtual-agent
+```
+
+**Education benefit apps (optional):**
+```
+1990ez-edu-benefits, toe, survivor-dependent-education-benefit-22-5490,
+1995-edu-benefits, 10297-edu-benefits, enrollment-verification, education-letters
+```
+
+---
+
+## Daily Workflow
+
+### Monday Morning Routine
+
+Start fresh with the latest code and dependencies:
+
+```bash
+vets-start
+```
+
+This will:
+- Pull latest changes from main
+- Update all dependencies
+- Start the dev server
+
+Expected output:
+```
+→ Checking git status...
+  Current branch: main
+  Pulling latest changes from origin/main...
+  ✓ Successfully pulled from main
+
+→ Checking Node version...
+  Node version: v22.23.0 (Required: >=22.0.0 <23)
+
+→ Checking Yarn version...
+  Yarn version: 1.19.1 (Required: 1.19.1)
+
+→ Installing dependencies via jfrog proxy...
+  (This uses NODE_TLS_REJECT_UNAUTHORIZED=0 for jfrog SSL)
+
+✓ Installation complete!
+
+Starting development server...
+```
+
+### Tuesday-Friday
+
+Quick start without updating dependencies:
+
+```bash
+vets-dev
+```
+
+### Working on Specific Apps
+
+```bash
+# Frontend features
+vets-dev --entry=auth,login-page,profile
+
+# Claims and appeals
+vets-dev --entry=claims-status,0996-higher-level-review
+
+# Education benefits
+vets-dev --entry=1990ez-edu-benefits,toe,education-letters
+```
+
+### Using Remote API
+
+When you need to test against a deployed environment:
+
+```bash
+vets-dev --entry=auth,profile --api=https://dev-api.va.gov
+```
+
+!!! warning "CORS Required"
+    When using a non-local API, you must disable CORS in your browser. See the [troubleshooting section](#cors-issues) below.
+
+---
+
+## Git Pull Behavior
+
+The `vets-start` script handles git pull intelligently based on your current state:
+
+### ✅ Clean Main Branch
+
+```
+Current branch: main
+No uncommitted changes
+→ Automatically pulls from origin/main
+```
+
+**Result**: Pulls latest changes automatically.
+
+### ⚠️ Uncommitted Changes
+
+```
+Current branch: main
+⚠ You have uncommitted changes
+→ Skips git pull (commit or stash your changes first)
+```
+
+**Result**: Skips pull to protect your work. Commit or stash changes first.
+
+### ⚠️ Feature Branch
+
+```
+Current branch: feature/my-work
+⚠ Not on main branch
+→ Skips git pull (not on main)
+```
+
+**Result**: Skips pull. Switch to main manually if you want latest.
+
+---
+
+## Dev Server
+
+The dev server runs on `http://localhost:3001` by default.
+
+### Available Options
+
+```bash
+yarn watch [options]
+
+Options:
+  --entry=<apps>              Comma-separated list of app entry names
+  --api=<url>                 Remote API URL (proxied through dev server)
+  --port=<num>                Dev server port (default: 3001)
+  --host=<addr>               Dev server host (default: 127.0.0.1)
+  --scaffold                  Generate HTML scaffold pages
+  --verbose                   Show all esbuild output
+  --local-proxy-rewrite       Enable proxy for testing injected header/footer
+```
+
+### Finding Application Names
+
+List all available applications:
+
+```bash
+cd ~/Code/va.gov/vets-website
+yarn apps
+```
+
+Or search for manifests:
+
+```bash
+find src/applications -name "manifest.json" -exec grep -l "entryName" {} \;
+```
+
+---
+
+## Troubleshooting
+
+### SSL Certificate Errors
+
+If you see SSL errors when installing dependencies:
+
+```
+Error: unable to get local issuer certificate
+```
+
+**Solution**: The scripts automatically use `NODE_TLS_REJECT_UNAUTHORIZED=0` for jfrog proxy SSL. If you're running manual commands, ensure you include it:
+
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+```
+
+### Module Not Found Errors
+
+If you see "Cannot find module" errors:
+
+```bash
+# Clean reinstall
+cd ~/Code/va.gov/vets-website
+rm -rf node_modules yarn.lock
+vets-start
+```
+
+Or manually:
+
+```bash
+rm -rf node_modules yarn.lock
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+```
+
+### Port Already in Use
+
+If port 3001 is already in use:
+
+```
+Error: listen EADDRINUSE: address already in use 127.0.0.1:3001
+```
+
+**Solution**: Kill the process using the port:
+
+```bash
+lsof -ti:3001 | xargs kill -9
+```
+
+Or use a different port:
+
+```bash
+vets-dev --port=3002
+```
+
+### Cypress Binary Not Installed
+
+The postinstall script should handle this automatically, but if needed:
+
+```bash
+npx cypress install
+```
+
+### CORS Issues
+
+When using a remote API (`--api=https://...`), you must disable CORS in your browser:
+
+**Chrome/Edge:**
+```bash
+open -na "Google Chrome" --args --disable-web-security --user-data-dir=/tmp/chrome-dev
+```
+
+**Safari:**
+Develop menu → Disable Cross-Origin Restrictions
+
+**Firefox:**
+Install a CORS extension from the Firefox Add-ons store
+
+---
+
+## Webpack to esbuild Migration
+
+The vets-website project has migrated from webpack to esbuild. Old instructions are obsolete.
+
+### What Changed
+
+| Old (webpack) | New (esbuild) | Notes |
+|---------------|---------------|-------|
+| `yarn watch --env entry=...` | `yarn watch --entry=...` | Flag changed |
+| Edit `webpack.config.js` | Not needed | File removed |
+| Install `copy-webpack-plugin` | Not needed | No webpack plugins |
+| Rename patches directory | Not needed | No patches needed |
+| Complex postinstall steps | `yarn install-safe` | Simplified |
+
+### Old Instructions (Obsolete)
+
+If you have old setup notes that include:
+
+- ❌ Removing and renaming patches
+- ❌ Installing webpack plugins
+- ❌ Modifying `webpack.config.js`
+- ❌ Complex `NODE_PUPPETEER` flags
+
+**Discard them**. The new workflow is much simpler.
+
+---
+
+## Understanding `yarn install-safe`
+
+This custom command is defined in `package.json` and is equivalent to:
+
+```bash
+yarn install --ignore-scripts && yarn postinstall
+```
+
+**Why it's safer:**
+
+- `--ignore-scripts` prevents potentially untrusted scripts from running during install
+- The custom `postinstall` script only runs scripts from trusted packages
+- Works correctly with jfrog proxy and corporate SSL certificates
+
+---
+
+## Quick Reference
+
+### Commands
+
+```bash
+# Monday morning (full sync)
+vets-start
+
+# Daily quick start
+vets-dev
+
+# Jump to directory
+vets-cd
+
+# Manual dependency install
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+
+# List all apps
+yarn apps
+
+# Start with specific apps
+yarn watch --entry=app1,app2,app3
+
+# Build for production
+yarn build
+
+# Run tests
+yarn test
+```
+
+### Script Comparison
+
+| Feature | `vets-start` | `vets-dev` |
+|---------|-------------|-----------|
+| Git pull | ✅ Yes (if on main) | ❌ No |
+| Install dependencies | ✅ Yes | ❌ No |
+| Start dev server | ✅ Yes | ✅ Yes |
+| Time | 3-5 minutes | 5-15 seconds |
+| Use frequency | Weekly | Daily |
+
+---
+
+## Additional Resources
+
+- **VA Platform Documentation**: [Setting up your local frontend environment](https://depo-platform-documentation.scrollhelp.site/developer-docs/Setting-up-your-local-frontend-environment.1844215878.html)
+- **esbuild Documentation**: [esbuild.github.io](https://esbuild.github.io)
+- **vets-website README**: `~/Code/va.gov/vets-website/README.md`
+- **Script Documentation**: `~/dotfiles/scripts/vets-website/`
+  - `README.md` - Overview
+  - `QUICK-REFERENCE.md` - Command cheat sheet
+  - `SCRIPT-COMPARISON.md` - Detailed comparison
+  - `STARTUP-INSTRUCTIONS.md` - Complete guide
+
+---
+
+## Related Documentation
+
+- [Work Machine Setup](work-machine.md) - General work machine configuration
+- [Complete Work Setup Guide](work-setup-complete.md) - Full laptop setup walkthrough
+- [Claude Code SSL Fix](claude-code-ssl-fix.md) - Corporate SSL certificate setup

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - Overview: work-machine.md
       - Complete Setup Guide: work-setup-complete.md
       - Claude Code SSL Fix: claude-code-ssl-fix.md
+      - Vets-Website Scripts: vets-website.md
   - Reference:
       - dotfiles CLI: cli.md
       - Zsh Configuration: zsh.md

--- a/scripts/vets-website/QUICK-REFERENCE.md
+++ b/scripts/vets-website/QUICK-REFERENCE.md
@@ -1,0 +1,84 @@
+# Vets-Website Quick Reference
+
+## Daily Workflow
+
+```bash
+# Pull latest + update dependencies + start (Monday morning routine)
+~/dotfiles/scripts/vets-website/start-vets-website.sh
+# Or: vets-start
+
+# Quick daily start - assumes dependencies are current (most common)
+~/dotfiles/scripts/vets-website/dev.sh
+# Or: vets-dev
+
+# With specific apps
+vets-dev --entry=auth,profile,static-pages
+
+# With remote API
+vets-dev --entry=auth,profile --api=https://dev-api.va.gov
+```
+
+## Recommended Shell Aliases
+
+Add to `~/.zshrc.local`:
+```bash
+alias vets-start="~/dotfiles/scripts/vets-website/start-vets-website.sh"
+alias vets-dev="~/dotfiles/scripts/vets-website/dev.sh"
+alias vets-cd="cd ~/Code/va.gov/vets-website"
+```
+
+## Common Manual Commands
+
+```bash
+cd ~/Code/va.gov/vets-website
+
+# Install/update dependencies
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+
+# List available apps
+yarn apps
+
+# Start dev server
+yarn watch --entry=auth,profile,static-pages
+
+# Run tests
+yarn test
+
+# Build for production
+yarn build
+```
+
+## Key Changes from Webpack
+
+| Old Command | New Command |
+|-------------|-------------|
+| `yarn watch --env entry=app1,app2` | `yarn watch --entry=app1,app2` |
+| Edit `webpack.config.js` | Not needed (esbuild) |
+| Install webpack plugins | Not needed |
+| Rename patches | Not needed |
+
+## Dev Server
+
+- URL: `http://localhost:3001`
+- Port can be changed: `yarn watch --port=3002`
+
+## Troubleshooting
+
+### Clean reinstall
+```bash
+cd ~/Code/va.gov/vets-website
+rm -rf node_modules yarn.lock
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+```
+
+### Cypress issues
+```bash
+npx cypress install
+```
+
+## Documentation
+
+- Full instructions: `~/dotfiles/scripts/vets-website/STARTUP-INSTRUCTIONS.md`
+- Script info: `~/dotfiles/scripts/vets-website/README.md`
+- Script comparison: `~/dotfiles/scripts/vets-website/SCRIPT-COMPARISON.md`
+- Repository README: `~/Code/va.gov/vets-website/README.md`

--- a/scripts/vets-website/README.md
+++ b/scripts/vets-website/README.md
@@ -1,0 +1,78 @@
+# Vets-Website Development Scripts
+
+Personal workflow scripts for running vets-website with jfrog proxy.
+
+## Location
+These scripts live in `~/dotfiles/scripts/vets-website/` (version controlled with your dotfiles)
+
+## Scripts
+
+### `start-vets-website.sh`
+Full setup and start script. Use this:
+- On first setup
+- To pull latest changes and update dependencies
+- When dependencies seem broken
+
+**What it does:**
+1. Pulls latest changes from `main` (if on main branch with no uncommitted changes)
+2. Installs/updates dependencies via jfrog proxy
+3. Starts the dev server
+
+```bash
+~/dotfiles/scripts/vets-website/start-vets-website.sh
+# Or with alias: vets-start
+```
+
+### `dev.sh`
+Quick start for daily development. Assumes dependencies are already installed.
+
+```bash
+# Start with default apps
+~/dotfiles/scripts/vets-website/dev.sh
+# Or with alias: vets-dev
+
+# Start with specific apps
+vets-dev --entry=auth,profile,static-pages
+
+# Start with remote API
+vets-dev --entry=auth,profile --api=https://dev-api.va.gov
+```
+
+## Creating Aliases (Recommended)
+
+Add to your `~/.zshrc.local`:
+
+```bash
+# Vets-website aliases
+alias vets-start="~/dotfiles/scripts/vets-website/start-vets-website.sh"
+alias vets-dev="~/dotfiles/scripts/vets-website/dev.sh"
+alias vets-cd="cd ~/Code/va.gov/vets-website"
+```
+
+Then reload your shell:
+```bash
+source ~/.zshrc
+```
+
+Now you can use:
+```bash
+vets-start      # Full setup and start
+vets-dev        # Quick start
+vets-cd         # Jump to vets-website directory
+```
+
+## Configuration
+
+Both scripts look for vets-website at:
+```
+~/Code/va.gov/vets-website
+```
+
+If your vets-website is in a different location, edit the `VETS_WEBSITE_DIR` variable in both scripts.
+
+## Documentation
+
+See the other markdown files in this directory for detailed documentation:
+- `QUICK-REFERENCE.md` - Command cheat sheet
+- `SCRIPT-COMPARISON.md` - Detailed comparison of vets-start vs vets-dev
+- `STARTUP-INSTRUCTIONS.md` - Complete setup and usage instructions

--- a/scripts/vets-website/SCRIPT-COMPARISON.md
+++ b/scripts/vets-website/SCRIPT-COMPARISON.md
@@ -1,0 +1,134 @@
+# vets-start vs vets-dev - Quick Comparison
+
+## Side-by-Side Comparison
+
+| Feature | `vets-start` | `vets-dev` |
+|---------|-------------|-----------|
+| **Git pull** | ✅ Yes (if on main) | ❌ No |
+| **Install dependencies** | ✅ Yes | ❌ No |
+| **Start dev server** | ✅ Yes | ✅ Yes |
+| **Time to run** | 3-5 minutes | 5-15 seconds |
+| **Use frequency** | Weekly/when needed | Daily |
+
+## Detailed Breakdown
+
+### `vets-start` - Full Sync & Setup
+
+**Steps performed:**
+1. Check git status
+2. **Pull latest from main** (if on main branch with clean working tree)
+3. Check Node/Yarn versions
+4. **Install/update dependencies** via jfrog proxy
+5. Start dev server
+
+**Best for:**
+- Monday morning "get everything up to date" routine
+- After being away from the project for a while
+- When you see dependency errors
+- First time setup
+
+**Example scenarios:**
+```bash
+# Monday morning - sync everything
+git checkout main
+vets-start
+
+# After vacation - get latest everything
+vets-start
+
+# Saw "Cannot find module" error
+vets-start
+```
+
+### `vets-dev` - Quick Start
+
+**Steps performed:**
+1. Navigate to project directory
+2. Start dev server
+
+**Best for:**
+- Daily development (Tuesday-Friday)
+- Restarting after making changes
+- When you know dependencies are current
+- Quick iteration
+
+**Example scenarios:**
+```bash
+# Starting work in the morning (no updates needed)
+vets-dev
+
+# Restarting after making changes
+vets-dev --entry=profile,auth
+
+# Testing with remote API
+vets-dev --api=https://dev-api.va.gov
+```
+
+## Weekly Workflow Example
+
+**Monday:**
+```bash
+vets-start  # Pull latest + update everything
+# Work all day...
+```
+
+**Tuesday-Friday:**
+```bash
+vets-dev    # Just start server, fast!
+# Work all day...
+```
+
+**After pulling changes yourself:**
+```bash
+git pull
+# If package.json changed:
+vets-start  # Update dependencies
+
+# If only code changed:
+vets-dev    # Just restart server
+```
+
+## Git Pull Behavior in vets-start
+
+The script handles different scenarios automatically:
+
+### ✅ Clean main branch
+```
+Current branch: main
+No uncommitted changes
+→ Automatically pulls from origin/main
+```
+
+### ⚠️  Uncommitted changes
+```
+Current branch: main
+You have uncommitted changes
+→ Skips git pull (commit or stash first)
+```
+
+### ⚠️  Feature branch
+```
+Current branch: feature/my-work
+→ Skips git pull (not on main)
+→ Tip shown to manually checkout main if needed
+```
+
+## Quick Decision Guide
+
+**Use `vets-start` when:**
+- It's Monday morning
+- You haven't worked on the project in days
+- package.json or yarn.lock changed
+- You see module/dependency errors
+- You want to sync with latest main
+
+**Use `vets-dev` when:**
+- You're in the middle of active development
+- You just need to restart the server
+- Dependencies are already current
+- You want to be coding in 10 seconds
+
+## TL;DR
+
+**`vets-start`**: "Update everything and get me ready to work" (slow, thorough)
+**`vets-dev`**: "Just start the damn server" (fast, minimal)

--- a/scripts/vets-website/STARTUP-INSTRUCTIONS.md
+++ b/scripts/vets-website/STARTUP-INSTRUCTIONS.md
@@ -1,0 +1,169 @@
+# Vets-Website Startup Instructions (with jfrog proxy)
+
+## Prerequisites
+
+- Node.js 22.x
+- Yarn 1.19.1
+- jfrog proxy configured in `~/.npmrc`
+
+## Build System Update
+
+**Important:** The platform has migrated from webpack to esbuild. Old webpack-based instructions are obsolete.
+
+### What Changed
+
+- ❌ ~~webpack~~ → ✅ esbuild
+- ❌ ~~`yarn watch --env entry=...`~~ → ✅ `yarn watch --entry=...`
+- ❌ No need to modify `config/webpack.config.js` (file doesn't exist anymore)
+- ❌ No need to install `copy-webpack-plugin`
+- ❌ No need to rename patches or do complex setup
+
+## Daily Startup
+
+### Option 1: Use the automated scripts (Recommended)
+
+```bash
+# Full setup (Monday morning routine)
+~/dotfiles/scripts/vets-website/start-vets-website.sh
+# Or: vets-start
+
+# Quick start (daily use)
+~/dotfiles/scripts/vets-website/dev.sh
+# Or: vets-dev
+```
+
+The full `start-vets-website.sh` script will:
+1. Pull latest changes from main (if on main branch with clean working tree)
+2. Check your Node and Yarn versions
+3. Install dependencies via jfrog proxy
+4. Start the dev server with common applications
+
+### Option 2: Manual commands
+
+If you prefer to run commands manually:
+
+```bash
+cd ~/Code/va.gov/vets-website
+
+# Pull latest and install dependencies
+git pull
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+
+# Start the dev server with specific applications
+yarn watch --entry=auth,login-page,profile,static-pages
+
+# Or with all education benefit apps
+yarn watch --entry=auth,login-page,profile,static-pages,terms-of-use,verify,virtual-agent,1990ez-edu-benefits,toe,survivor-dependent-education-benefit-22-5490,1995-edu-benefits,10297-edu-benefits,enrollment-verification,education-letters
+```
+
+## Common Commands
+
+| Task | Command |
+|------|---------|
+| Install dependencies | `NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe` |
+| List available apps | `yarn apps` |
+| Start dev server (all apps) | `yarn watch` |
+| Start dev server (specific apps) | `yarn watch --entry=app1,app2,app3` |
+| Build for production | `yarn build` |
+| Run tests | `yarn test` |
+| Start with remote API | `yarn watch --api=https://dev-api.va.gov` |
+
+## Understanding `yarn install-safe`
+
+This command is equivalent to:
+```bash
+yarn install --ignore-scripts && yarn postinstall
+```
+
+It's more secure because:
+- `--ignore-scripts` prevents potentially untrusted scripts from running during install
+- The custom `postinstall` script only runs scripts from trusted packages
+
+## Dev Server
+
+The dev server runs on `http://localhost:3001` by default.
+
+### Available Options
+
+```bash
+yarn watch [options]
+
+Options:
+  --entry=<apps>              Comma-separated list of app entry names
+  --api=<url>                 Remote API URL (proxied through dev server)
+  --port=<num>                Dev server port (default: 3001)
+  --host=<addr>               Dev server host (default: 127.0.0.1)
+  --scaffold                  Generate HTML scaffold pages
+  --verbose                   Show all esbuild output
+  --local-proxy-rewrite       Enable proxy for testing injected header/footer
+```
+
+### Example: Watch specific apps with remote API
+
+```bash
+yarn watch --entry=auth,profile --api=https://dev-api.va.gov
+```
+
+**Note:** When using a non-local API, you'll need to disable CORS in your browser.
+
+## Finding Application Entry Names
+
+Each application has a `manifest.json` file that contains its `entryName`. You can:
+
+1. List all apps:
+   ```bash
+   yarn apps
+   ```
+
+2. Or search manually:
+   ```bash
+   find src/applications -name "manifest.json" -exec grep -l "entryName" {} \;
+   ```
+
+## Troubleshooting
+
+### Certificate/SSL Issues with jfrog
+
+If you get SSL errors, ensure your command includes:
+```bash
+NODE_TLS_REJECT_UNAUTHORIZED=0
+```
+
+This is already included in the automated scripts.
+
+### Dependencies out of sync
+
+If you see weird errors after pulling changes:
+```bash
+# Clean and reinstall
+cd ~/Code/va.gov/vets-website
+rm -rf node_modules yarn.lock
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+```
+
+### Cypress binary not installed
+
+The postinstall script should handle this, but if needed:
+```bash
+npx cypress install
+```
+
+## What Happened to the Old Webpack Instructions?
+
+Old webpack-based instructions are obsolete. Here's the mapping:
+
+| Old (webpack) | New (esbuild) | Notes |
+|---------------|---------------|-------|
+| Remove yarn.lock & node_modules | Not needed | Clean install only when dependencies are broken |
+| Rename patches | Not needed | Patches directory doesn't exist anymore |
+| Install copy-webpack-plugin | Not needed | esbuild doesn't use webpack plugins |
+| Edit webpack.config.js | Not needed | File doesn't exist; esbuild config is different |
+| yarn watch --env entry=... | yarn watch --entry=... | Changed from --env to --entry |
+| Complex postinstall | yarn install-safe | Simplified and secured |
+
+## Additional Resources
+
+- [Platform Documentation](https://depo-platform-documentation.scrollhelp.site/developer-docs/Setting-up-your-local-frontend-environment.1844215878.html)
+- [esbuild Documentation](https://esbuild.github.io)
+- Main README: `~/Code/va.gov/vets-website/README.md`
+- Script comparison: `SCRIPT-COMPARISON.md` in this directory

--- a/scripts/vets-website/dev.sh
+++ b/scripts/vets-website/dev.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Quick daily dev server startup (assumes dependencies are already installed)
+#
+# Usage: ~/dotfiles/scripts/vets-website/dev.sh [options]
+#        Or use alias: vets-dev [options]
+#
+# Examples:
+#   vets-dev                                    # Start with default apps
+#   vets-dev --entry=auth,profile,static-pages  # Start with specific apps
+#   vets-dev --api=https://dev-api.va.gov       # Start with remote API
+
+set -e
+
+# Navigate to vets-website directory
+VETS_WEBSITE_DIR="$HOME/Code/va.gov/vets-website"
+
+if [ ! -d "$VETS_WEBSITE_DIR" ]; then
+  echo "ERROR: vets-website directory not found at $VETS_WEBSITE_DIR"
+  echo "Please update VETS_WEBSITE_DIR in this script to point to your vets-website location"
+  exit 1
+fi
+
+cd "$VETS_WEBSITE_DIR"
+
+# Default applications to load
+DEFAULT_APPS="auth,login-page,profile,static-pages,terms-of-use,verify,virtual-agent"
+
+# Education benefit apps (from your old workflow)
+EDU_APPS="1990ez-edu-benefits,toe,survivor-dependent-education-benefit-22-5490,1995-edu-benefits,10297-edu-benefits,enrollment-verification,education-letters"
+
+# Check if user provided app list
+if [ -n "$1" ]; then
+  # User provided apps or options, pass through
+  echo "Starting dev server with: $@"
+  yarn watch "$@"
+else
+  # Use default apps
+  echo "Starting dev server with default apps: $DEFAULT_APPS"
+  echo ""
+  echo "To start with different apps, use:"
+  echo "  vets-dev --entry=app1,app2,app3"
+  echo ""
+  echo "To include education apps, use:"
+  echo "  vets-dev --entry=$DEFAULT_APPS,$EDU_APPS"
+  echo ""
+  yarn watch --entry="$DEFAULT_APPS"
+fi

--- a/scripts/vets-website/start-vets-website.sh
+++ b/scripts/vets-website/start-vets-website.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# Daily startup script for vets-website
+# Updated for esbuild-based build system (post-webpack removal)
+#
+# This script handles:
+# - Git pull from main (if conditions are right)
+# - Clean dependency installation via jfrog proxy (configured in ~/.npmrc)
+# - Starting the dev server with specific applications
+#
+# Usage: ~/dotfiles/scripts/vets-website/start-vets-website.sh
+#        Or use alias: vets-start
+
+set -e  # Exit on error
+
+# Navigate to vets-website directory
+VETS_WEBSITE_DIR="$HOME/Code/va.gov/vets-website"
+
+if [ ! -d "$VETS_WEBSITE_DIR" ]; then
+  echo "ERROR: vets-website directory not found at $VETS_WEBSITE_DIR"
+  echo "Please update VETS_WEBSITE_DIR in this script to point to your vets-website location"
+  exit 1
+fi
+
+cd "$VETS_WEBSITE_DIR"
+echo "Working directory: $VETS_WEBSITE_DIR"
+echo ""
+
+echo "========================================"
+echo "Starting vets-website setup..."
+echo "========================================"
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Git pull from main
+echo -e "${BLUE}→ Checking git status...${NC}"
+CURRENT_BRANCH=$(git branch --show-current)
+echo "  Current branch: $CURRENT_BRANCH"
+
+# Check for uncommitted changes
+if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+  echo -e "${YELLOW}  ⚠ You have uncommitted changes${NC}"
+  echo "  Skipping git pull (commit or stash your changes first)"
+  echo ""
+else
+  if [ "$CURRENT_BRANCH" = "main" ]; then
+    echo "  Pulling latest changes from origin/main..."
+    if git pull origin main; then
+      echo -e "${GREEN}  ✓ Successfully pulled from main${NC}"
+    else
+      echo -e "${RED}  ✗ Git pull failed${NC}"
+      echo "  Continuing anyway..."
+    fi
+  else
+    echo -e "${YELLOW}  ⚠ Not on main branch${NC}"
+    echo "  Tip: Run 'git checkout main && git pull' if you want latest main"
+  fi
+  echo ""
+fi
+
+# Check Node version
+echo -e "${BLUE}→ Checking Node version...${NC}"
+NODE_VERSION=$(node --version)
+echo "  Node version: $NODE_VERSION (Required: >=22.0.0 <23)"
+echo ""
+
+# Check Yarn version
+echo -e "${BLUE}→ Checking Yarn version...${NC}"
+YARN_VERSION=$(yarn --version)
+echo "  Yarn version: $YARN_VERSION (Required: 1.19.1)"
+echo ""
+
+# Install dependencies using jfrog proxy
+# The --ignore-scripts flag prevents potentially untrusted scripts from running
+# The postinstall script runs only trusted package postinstall scripts
+echo -e "${BLUE}→ Installing dependencies via jfrog proxy...${NC}"
+echo "  (This uses NODE_TLS_REJECT_UNAUTHORIZED=0 for jfrog SSL)"
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+echo ""
+
+# Note: yarn install-safe is equivalent to:
+# yarn install --ignore-scripts && yarn postinstall
+# This approach is more secure as it only runs trusted postinstall scripts
+
+echo -e "${GREEN}✓ Installation complete!${NC}"
+echo ""
+
+# Start the dev server
+echo "========================================"
+echo "Starting development server..."
+echo "========================================"
+echo ""
+echo "Default applications loaded:"
+echo "  - auth"
+echo "  - login-page"
+echo "  - profile"
+echo "  - static-pages"
+echo "  - terms-of-use"
+echo "  - verify"
+echo "  - virtual-agent"
+echo ""
+echo "To add more applications, edit this script and modify the --entry parameter"
+echo "See available apps: yarn apps"
+echo ""
+
+# Start watch mode with specified applications
+# You can customize the --entry parameter to include the apps you need
+yarn watch --entry=auth,login-page,profile,static-pages,terms-of-use,verify,virtual-agent
+
+# Alternative: Start with all education benefit apps (from your old instructions)
+# yarn watch --entry=auth,login-page,profile,static-pages,terms-of-use,verify,virtual-agent,1990ez-edu-benefits,toe,survivor-dependent-education-benefit-22-5490,1995-edu-benefits,10297-edu-benefits,enrollment-verification,education-letters


### PR DESCRIPTION
## Summary

Adds workflow automation scripts for the VA.gov vets-website project with jfrog proxy support.

## Scripts Added

### Executable Scripts
- **start-vets-website.sh**: Full setup script (3-5 minutes)
  - Pulls latest from origin/main (if on clean main branch)
  - Installs/updates dependencies via jfrog proxy
  - Starts dev server with configurable applications

- **dev.sh**: Quick daily startup script (5-15 seconds)
  - Navigates to project directory
  - Starts dev server immediately
  - Assumes dependencies are current

### Documentation
- **README.md**: Overview and basic usage
- **QUICK-REFERENCE.md**: Command cheat sheet for daily workflow
- **SCRIPT-COMPARISON.md**: Detailed comparison of start vs dev scripts
- **STARTUP-INSTRUCTIONS.md**: Complete setup instructions and troubleshooting guide

## Key Features

✅ Automatic git pull from main (with smart detection of uncommitted changes)
✅ jfrog proxy support with NODE_TLS_REJECT_UNAUTHORIZED=0
✅ Modern esbuild-based workflow (replaces obsolete webpack instructions)
✅ Comprehensive documentation for different use cases
✅ Shell aliases recommended for quick access

## Usage

After merging, the aliases in ~/.zshrc.local already point to these scripts:
```bash
alias vets-start="~/dotfiles/scripts/vets-website/start-vets-website.sh"
alias vets-dev="~/dotfiles/scripts/vets-website/dev.sh"
alias vets-cd="cd ~/Code/va.gov/vets-website"
```

Monday routine: `vets-start` (pull + install + start)
Daily use: `vets-dev` (quick start)