### PR TITLE
Add JFrog authentication error handling to vets-website startup script

### DIFF
--- a/scripts/vets-website/start-vets-website.sh
+++ b/scripts/vets-website/start-vets-website.sh
@@ -130,12 +130,102 @@ YARN_VERSION=$(yarn --version)
 echo "  Yarn version: $YARN_VERSION (Required: 1.19.1)"
 echo ""
 
-# Install dependencies using jfrog proxy
+# Clear yarn cache for fresh install
+echo -e "${BLUE}→ Clearing yarn cache...${NC}"
+yarn cache clean
+echo ""
+
+# Function to update JFrog token in .npmrc
+update_jfrog_token() {
+  local new_token="$1"
+  if [ -f ".npmrc" ]; then
+    # Update existing token line
+    sed -i '' "s|//jfrog.accenturefederaldev.com/artifactory/api/npm/afs-npm-proxy/:_authToken=.*|//jfrog.accenturefederaldev.com/artifactory/api/npm/afs-npm-proxy/:_authToken=$new_token|" .npmrc
+    echo -e "${GREEN}  ✓ Updated JFrog token in .npmrc${NC}"
+  else
+    echo -e "${RED}  ✗ .npmrc file not found${NC}"
+    return 1
+  fi
+}
+
+# Install dependencies using jfrog proxy with retry on auth failure
 # The --ignore-scripts flag prevents potentially untrusted scripts from running
 # The postinstall script runs only trusted package postinstall scripts
-echo -e "${BLUE}→ Installing dependencies via jfrog proxy...${NC}"
-echo "  (This uses NODE_TLS_REJECT_UNAUTHORIZED=0 for jfrog SSL)"
-NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe
+MAX_RETRIES=2
+RETRY_COUNT=0
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+  echo -e "${BLUE}→ Installing dependencies via jfrog proxy...${NC}"
+  echo "  (This uses NODE_TLS_REJECT_UNAUTHORIZED=0 for jfrog SSL)"
+  echo ""
+
+  # Use temporary file to capture output while showing it in real-time
+  TEMP_LOG=$(mktemp)
+
+  # Run installation with tee to show output and capture it
+  if NODE_TLS_REJECT_UNAUTHORIZED=0 yarn install-safe 2>&1 | tee "$TEMP_LOG"; then
+    INSTALL_EXIT_CODE=0
+  else
+    INSTALL_EXIT_CODE=$?
+  fi
+
+  # Read the captured output for error detection
+  INSTALL_OUTPUT=$(cat "$TEMP_LOG")
+  rm -f "$TEMP_LOG"
+
+  if [ $INSTALL_EXIT_CODE -eq 0 ]; then
+    echo ""
+    echo -e "${GREEN}✓ Installation successful!${NC}"
+    break
+  else
+    # Check if it's an authentication error
+    if echo "$INSTALL_OUTPUT" | grep -qiE "(401|403|unauthorized|forbidden|authentication|auth.*failed)"; then
+      RETRY_COUNT=$((RETRY_COUNT + 1))
+
+      if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+        echo ""
+        echo -e "${RED}✗ Authentication failed with JFrog${NC}"
+        echo ""
+
+        # Delete yarn.lock to force using JFrog registry
+        if [ -f "yarn.lock" ]; then
+          echo "  Deleting yarn.lock to use JFrog registry instead of hardcoded npmjs.org URLs"
+          rm yarn.lock
+        fi
+
+        echo "Your JFrog token may be expired or invalid."
+        echo "To get a new token:"
+        echo "  1. Visit: https://jfrog.accenturefederaldev.com/ui/admin/artifactory/user_profile"
+        echo "  2. Click 'Generate Identity Token' or use an existing token"
+        echo "  3. Copy the token"
+        echo ""
+        read -p "Enter new JFrog token (or press Enter to skip): " NEW_TOKEN
+
+        if [ -n "$NEW_TOKEN" ]; then
+          update_jfrog_token "$NEW_TOKEN"
+          echo ""
+          echo "Retrying installation with new token..."
+          echo "  (This may take 5-10 minutes on first run without yarn.lock)"
+          echo ""
+        else
+          echo -e "${YELLOW}Skipping token update${NC}"
+          break
+        fi
+      else
+        echo ""
+        echo -e "${RED}✗ Installation failed after $RETRY_COUNT attempts${NC}"
+        break
+      fi
+    else
+      # Non-auth error, show output and exit
+      echo ""
+      echo -e "${RED}✗ Installation failed (non-authentication error)${NC}"
+      echo "Check the output above for details"
+      break
+    fi
+  fi
+done
+
 echo ""
 
 # Note: yarn install-safe is equivalent to:


### PR DESCRIPTION
## Summary
Improves the vets-website startup script to handle JFrog authentication failures gracefully. When the script detects authentication errors (401/403), it automatically prompts for a new JFrog token, deletes the problematic yarn.lock file, and retries the installation. This resolves the issue where expired JFrog tokens would cause silent failures or 403 Forbidden errors.

## Type
- [x] Feature
- [ ] Fix
- [ ] Refactor / chore
- [ ] Docs

## Validation
- [x] `shellcheck -S warning` on changed bash; `zsh -n` on changed zsh files (`install.sh`, `home/zshrc`, …)
- [ ] Ran the bats suite (`bats scripts/tests/`)
- [ ] Exercised install/verify against an isolated `HOME=$(mktemp -d)` (if behavior changed)

## Checklist
- [ ] New tracked dotfile? Added a line to `config/symlinks.map` and a row to the README table
- [ ] Changed a real `bootstrap.sh` step? Updated its `--dry-run` preview in `scripts/lib/dryrun_helpers.sh`
- [ ] Updated docs (`README.md` / `docs/`) and the `CHANGELOG.md` `[Unreleased]` section as needed
- [x] No secrets or machine-specific values committed (gitleaks runs in CI and pre-commit)

## Notes
**Changes:**
- Add yarn cache clean on startup to prevent stale cache issues
- Add authentication error detection (401/403/forbidden errors)
- Automatically delete yarn.lock on auth failure to force JFrog registry usage
- Prompt user for new JFrog token when authentication fails
- Show installation output in real-time using tee (no more silent hangs)
- Add retry logic with up to 2 attempts
- Display helpful instructions for generating new JFrog tokens

**Testing:** Tested with expired JFrog token scenario - script correctly detected the auth failure, prompted for new token, and successfully retried installation.