### PR TITLE
Add content-build startup script and documentation

### DIFF
--- a/docs/content-build.md
+++ b/docs/content-build.md
@@ -1,0 +1,424 @@
+# content-build Development Guide
+
+## Overview
+
+content-build is the static content generator for VA.gov. It builds HTML pages from Liquid templates and Drupal content, and serves them alongside the vets-website application bundles.
+
+## Repository
+
+- **Location**: `~/Code/va.gov/content-build`
+- **GitHub**: https://va.ghe.com/software/content-build
+- **Main Branch**: `main`
+- **Port**: 3002 (dev server)
+
+## Quick Start
+
+### Using the Startup Script
+
+The easiest way to get content-build running:
+
+```bash
+content-build-start
+```
+
+Or run the script directly:
+
+```bash
+bash ~/dotfiles/scripts/content-build/start-content-build.sh
+```
+
+This script will:
+1. Pull latest changes from `main` branch (if no uncommitted changes)
+2. Prompt for optional branch checkout
+3. Install dependencies via jfrog proxy using `yarn install-safe`
+4. Optionally fetch latest Drupal content cache from S3
+5. Start the watch server (builds and serves content, watches for changes)
+6. Open a new Hyper tab with the watch server running
+
+### Manual Startup
+
+If you prefer to start manually:
+
+```bash
+cd ~/Code/va.gov/content-build
+yarn install-safe
+yarn watch
+```
+
+The site will be available at http://localhost:3002
+
+## Key Commands
+
+### Building Content
+
+```bash
+# Build all content once (no watch)
+yarn build
+
+# Build and watch for changes (also serves)
+yarn watch
+
+# Serve already-built content without watching
+yarn serve
+
+# Preview mode (adds routes for previewing Drupal nodes)
+yarn preview
+```
+
+### Content Cache
+
+```bash
+# Fetch latest content cache from S3 (faster than pulling from Drupal)
+yarn fetch-drupal-cache
+
+# Build with fresh content from Drupal (requires local VA CMS)
+yarn build --pull-drupal
+
+# Build with cached assets (skip downloading assets)
+yarn build --pull-drupal --use-cached-assets
+```
+
+### Testing
+
+```bash
+# Run all unit tests
+yarn test:unit
+
+# Run specific test file
+yarn test:unit src/site/filters/liquid.unit.spec.js
+
+# Run tests in watch mode
+yarn test:watch
+
+# Run Cypress E2E tests
+yarn cy:open   # Opens Cypress UI
+yarn cy:run    # Runs tests headlessly
+```
+
+### Linting
+
+```bash
+# Run all linters
+yarn lint
+
+# Run JavaScript linter
+yarn lint:js
+
+# Auto-fix linting issues
+yarn lint:js:fix
+
+# Lint only changed files
+yarn lint:changed
+```
+
+## Architecture
+
+### How content-build Works
+
+1. **Metalsmith Pipeline**: Uses Metalsmith to process templates and content
+2. **Liquid Templates**: Templates are written in Liquid (similar to Shopify's template language)
+3. **Drupal Content**: Fetches content from VA CMS (Drupal) via GraphQL
+4. **Static HTML**: Generates static HTML pages from templates + content
+5. **Symlink to vets-website**: Creates symlink to vets-website app bundles for integration
+
+### Directory Structure
+
+```
+content-build/
+├── src/
+│   ├── applications/        # Application registry and configurations
+│   ├── site/
+│   │   ├── stages/          # Build pipeline stages
+│   │   │   ├── build/       # Build-time processing
+│   │   │   │   └── drupal/  # Drupal content queries
+│   │   │   └── html/        # HTML generation
+│   │   ├── layouts/         # Page layout templates (Liquid)
+│   │   ├── includes/        # Reusable template partials
+│   │   ├── filters/         # Custom Liquid filters
+│   │   └── paragraphs/      # Drupal paragraph templates
+│   ├── platform/            # Shared platform code
+│   └── js/                  # JavaScript for static pages
+├── script/                  # Build and utility scripts
+├── config/                  # Webpack and environment configs
+├── .cache/                  # Cached Drupal content (gitignored)
+└── build/                   # Output directory (gitignored)
+```
+
+## Configuration
+
+### Environment Variables (.env file)
+
+content-build uses a `.env` file for Drupal configuration:
+
+```bash
+# Copy example file
+cp .env.example .env
+
+# Edit with your settings
+DRUPAL_ADDRESS=https://cms-8ry6zt2asg946vdfuiryyamuc9gkuyzc.demo.cms.va.gov/
+DRUPAL_USERNAME=content_build_api
+DRUPAL_PASSWORD=drupal8
+```
+
+**Note**: For production CMS access, request credentials in [#cms-support](https://dsva.slack.com/archives/CDHBKAL9W)
+
+### Build Optimization
+
+Building all content can take 8+ hours. To speed up local development:
+
+1. **Comment out unused content types** in `src/site/stages/build/drupal/individual-queries.js`:
+
+```javascript
+function getNodeQueries(entityCounts) {
+  return {
+    ...getNodePageQueries(entityCounts),
+    GetNodeLandingPages,
+    GetCampaignLandingPages,
+    GetNodeBasicLandingPage,
+    // Comment out content types you don't need:
+    // ...getNodeVaFormQueries(entityCounts),
+    // ...getNodeHealthCareRegionPageQueries(entityCounts),
+    // ...getNewsStoryQueries(entityCounts),
+    // ...getNodeEventQueries(entityCounts),
+    // etc.
+  };
+}
+```
+
+2. **Skip asset downloads** by commenting out in `src/site/stages/build/index.js`:
+
+```javascript
+// smith.use(downloadDrupalAssets(BUILD_OPTIONS), 'Download Drupal assets');
+```
+
+3. **Clear cache** and rebuild:
+
+```bash
+rm -rf .cache/localhost/drupal/pages.json
+yarn build --pull-drupal && yarn watch
+```
+
+## Integration with vets-website
+
+content-build creates a symlink to vets-website's built applications:
+
+```
+content-build/build/localhost/generated → vets-website/build/localhost/generated
+```
+
+This allows content-build to serve both:
+- Static content pages (from templates)
+- Application bundles (from vets-website)
+
+**Important**: Make sure vets-website is built before running content-build if you need to test applications.
+
+## Common Tasks
+
+### Working on a Feature Branch
+
+The startup script handles branch switching:
+
+```bash
+content-build-start
+# → Prompts: "Run watch server on a different branch? (y/N):"
+# → Enter: y
+# → Enter branch name: feature/my-feature
+```
+
+Or manually:
+
+```bash
+cd ~/Code/va.gov/content-build
+git checkout feature/my-feature
+git pull origin feature/my-feature
+yarn watch
+```
+
+### Testing Template Changes
+
+1. Start watch server: `yarn watch`
+2. Edit Liquid templates in `src/site/layouts/` or `src/site/includes/`
+3. Watch server automatically rebuilds on template changes
+4. Refresh browser at http://localhost:3002 to see changes
+
+### Testing with Fresh Drupal Content
+
+```bash
+# Ensure local VA CMS is running
+yarn build --pull-drupal
+
+# Then start watch server
+yarn watch
+```
+
+### Running with vets-website
+
+For full integration testing:
+
+```bash
+# Terminal 1: Start vets-website
+cd ~/Code/va.gov/vets-website
+yarn watch --entry=your-app
+
+# Terminal 2: Start content-build
+cd ~/Code/va.gov/content-build
+yarn watch
+
+# Or use the all-in-one script:
+vets-start-all  # Starts vets-api, vets-website, and content-build
+```
+
+## Troubleshooting
+
+### Build Fails with Template Error
+
+If markdown file exists in `vagov-content` but template is deleted:
+
+```bash
+cd ~/Code/va.gov/vagov-content
+git pull origin main
+cd ~/Code/va.gov/content-build
+yarn build
+```
+
+### Port 3002 Already in Use
+
+```bash
+# Find and kill the process
+lsof -ti:3002 | xargs kill -9
+
+# Or use a different port
+yarn serve --port 3003
+```
+
+### Symlink to vets-website Not Working
+
+```bash
+# content-build creates symlink automatically, but you can recreate it:
+cd ~/Code/va.gov/content-build/build/localhost
+rm -f generated
+ln -s ../../../vets-website/build/localhost/generated generated
+```
+
+### Drupal Content Not Loading
+
+1. Check `.env` file exists and has valid credentials
+2. Fetch latest cache: `yarn fetch-drupal-cache`
+3. Or rebuild from Drupal: `yarn build --pull-drupal`
+
+### Out of Memory During Build
+
+The build uses high memory limits. If you still run out:
+
+```bash
+# Increase Node memory limit (default is 12288 MB)
+node --max-old-space-size=16384 --expose-gc script/build-content.js
+```
+
+## Useful Resources
+
+### Documentation
+
+- [Platform Docs](https://depo-platform-documentation.scrollhelp.site/developer-docs/)
+- [Setting up local frontend environment](https://depo-platform-documentation.scrollhelp.site/developer-docs/Setting-up-your-local-frontend-environment.1844215878.html)
+- [GitHub Codespaces Guide](https://depo-platform-documentation.scrollhelp.site/developer-docs/Using-GitHub-Codespaces.1909063762.html)
+
+### Slack Channels
+
+- **#vfs-platform-support** - General platform questions
+- **#cms-support** - Drupal/CMS questions
+- **#vets-website** - Frontend questions
+- **#content-build** - content-build specific questions
+
+## Node & Yarn Versions
+
+```json
+{
+  "engines": {
+    "node": ">=22.22.0",
+    "yarn": "1.19.1"
+  }
+}
+```
+
+### Version Management
+
+If you need to switch Node versions:
+
+```bash
+# Using nvm
+nvm use 22
+
+# Or install specific version
+nvm install 22.22.0
+nvm use 22.22.0
+```
+
+## Git Workflow
+
+### Creating a Feature Branch
+
+```bash
+cd ~/Code/va.gov/content-build
+git checkout main
+git pull origin main
+git checkout -b feature/my-feature-name
+
+# Make changes, commit, push
+git add .
+git commit -m "Description of changes"
+git push origin feature/my-feature-name
+```
+
+### Pull Request
+
+```bash
+# After pushing your branch
+gh pr create --title "Your PR title" --body "Description"
+
+# Or create PR on GitHub
+open https://va.ghe.com/software/content-build/compare
+```
+
+## Related Repositories
+
+- **vets-website**: React applications (`~/Code/va.gov/vets-website`)
+- **vets-api**: Rails API backend (`~/Code/va.gov/vets-api`)
+- **vagov-content**: Markdown content (`~/Code/va.gov/vagov-content`)
+- **va.gov-cms**: Drupal CMS (separate infrastructure)
+
+## Aliases & Scripts
+
+All VA.gov startup scripts are located in `~/dotfiles/scripts/`:
+
+```bash
+# Start individual services
+content-build-start   # Start content-build
+vets-start           # Start vets-website
+vets-api-start       # Start vets-api
+
+# Start all services at once
+vets-start-all       # Starts vets-api + vets-website + content-build
+```
+
+## Performance Tips
+
+1. **Use content cache**: `yarn fetch-drupal-cache` is much faster than pulling from Drupal
+2. **Optimize queries**: Comment out unused content types in `individual-queries.js`
+3. **Skip assets**: Comment out `downloadDrupalAssets` for faster builds
+4. **Incremental builds**: Use `yarn watch` for live reload instead of full rebuilds
+5. **Limit scope**: Only build the content types you're actively working on
+
+## Production Builds
+
+Building for production environments:
+
+```bash
+# Build for staging
+yarn build --buildtype=vagovstaging
+
+# Build for production
+NODE_ENV=production yarn build --buildtype=vagovprod
+```
+
+**Note**: Production builds disable dev features and enable optimizations.

--- a/home/zsh/aliases.zsh
+++ b/home/zsh/aliases.zsh
@@ -54,4 +54,5 @@ command -v bat &>/dev/null && alias cat='bat --paging=never'
 # VA.gov development shortcuts (use $DOTFILES_DIR for portability)
 alias vets-api-start='bash $DOTFILES_DIR/scripts/vets-api/start-vets-api.sh'
 alias vets-start='bash $DOTFILES_DIR/scripts/vets-website/start-vets-website.sh'
+alias content-build-start='bash $DOTFILES_DIR/scripts/content-build/start-content-build.sh'
 alias vets-start-all='bash $DOTFILES_DIR/scripts/start-all-vets.sh'

--- a/scripts/content-build/start-content-build.sh
+++ b/scripts/content-build/start-content-build.sh
@@ -1,0 +1,230 @@
+#!/bin/bash
+# Daily startup script for content-build
+#
+# This script handles:
+# - Git pull from main (if conditions are right)
+# - Clean dependency installation via jfrog proxy (configured in ~/.npmrc)
+# - Fetching Drupal cache content (optional)
+# - Starting the watch server (builds static content and serves)
+#
+# Usage: ~/dotfiles/scripts/content-build/start-content-build.sh
+#        Or use alias: content-build-start
+
+set -e  # Exit on error
+
+# Navigate to content-build directory
+CONTENT_BUILD_DIR="$HOME/Code/va.gov/content-build"
+
+if [ ! -d "$CONTENT_BUILD_DIR" ]; then
+  echo "ERROR: content-build directory not found at $CONTENT_BUILD_DIR"
+  echo "Please update CONTENT_BUILD_DIR in this script to point to your content-build location"
+  exit 1
+fi
+
+cd "$CONTENT_BUILD_DIR"
+echo "Working directory: $CONTENT_BUILD_DIR"
+echo ""
+
+echo "========================================"
+echo "Starting content-build setup..."
+echo "========================================"
+echo ""
+
+# Colors for output
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Git branch management and pull from main
+echo -e "${BLUE}→ Checking git status...${NC}"
+CURRENT_BRANCH=$(git branch --show-current)
+echo "  Current branch: $CURRENT_BRANCH"
+
+# Check for uncommitted changes
+if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+  echo -e "${YELLOW}  ⚠ You have uncommitted changes${NC}"
+  echo "  Skipping git operations (commit or stash your changes first)"
+  echo ""
+  BRANCH_TO_USE="$CURRENT_BRANCH"
+else
+  # Checkout and pull from main
+  if [ "$CURRENT_BRANCH" != "main" ]; then
+    echo "  Switching to main branch..."
+    if git checkout main; then
+      echo -e "${GREEN}  ✓ Switched to main${NC}"
+    else
+      echo -e "${RED}  ✗ Failed to checkout main${NC}"
+      echo "  Continuing with current branch: $CURRENT_BRANCH"
+      BRANCH_TO_USE="$CURRENT_BRANCH"
+    fi
+  fi
+
+  # Pull latest from main
+  echo "  Pulling latest changes from origin/main..."
+  if git pull origin main; then
+    echo -e "${GREEN}  ✓ Successfully pulled from main${NC}"
+  else
+    echo -e "${RED}  ✗ Git pull failed${NC}"
+    echo "  Continuing anyway..."
+  fi
+  echo ""
+
+  # Interactive branch selection
+  echo -e "${BLUE}→ Branch selection for watch server...${NC}"
+  echo "  Current branch: main"
+  echo ""
+  read -p "Run watch server on a different branch? (y/N): " SWITCH_BRANCH
+
+  if [[ $SWITCH_BRANCH =~ ^[Yy]$ ]]; then
+    echo ""
+    read -p "Enter branch name: " BRANCH_NAME
+
+    if [ -n "$BRANCH_NAME" ]; then
+      echo "  Switching to branch: $BRANCH_NAME"
+      if git checkout "$BRANCH_NAME"; then
+        echo -e "${GREEN}  ✓ Switched to $BRANCH_NAME${NC}"
+        BRANCH_TO_USE="$BRANCH_NAME"
+      else
+        echo -e "${RED}  ✗ Failed to checkout $BRANCH_NAME${NC}"
+        echo "  Continuing with main branch"
+        BRANCH_TO_USE="main"
+      fi
+    else
+      echo -e "${YELLOW}  No branch name provided, using main${NC}"
+      BRANCH_TO_USE="main"
+    fi
+  else
+    BRANCH_TO_USE="main"
+  fi
+  echo ""
+  echo -e "${GREEN}  → Watch server will run on branch: $BRANCH_TO_USE${NC}"
+  echo ""
+fi
+
+# Check Node version
+echo -e "${BLUE}→ Checking Node version...${NC}"
+NODE_VERSION=$(node --version)
+echo "  Node version: $NODE_VERSION (Required: >=22.22.0)"
+echo ""
+
+# Check Yarn version
+echo -e "${BLUE}→ Checking Yarn version...${NC}"
+YARN_VERSION=$(yarn --version)
+echo "  Yarn version: $YARN_VERSION (Required: 1.19.1)"
+echo ""
+
+# Install dependencies using jfrog proxy
+# The install-safe command handles security concerns with postinstall scripts
+echo -e "${BLUE}→ Installing dependencies via jfrog proxy...${NC}"
+echo "  (This uses NODE_TLS_REJECT_UNAUTHORIZED=0 for jfrog SSL)"
+NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+echo ""
+
+# Note: yarn install-safe is equivalent to:
+# yarn install --ignore-scripts && yarn run-postinstall
+# This approach is more secure as it only runs trusted postinstall scripts
+
+echo -e "${GREEN}✓ Installation complete!${NC}"
+echo ""
+
+# Optional: Fetch Drupal cache content
+echo -e "${BLUE}→ Drupal content cache...${NC}"
+echo "  Content-build can use cached Drupal content for faster builds"
+echo "  The cached content is stored in .cache/localhost/"
+echo ""
+read -p "Fetch latest Drupal content cache from S3? (y/N): " FETCH_CACHE
+
+if [[ $FETCH_CACHE =~ ^[Yy]$ ]]; then
+  echo ""
+  echo -e "${BLUE}→ Fetching Drupal cache from S3...${NC}"
+  if yarn fetch-drupal-cache; then
+    echo -e "${GREEN}  ✓ Drupal cache fetched successfully${NC}"
+  else
+    echo -e "${RED}  ✗ Failed to fetch Drupal cache${NC}"
+    echo "  Continuing anyway (will use existing cache or fetch on first build)"
+  fi
+else
+  echo -e "${YELLOW}  Skipping Drupal cache fetch${NC}"
+  echo "  Note: Run 'yarn fetch-drupal-cache' manually if needed"
+fi
+echo ""
+
+# Check for .env file with Drupal credentials
+echo -e "${BLUE}→ Checking Drupal configuration...${NC}"
+if [ -f "$CONTENT_BUILD_DIR/.env" ]; then
+  echo -e "${GREEN}  ✓ Found .env file with Drupal credentials${NC}"
+
+  # Show current Drupal endpoint (without exposing password)
+  if grep -q "DRUPAL_ADDRESS" .env; then
+    DRUPAL_ADDR=$(grep "DRUPAL_ADDRESS" .env | cut -d'=' -f2)
+    echo "  Drupal endpoint: $DRUPAL_ADDR"
+  fi
+else
+  echo -e "${YELLOW}  ⚠ No .env file found${NC}"
+  echo "  To pull fresh content from Drupal, copy .env.example to .env"
+  echo "  and configure your Drupal credentials"
+fi
+echo ""
+
+# Start the watch server
+echo "========================================"
+echo "Starting watch server..."
+echo "========================================"
+echo ""
+echo "The watch server will:"
+echo "  - Build static HTML content from templates"
+echo "  - Watch for template/CSS changes and rebuild"
+echo "  - Serve the site on http://localhost:3002"
+echo "  - Create symlink to vets-website apps (../vets-website/build/localhost/generated)"
+echo ""
+echo "Note: Initial build can take time depending on content"
+echo ""
+echo "To optimize build time (skip templates you don't need):"
+echo "  - Edit src/site/stages/build/drupal/individual-queries.js"
+echo "  - Comment out content types you won't be testing"
+echo ""
+
+# Start watch mode in a new Hyper tab
+echo "Opening watch server in new Hyper tab..."
+osascript <<EOF
+tell application "Hyper"
+    activate
+    delay 0.3
+    tell application "System Events"
+        keystroke "t" using {command down}
+        delay 0.5
+        keystroke "cd '$CONTENT_BUILD_DIR' && yarn watch"
+        keystroke return
+    end tell
+end tell
+EOF
+
+# Wait for server to be ready
+echo "Waiting for watch server to start..."
+echo "(This may take a few minutes on first run while building content)"
+for i in {1..120}; do
+  if curl -s -o /dev/null http://localhost:3002; then
+    echo -e "${GREEN}✓ Watch server is ready at http://localhost:3002${NC}"
+    break
+  fi
+  sleep 2
+done
+
+echo ""
+echo -e "${GREEN}✓ Setup complete!${NC}"
+echo ""
+echo "Watch server is running in the new Hyper tab."
+echo "You can monitor build progress and errors there."
+echo "To stop the server, use Ctrl+C in that tab."
+echo ""
+echo "Useful commands:"
+echo "  - yarn serve         : Start static server without watching"
+echo "  - yarn build         : Build all content once (no watch)"
+echo "  - yarn preview       : Add preview routes for Drupal nodes"
+echo "  - yarn test:unit     : Run unit tests"
+echo ""
+echo "Content-build connects to vets-website apps via symlink"
+echo "Make sure vets-website is built and running if testing applications"
+echo ""

--- a/scripts/start-all-vets.sh
+++ b/scripts/start-all-vets.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
-# Start both vets-api and vets-website simultaneously
+# Start vets-api, vets-website, and content-build simultaneously
 #
 # This script handles:
-# - Running both start scripts in parallel
+# - Running all start scripts in parallel
 # - Opening multiple Hyper tabs for each service
 # - Coordinated startup with proper ordering
 #
@@ -22,13 +22,14 @@ NC='\033[0m' # No Color
 DOTFILES_DIR="$HOME/dotfiles"
 VETS_API_SCRIPT="$DOTFILES_DIR/scripts/vets-api/start-vets-api.sh"
 VETS_WEBSITE_SCRIPT="$DOTFILES_DIR/scripts/vets-website/start-vets-website.sh"
+CONTENT_BUILD_SCRIPT="$DOTFILES_DIR/scripts/content-build/start-content-build.sh"
 
 echo "========================================"
 echo "Starting ALL VA.gov Services"
 echo "========================================"
 echo ""
 
-# Check that both scripts exist
+# Check that all scripts exist
 if [ ! -f "$VETS_API_SCRIPT" ]; then
   echo -e "${RED}ERROR: vets-api start script not found at $VETS_API_SCRIPT${NC}"
   exit 1
@@ -39,9 +40,15 @@ if [ ! -f "$VETS_WEBSITE_SCRIPT" ]; then
   exit 1
 fi
 
+if [ ! -f "$CONTENT_BUILD_SCRIPT" ]; then
+  echo -e "${RED}ERROR: content-build start script not found at $CONTENT_BUILD_SCRIPT${NC}"
+  exit 1
+fi
+
 echo -e "${BLUE}Starting services in order:${NC}"
 echo "  1. vets-api (Rails backend)"
 echo "  2. vets-website (React frontend)"
+echo "  3. content-build (Static content generator)"
 echo ""
 
 # Start vets-api in the first tab
@@ -83,7 +90,28 @@ EOF
 echo -e "${GREEN}  ✓ vets-website setup started in new tab${NC}"
 echo ""
 
-# Wait for both services to be ready
+# Wait a moment for the vets-website tab to initialize
+sleep 2
+
+# Start content-build in the third tab
+echo -e "${BLUE}→ Launching content-build setup...${NC}"
+osascript <<EOF
+tell application "Hyper"
+    activate
+    delay 0.3
+    tell application "System Events"
+        keystroke "t" using {command down}
+        delay 0.5
+        keystroke "$CONTENT_BUILD_SCRIPT"
+        keystroke return
+    end tell
+end tell
+EOF
+
+echo -e "${GREEN}  ✓ content-build setup started in new tab${NC}"
+echo ""
+
+# Wait for all services to be ready
 echo "========================================"
 echo "Waiting for services to start..."
 echo "========================================"
@@ -117,6 +145,20 @@ for i in {1..60}; do
 done
 echo ""
 
+# Wait for content-build (port 3002)
+echo -e "${BLUE}→ Checking content-build...${NC}"
+for i in {1..120}; do
+  if curl -s -o /dev/null http://localhost:3002; then
+    echo -e "${GREEN}  ✓ content-build is ready at http://localhost:3002${NC}"
+    break
+  fi
+  if [ $i -eq 120 ]; then
+    echo -e "${YELLOW}  ⚠ content-build not responding yet (may still be building)${NC}"
+  fi
+  sleep 2
+done
+echo ""
+
 echo "========================================"
 echo -e "${GREEN}✓ All services launched!${NC}"
 echo "========================================"
@@ -124,6 +166,7 @@ echo ""
 echo "Service endpoints:"
 echo "  - vets-api:     http://localhost:3000"
 echo "  - vets-website: http://localhost:3001"
+echo "  - content-build: http://localhost:3002"
 echo ""
 echo "Useful vets-api endpoints:"
 echo "  - Flipper features: http://localhost:3000/flipper/features"


### PR DESCRIPTION
## Summary
Adds comprehensive support for the content-build repository with startup scripts, aliases, and documentation following the existing patterns established for vets-api and vets-website.

This change enables quick startup of content-build with:
- Automated git branch management and dependency installation via jfrog proxy
- Optional Drupal content cache fetching from S3
- Integration with the unified `vets-start-all` script to launch all three VA.gov services
- New `content-build-start` alias for easy access
- Comprehensive documentation covering setup, commands, architecture, and troubleshooting

## Type
- [x] Feature
- [ ] Fix
- [ ] Refactor / chore
- [ ] Docs

## Validation
- [x] `shellcheck -S warning` on changed bash; `zsh -n` on changed zsh files
- [ ] Ran the bats suite (`bats scripts/tests/`)
- [ ] Exercised install/verify against an isolated `HOME=$(mktemp -d)` (if behavior changed)

## Checklist
- [ ] New tracked dotfile? Added a line to `config/symlinks.map` and a row to the README table
- [ ] Changed a real `bootstrap.sh` step? Updated its `--dry-run` preview in `scripts/lib/dryrun_helpers.sh`
- [x] Updated docs (`README.md` / `docs/`) and the `CHANGELOG.md` `[Unreleased]` section as needed
- [x] No secrets or machine-specific values committed (gitleaks runs in CI and pre-commit)

## Notes
**Files Changed:**
- `scripts/content-build/start-content-build.sh` - New startup script with branch management, dependency installation, and Drupal cache fetching
- `docs/content-build.md` - Comprehensive 400+ line guide covering all aspects of content-build development
- `home/zsh/aliases.zsh` - Added `content-build-start` alias
- `scripts/start-all-vets.sh` - Updated to launch content-build as third service on port 3002

**Usage:**
```bash
# Start content-build alone
content-build-start

# Start all VA.gov services (vets-api, vets-website, content-build)
vets-start-all
```