### PR TITLE
Fix terminal command case issue in Ghostty and Hyper

### DIFF
--- a/scripts/lib/terminal_helpers.sh
+++ b/scripts/lib/terminal_helpers.sh
@@ -85,28 +85,34 @@ open_terminal_tab() {
 
   case $TERMINAL in
     Ghostty)
+      # Use clipboard to avoid keystroke issues with long commands
       osascript <<EOF
+set the clipboard to "$COMMAND"
 tell application "Ghostty"
     activate
     delay 0.3
     tell application "System Events"
         keystroke "t" using {command down}
         delay 0.5
-        keystroke "$COMMAND"
+        keystroke "v" using {command down}
+        delay 0.2
         keystroke return
     end tell
 end tell
 EOF
       ;;
     Hyper)
+      # Use clipboard to avoid keystroke issues with long commands
       osascript <<EOF
+set the clipboard to "$COMMAND"
 tell application "Hyper"
     activate
     delay 0.3
     tell application "System Events"
         keystroke "t" using {command down}
         delay 0.5
-        keystroke "$COMMAND"
+        keystroke "v" using {command down}
+        delay 0.2
         keystroke return
     end tell
 end tell


### PR DESCRIPTION
## Summary
Fixed a bug where commands sent to new terminal tabs in Ghostty and Hyper were being converted to uppercase (e.g., `CD`, `BUNDLE EXEC` instead of `cd`, `bundle exec`). This was causing "command not found" errors when running the vets-api startup scripts.

The fix changes the `open_terminal_tab` function to use clipboard paste (Cmd+V) instead of keystroke simulation, which preserves the exact case and special characters of the command.

## Type
- [ ] Feature
- [x] Fix
- [ ] Refactor / chore
- [ ] Docs

## Validation
- [x] `shellcheck -S warning` on changed bash; `zsh -n` on changed zsh files (`install.sh`, `home/zshrc`, …)
- [ ] Ran the bats suite (`bats scripts/tests/`)
- [ ] Exercised install/verify against an isolated `HOME=$(mktemp -d)` (if behavior changed)

## Checklist
- [ ] New tracked dotfile? Added a line to `config/symlinks.map` and a row to the README table
- [ ] Changed a real `bootstrap.sh` step? Updated its `--dry-run` preview in `scripts/lib/dryrun_helpers.sh`
- [ ] Updated docs (`README.md` / `docs/`) and the `CHANGELOG.md` `[Unreleased]` section as needed
- [x] No secrets or machine-specific values committed (gitleaks runs in CI and pre-commit)

## Notes
- Shellcheck passed in pre-commit hooks
- Only affects Ghostty and Hyper terminal emulators
- Terminal.app and iTerm2 implementations unchanged (they already use different methods)
- Tested with vets-api startup script successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)