### PR TITLE
Add database migrations and seeding to startup script

### DIFF
--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -285,6 +285,28 @@ else
 fi
 echo ""
 
+# Run database migrations
+echo -e "${BLUE}→ Running database migrations...${NC}"
+if bundle exec rails db:migrate; then
+  echo -e "${GREEN}  ✓ Database migrations completed${NC}"
+else
+  echo -e "${RED}  ✗ Database migrations failed${NC}"
+  echo "  Cannot start server without successful migrations"
+  exit 1
+fi
+echo ""
+
+# Seed database
+echo -e "${BLUE}→ Seeding database...${NC}"
+if bundle exec rails db:seed; then
+  echo -e "${GREEN}  ✓ Database seeded${NC}"
+else
+  echo -e "${RED}  ✗ Database seeding failed${NC}"
+  echo "  Cannot start server without successful seeding"
+  exit 1
+fi
+echo ""
+
 # Clear Rails cache
 echo -e "${BLUE}→ Clearing Rails cache...${NC}"
 if bundle exec rails runner 'Rails.cache.clear' > /dev/null 2>&1; then

--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -290,9 +290,17 @@ echo -e "${BLUE}→ Running database migrations...${NC}"
 if bundle exec rails db:migrate; then
   echo -e "${GREEN}  ✓ Database migrations completed${NC}"
 else
-  echo -e "${RED}  ✗ Database migrations failed${NC}"
-  echo "  Cannot start server without successful migrations"
-  exit 1
+  echo -e "${YELLOW}  ⚠ Database migrations failed${NC}"
+  echo "  Attempting fallback: rails db:schema:load"
+  echo ""
+
+  if bundle exec rails db:schema:load; then
+    echo -e "${GREEN}  ✓ Database schema loaded successfully${NC}"
+  else
+    echo -e "${RED}  ✗ Both db:migrate and db:schema:load failed${NC}"
+    echo "  Cannot start server without a valid database"
+    exit 1
+  fi
 fi
 echo ""
 

--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -287,17 +287,31 @@ echo ""
 
 # Run database migrations
 echo -e "${BLUE}→ Running database migrations...${NC}"
-if bundle exec rails db:migrate; then
-  echo -e "${GREEN}  ✓ Database migrations completed${NC}"
+MIGRATE_OUTPUT=$(bundle exec rails db:migrate 2>&1)
+MIGRATE_STATUS=$?
+
+if [ $MIGRATE_STATUS -eq 0 ]; then
+  # Check if there were any migrations to run
+  if echo "$MIGRATE_OUTPUT" | grep -q "Migrating to"; then
+    echo -e "${GREEN}  ✓ Database migrations applied${NC}"
+    echo "$MIGRATE_OUTPUT" | grep "Migrating to" | sed 's/^/    /'
+  else
+    echo -e "${GREEN}  ✓ Database is up to date (no pending migrations)${NC}"
+  fi
 else
   echo -e "${YELLOW}  ⚠ Database migrations failed${NC}"
-  echo "  Attempting fallback: rails db:schema:load"
+  echo "$MIGRATE_OUTPUT" | sed 's/^/    /'
   echo ""
+  echo -e "${BLUE}  → Attempting fallback: rails db:schema:load...${NC}"
 
-  if bundle exec rails db:schema:load; then
+  SCHEMA_OUTPUT=$(bundle exec rails db:schema:load 2>&1)
+  SCHEMA_STATUS=$?
+
+  if [ $SCHEMA_STATUS -eq 0 ]; then
     echo -e "${GREEN}  ✓ Database schema loaded successfully${NC}"
   else
     echo -e "${RED}  ✗ Both db:migrate and db:schema:load failed${NC}"
+    echo "$SCHEMA_OUTPUT" | sed 's/^/    /'
     echo "  Cannot start server without a valid database"
     exit 1
   fi
@@ -306,10 +320,20 @@ echo ""
 
 # Seed database
 echo -e "${BLUE}→ Seeding database...${NC}"
-if bundle exec rails db:seed; then
-  echo -e "${GREEN}  ✓ Database seeded${NC}"
+SEED_OUTPUT=$(bundle exec rails db:seed 2>&1)
+SEED_STATUS=$?
+
+if [ $SEED_STATUS -eq 0 ]; then
+  # Show summary of what was seeded if available
+  if echo "$SEED_OUTPUT" | grep -q "Created\|Seeded\|Added"; then
+    echo -e "${GREEN}  ✓ Database seeded${NC}"
+    echo "$SEED_OUTPUT" | grep -E "Created|Seeded|Added" | sed 's/^/    /'
+  else
+    echo -e "${GREEN}  ✓ Database seeding completed${NC}"
+  fi
 else
   echo -e "${RED}  ✗ Database seeding failed${NC}"
+  echo "$SEED_OUTPUT" | sed 's/^/    /'
   echo "  Cannot start server without successful seeding"
   exit 1
 fi


### PR DESCRIPTION
## Summary
Adds database migration and seeding steps to the vets-api startup script to ensure the database is up to date before starting the server. Includes fallback mechanism for when migrations fail.

## Changes
- Run `rails db:migrate` before starting the server
- If migrations fail, fallback to `rails db:schema:load` 
- Run `rails db:seed` to populate the database
- Exit only if both migration approaches fail (with clear error messages)
- Ensures database schema is current and data is seeded

## Why?
Without running migrations, the server may fail to start or have runtime errors due to missing database schema changes. The seeding step ensures test data is available for development.

The `db:schema:load` fallback handles cases where:
- Migrations are in a broken state
- Database needs to be rebuilt from scratch
- Migration history has issues

## Test plan
- [x] Run `vets-api-start` and verify migrations run
- [x] Run `vets-api-start` and verify seeding runs
- [x] Test with pending migrations - verify they apply successfully
- [x] Test with migration failure - verify fallback to schema:load
- [x] Test with both failing - verify script exits with error

## Usage
When running `vets-api-start`, you'll now see:
```
→ Running database migrations...
  ✓ Database migrations completed

→ Seeding database...
  ✓ Database seeded
```

Or if migrations fail:
```
→ Running database migrations...
  ⚠ Database migrations failed
  Attempting fallback: rails db:schema:load

  ✓ Database schema loaded successfully
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)