### PR TITLE
Improve terminal selector UX to display options upfront

### DIFF
--- a/scripts/content-build/start-content-build.sh
+++ b/scripts/content-build/start-content-build.sh
@@ -17,6 +17,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="${DOTFILES_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 source "$DOTFILES_DIR/scripts/lib/terminal_helpers.sh"
 
+# Ensure terminal is configured before starting
+ensure_terminal_configured
+
 # Navigate to content-build directory
 CONTENT_BUILD_DIR="$HOME/Code/va.gov/content-build"
 

--- a/scripts/lib/terminal_helpers.sh
+++ b/scripts/lib/terminal_helpers.sh
@@ -6,21 +6,30 @@ TERMINAL_CONFIG_FILE="$HOME/.dotfiles_terminal_preference"
 
 # Get the user's preferred terminal emulator
 # If not set, prompt them to choose and store the preference
+# Pass "quiet" as first argument to suppress output after setup
 get_terminal_emulator() {
+  local quiet_mode="$1"
+
   if [ -f "$TERMINAL_CONFIG_FILE" ]; then
     cat "$TERMINAL_CONFIG_FILE"
     return 0
   fi
 
   # No preference stored, prompt user
+  echo ""
   echo "========================================"
-  echo "Terminal Emulator Selection"
+  echo "⚙️  First-Time Terminal Setup Required"
   echo "========================================"
   echo ""
-  echo "Select your terminal emulator:"
+  echo "This script needs to open new terminal tabs."
+  echo "Please select your terminal emulator:"
+  echo ""
   echo "  1) Hyper"
   echo "  2) macOS Terminal (Terminal.app)"
   echo "  3) iTerm2"
+  echo ""
+  echo "Your choice will be saved for future use."
+  echo "(Run 'reset_terminal_preference' to change later)"
   echo ""
   read -r -p "Enter choice [1-3] (default: 2): " TERMINAL_CHOICE
   echo ""
@@ -36,17 +45,31 @@ get_terminal_emulator() {
       TERMINAL="iTerm"
       ;;
     *)
-      echo "Invalid choice. Defaulting to macOS Terminal."
+      echo "⚠️  Invalid choice. Defaulting to macOS Terminal."
       TERMINAL="Terminal"
       ;;
   esac
 
   # Store the preference
   echo "$TERMINAL" > "$TERMINAL_CONFIG_FILE"
-  echo "Terminal preference saved: $TERMINAL"
+  echo "✓ Terminal preference saved: $TERMINAL"
   echo ""
 
-  echo "$TERMINAL"
+  # Output terminal name for command substitution (unless in quiet mode)
+  if [ "$quiet_mode" != "quiet" ]; then
+    cat "$TERMINAL_CONFIG_FILE"
+  fi
+}
+
+# Ensure terminal preference is set before running scripts
+# Call this at the start of scripts that use open_terminal_tab
+# This ensures the terminal selection happens upfront, not mid-execution
+ensure_terminal_configured() {
+  if [ ! -f "$TERMINAL_CONFIG_FILE" ]; then
+    # Terminal not configured yet - trigger the setup in quiet mode
+    # This displays the menu and confirmation but not the redundant terminal name
+    get_terminal_emulator quiet
+  fi
 }
 
 # Open a new tab and execute a command

--- a/scripts/start-all-vets.sh
+++ b/scripts/start-all-vets.sh
@@ -16,6 +16,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="${DOTFILES_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
 source "$DOTFILES_DIR/scripts/lib/terminal_helpers.sh"
 
+# Ensure terminal is configured before starting
+# This prompts the user upfront if needed, not mid-execution
+ensure_terminal_configured
+
 # Colors for output
 GREEN='\033[0;32m'
 BLUE='\033[0;34m'

--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -17,6 +17,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="${DOTFILES_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 source "$DOTFILES_DIR/scripts/lib/terminal_helpers.sh"
 
+# Ensure terminal is configured before starting
+ensure_terminal_configured
+
 # Navigate to vets-api directory
 VETS_API_DIR="$HOME/Code/va.gov/vets-api"
 VETS_API_MOCKDATA_DIR="$HOME/Code/va.gov/vets-api-mockdata"

--- a/scripts/vets-website/start-vets-website.sh
+++ b/scripts/vets-website/start-vets-website.sh
@@ -17,6 +17,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOTFILES_DIR="${DOTFILES_DIR:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
 source "$DOTFILES_DIR/scripts/lib/terminal_helpers.sh"
 
+# Ensure terminal is configured before starting
+ensure_terminal_configured
+
 # Navigate to vets-website directory
 VETS_WEBSITE_DIR="$HOME/Code/va.gov/vets-website"
 


### PR DESCRIPTION
## Summary

Fixes an issue where the terminal emulator selection prompt would interrupt script execution mid-way through, causing a jarring user experience. Now the terminal selection happens upfront before any script work begins.

### Changes Made

- **Enhanced terminal selection prompt** with clearer messaging and visual indicators (⚙️, ✓, ⚠️)
- **Added `ensure_terminal_configured()` function** that checks if terminal preference is set before script execution
- **Updated all start scripts** to call `ensure_terminal_configured()` immediately after sourcing helpers:
  - `scripts/start-all-vets.sh`
  - `scripts/vets-api/start-vets-api.sh`
  - `scripts/vets-website/start-vets-website.sh`
  - `scripts/content-build/start-content-build.sh`

### Before
Users would see the terminal selection prompt pop up randomly during script execution, interrupting the flow.

### After
Users see a clear, informative prompt at the start (only on first run), explaining why the selection is needed and that their choice will be saved for future use.

## Test plan
- [ ] Run any start script for the first time (after `rm ~/.dotfiles_terminal_preference`)
- [ ] Verify terminal selection prompt appears before main script output
- [ ] Verify choice is saved and not prompted again on subsequent runs
- [ ] Verify `reset_terminal_preference` command allows changing the selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)