### PR TITLE
Add cache and Sidekiq queue clearing on startup

### DIFF
--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -201,6 +201,24 @@ else
 fi
 echo ""
 
+# Clear Rails cache
+echo -e "${BLUE}→ Clearing Rails cache...${NC}"
+if bundle exec rails runner 'Rails.cache.clear' > /dev/null 2>&1; then
+  echo -e "${GREEN}  ✓ Rails cache cleared${NC}"
+else
+  echo -e "${YELLOW}  ⚠ Failed to clear Rails cache (continuing anyway)${NC}"
+fi
+echo ""
+
+# Clear Sidekiq queues
+echo -e "${BLUE}→ Clearing Sidekiq queues...${NC}"
+if bundle exec rails runner 'Sidekiq::Queue.all.each(&:clear); Sidekiq::RetrySet.new.clear; Sidekiq::ScheduledSet.new.clear' > /dev/null 2>&1; then
+  echo -e "${GREEN}  ✓ Sidekiq queues cleared${NC}"
+else
+  echo -e "${YELLOW}  ⚠ Failed to clear Sidekiq queues (continuing anyway)${NC}"
+fi
+echo ""
+
 echo -e "${GREEN}✓ Installation complete!${NC}"
 echo ""
 

--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -173,7 +173,7 @@ echo ""
 
 # Configure Bundler to mirror rubygems.org to jfrog
 echo -e "${BLUE}→ Configuring Bundler mirror...${NC}"
-bundle config mirror.https://rubygems.org https://jfrog.accenturefederaldev.com/artifactory/afs-gems-proxy
+bundle config set mirror.https://rubygems.org https://jfrog.accenturefederaldev.com/artifactory/afs-gems-proxy
 echo -e "${GREEN}  ✓ Bundler mirror configured${NC}"
 echo ""
 


### PR DESCRIPTION
## Summary
- Clear Rails cache before starting vets-api server to avoid stale data
- Clear Sidekiq queues (default, retry, and scheduled) for a fresh state on each startup
- Both operations fail gracefully if they encounter errors, allowing the server to start regardless

## Changes
Added two new steps to the `start-vets-api.sh` script that run after bundle install but before starting the Rails server:
1. Clear Rails cache using `Rails.cache.clear`
2. Clear all Sidekiq queues (default, retry, and scheduled sets)

## Test plan
- [x] Run the start script and verify cache clearing step executes
- [x] Run the start script and verify Sidekiq queue clearing step executes
- [x] Verify Rails server starts successfully after these steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)