### PR TITLE
Add JFrog CLI and Go proxy configuration

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -66,6 +66,7 @@ brew "httpie"         # human-friendly HTTP client (replaces curl for interactiv
 brew "watch"          # re-run a command on an interval (e.g. watch kubectl get pods)
 brew "direnv"         # per-directory environment variables via .envrc files
 brew "newman"         # CLI runner for Insomnia/Postman collections (useful in CI)
+brew "jfrog-cli"      # JFrog Artifactory CLI for artifact management and Go proxy authentication
 brew "redis"          # in-memory data store — background jobs (Sidekiq), caching, sessions
 brew "imagemagick"    # image conversion and manipulation (resize, crop, format conversion)
 brew "pdftk-java"    # PDF toolkit — merge, split, fill forms, extract pages

--- a/home/zsh/path.zsh
+++ b/home/zsh/path.zsh
@@ -55,6 +55,10 @@ fi
 export GOPATH="${GOPATH:-$HOME/go}"
 [[ -d "$GOPATH/bin" ]] && export PATH="$PATH:$GOPATH/bin"
 
+# Go module proxy — use JFrog Artifactory (corporate network requirement)
+# Falls back to direct if proxy is unavailable
+export GOPROXY="https://jfrog.accenturefederaldev.com/artifactory/afs-vgo-proxy/,direct"
+
 # Local binaries (Claude Code, pipx, etc.)
 [[ -d "$HOME/.local/bin" ]] && export PATH="$HOME/.local/bin:$PATH"
 

--- a/scripts/content-build/start-content-build.sh
+++ b/scripts/content-build/start-content-build.sh
@@ -201,7 +201,7 @@ open_terminal_tab "cd '$CONTENT_BUILD_DIR' && yarn watch"
 # Wait for server to be ready
 echo "Waiting for watch server to start..."
 echo "(This may take a few minutes on first run while building content)"
-for i in {1..120}; do
+for _ in {1..120}; do
   if curl -s -o /dev/null http://localhost:3002; then
     echo -e "${GREEN}✓ Watch server is ready at http://localhost:3002${NC}"
     break

--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -425,7 +425,7 @@ esac
 
 # Wait for server to be ready
 echo "Waiting for Rails server to start..."
-for i in {1..60}; do
+for _ in {1..60}; do
   if curl -s -o /dev/null http://localhost:3000; then
     echo -e "${GREEN}✓ Rails server is ready at http://localhost:3000${NC}"
     break

--- a/scripts/vets-website/start-vets-website.sh
+++ b/scripts/vets-website/start-vets-website.sh
@@ -170,7 +170,7 @@ open_terminal_tab "cd '$VETS_WEBSITE_DIR' && yarn watch --entry=auth,login-page,
 
 # Wait for server to be ready
 echo "Waiting for dev server to start..."
-for i in {1..30}; do
+for _ in {1..30}; do
   if curl -s -o /dev/null http://localhost:3001; then
     echo -e "${GREEN}✓ Dev server is ready at http://localhost:3001${NC}"
     break


### PR DESCRIPTION
## Summary

Adds JFrog CLI tooling and configures Go to use the corporate JFrog Artifactory proxy for module downloads.

### Changes Made

- **Brewfile**: Added `jfrog-cli` for JFrog Artifactory authentication and management
- **home/zsh/path.zsh**: Configured `GOPROXY` to use JFrog Artifactory proxy (afs-vgo-proxy) with fallback to direct downloads

### Background

This configuration is needed for Go tooling (like pre-commit hooks that install gitleaks/actionlint) to work on the corporate network where access to `proxy.golang.org` is restricted.

## Test plan
- [x] JFrog CLI installed via Homebrew
- [ ] Go proxy configuration loads in new shell sessions
- [ ] Go module downloads work through JFrog proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)