### PR TITLE
Fix shellcheck warnings for unused loop variables

### DIFF
--- a/scripts/content-build/start-content-build.sh
+++ b/scripts/content-build/start-content-build.sh
@@ -201,7 +201,7 @@ open_terminal_tab "cd '$CONTENT_BUILD_DIR' && yarn watch"
 # Wait for server to be ready
 echo "Waiting for watch server to start..."
 echo "(This may take a few minutes on first run while building content)"
-for i in {1..120}; do
+for _ in {1..120}; do
   if curl -s -o /dev/null http://localhost:3002; then
     echo -e "${GREEN}✓ Watch server is ready at http://localhost:3002${NC}"
     break

--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -425,7 +425,7 @@ esac
 
 # Wait for server to be ready
 echo "Waiting for Rails server to start..."
-for i in {1..60}; do
+for _ in {1..60}; do
   if curl -s -o /dev/null http://localhost:3000; then
     echo -e "${GREEN}✓ Rails server is ready at http://localhost:3000${NC}"
     break

--- a/scripts/vets-website/start-vets-website.sh
+++ b/scripts/vets-website/start-vets-website.sh
@@ -170,7 +170,7 @@ open_terminal_tab "cd '$VETS_WEBSITE_DIR' && yarn watch --entry=auth,login-page,
 
 # Wait for server to be ready
 echo "Waiting for dev server to start..."
-for i in {1..30}; do
+for _ in {1..30}; do
   if curl -s -o /dev/null http://localhost:3001; then
     echo -e "${GREEN}✓ Dev server is ready at http://localhost:3001${NC}"
     break


### PR DESCRIPTION
## Summary

Resolves shellcheck SC2034 warnings about unused loop variables in wait loops.

### Changes Made

Changed loop variable from `i` to `_` (underscore) in three scripts where the variable is declared but never used in the loop body:

- `scripts/content-build/start-content-build.sh` - line 204
- `scripts/vets-api/start-vets-api.sh` - line 428  
- `scripts/vets-website/start-vets-website.sh` - line 173

### Note

The loop variables in `scripts/start-all-vets.sh` were intentionally left as `i` because they ARE used in the loop body to check if the maximum wait time has been reached.

## Test plan
- [x] Shellcheck pre-commit hook passes
- [ ] Scripts still function correctly with underscore variable
- [ ] No behavioral changes to the wait loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)