### PR TITLE
Add branch management and betamocks configuration to vets-api script

### DIFF
--- a/docs/vets-api.md
+++ b/docs/vets-api.md
@@ -45,7 +45,7 @@ The comprehensive daily startup script that syncs everything.
 
 **What it does:**
 
-1. Checks vets-api git status and branch
+1. Checks vets-api git status and branch (saves original branch for later)
 2. **Checks out and pulls latest from `origin/master`** (if no uncommitted changes)
 3. **Interactive branch selection** - prompts to run server on a different branch
 4. Updates vets-api-mockdata repository (from master)
@@ -53,7 +53,9 @@ The comprehensive daily startup script that syncs everything.
 6. Validates Ruby version
 7. **Configures Gemfile and Bundler to use jfrog proxy** (replaces rubygems.org, sets mirror)
 8. **Optionally installs/updates bundle dependencies** (only prompts if gems are out of date)
-9. Starts the Rails server with foreman in a new Hyper tab
+9. **Configures betamocks** - prompts to enable or disable betamocks in settings.local.yml
+10. **Returns to original branch** - switches back to the branch you started on
+11. Starts the Rails server with foreman in a new Hyper tab
 
 **Time**: 2-4 minutes
 
@@ -160,9 +162,43 @@ Enter branch name: feature/my-work
 → Installing bundle dependencies...
   ✓ Bundle install complete
 
+========================================
+Configure betamocks
+========================================
+
+Enable betamocks? (Y/n): y
+→ Enabling betamocks in settings.local.yml...
+  ✓ Betamocks enabled
+
+→ Returning to original branch: feature-branch
+  ✓ Switched back to feature-branch
+
+========================================
+Select Rails server mode
+========================================
+
+Options:
+  1) Foreman (with Sidekiq) - Full stack with background jobs
+  2) Rails server only - Cleaner logs, no background processing
+
+Enter choice [1-2] (default: 1): 1
+
+========================================
+Starting Rails server with foreman...
+========================================
+
+Starting server with: foreman start -m all=1,clamd=0,freshclam=0
+Branch: feature-branch
+
+Opening Rails server in new terminal tab...
+Waiting for Rails server to start...
+✓ Rails server is ready at http://localhost:3000
+
 ✓ Setup complete!
 
-Rails server is running in the new Hyper tab.
+Rails server is running in the new terminal tab.
+  Branch: feature-branch
+  Betamocks: enabled
 ```
 
 ### Server Running in Hyper Tab
@@ -234,6 +270,86 @@ If you have uncommitted changes, the script skips all git operations:
 ```
 
 **Result**: Server runs on your current branch with uncommitted changes intact.
+
+### Returning to Original Branch
+
+After completing all setup steps (pulling master, updating dependencies, configuring betamocks), the script automatically returns to the branch you started on before launching the Rails server.
+
+```
+→ Returning to original branch: feature/my-work
+  ✓ Switched back to feature/my-work
+```
+
+This ensures that:
+- Your working branch is preserved
+- The server runs on your intended development branch
+- You don't accidentally leave the repository on master
+
+---
+
+## Betamocks Configuration
+
+The script provides interactive betamocks configuration to enable or disable mock external service responses.
+
+### What are Betamocks?
+
+Betamocks allow the vets-api to use pre-recorded responses from external services (VA backends, databases, APIs) instead of making real network calls. This is useful for:
+- Working offline or with limited network access
+- Consistent test data across developers
+- Faster API responses during development
+- Avoiding rate limits or API quotas
+
+### Interactive Configuration
+
+During startup, the script prompts:
+
+```
+========================================
+Configure betamocks
+========================================
+
+Enable betamocks? (Y/n):
+```
+
+**Enable betamocks (default)**:
+```
+Enable betamocks? (Y/n): y
+→ Enabling betamocks in settings.local.yml...
+  ✓ Betamocks enabled
+```
+
+**Disable betamocks**:
+```
+Enable betamocks? (Y/n): n
+→ Disabling betamocks in settings.local.yml...
+  ✓ Betamocks disabled
+```
+
+### Configuration Details
+
+The script updates `config/settings.local.yml`:
+
+```yaml
+betamocks:
+  cache_dir: "../vets-api-mockdata"
+  enabled: true          # or false
+  recording: false
+  services_config: config/betamocks/services_config.yml
+```
+
+### When to Enable Betamocks
+
+**Enable when**:
+- Working on frontend features that don't require real backend changes
+- Testing API responses with consistent mock data
+- Working offline or with limited network connectivity
+- Developing new features that use existing backend endpoints
+
+**Disable when**:
+- Testing actual backend integrations
+- Validating real API response formats
+- Debugging live service issues
+- Verifying authentication flows with real credentials
 
 ---
 
@@ -422,4 +538,7 @@ ps aux | grep foreman
 
 # Kill server process
 lsof -ti:3000 | xargs kill -9
+
+# Check betamocks status
+grep -A 1 "^betamocks:" ~/Code/va.gov/vets-api/config/settings.local.yml | grep "enabled:"
 ```

--- a/docs/vets-api.md
+++ b/docs/vets-api.md
@@ -51,11 +51,12 @@ The comprehensive daily startup script that syncs everything.
 4. Updates vets-api-mockdata repository (from master)
 5. Runs `make_table.rb` to generate mock data tables
 6. Validates Ruby version
-7. **Configures Gemfile and Bundler to use jfrog proxy** (replaces rubygems.org, sets mirror)
-8. **Optionally installs/updates bundle dependencies** (only prompts if gems are out of date)
-9. **Configures betamocks** - prompts to enable or disable betamocks in settings.local.yml
-10. **Returns to original branch** - switches back to the branch you started on
-11. Starts the Rails server with foreman in a new Hyper tab
+7. **Configures betamocks** - prompts to enable or disable betamocks in settings.local.yml
+8. **Configures gateway URL** - suggests fake URL for betamocks or real AIO URL
+9. **Configures Gemfile and Bundler to use jfrog proxy** (replaces rubygems.org, sets mirror)
+10. **Optionally installs/updates bundle dependencies** (only prompts if gems are out of date)
+11. **Returns to original branch** - switches back to the branch you started on
+12. Starts the Rails server with foreman in a new Hyper tab
 
 **Time**: 2-4 minutes
 
@@ -159,8 +160,8 @@ Enter branch name: feature/my-work
 → Configuring Gemfile for jfrog proxy...
   ✓ Gemfile configured for jfrog proxy
 
-→ Installing bundle dependencies...
-  ✓ Bundle install complete
+→ Checking Ruby version...
+  Ruby version: ruby 3.3.6
 
 ========================================
 Configure betamocks
@@ -169,6 +170,25 @@ Configure betamocks
 Enable betamocks? (Y/n): y
 → Enabling betamocks in settings.local.yml...
   ✓ Betamocks enabled
+
+========================================
+Configure gateway URL
+========================================
+
+→ Betamocks is enabled
+  When using betamocks, it's recommended to use a fake gateway URL
+  that won't resolve to prevent accidental external service calls.
+
+  Recommended: https://fake-dgi-vets.va.gov/vets-service/v1/
+
+Update gateway URL to fake URL? (Y/n): y
+  ✓ Updated development.yml with fake URL: https://fake-dgi-vets.va.gov/vets-service/v1/
+
+→ Configuring Gemfile for jfrog proxy...
+  ✓ Gemfile configured for jfrog proxy
+
+→ Installing bundle dependencies...
+  ✓ Bundle install complete
 
 → Returning to original branch: feature-branch
   ✓ Switched back to feature-branch
@@ -289,7 +309,7 @@ This ensures that:
 
 ## Betamocks Configuration
 
-The script provides interactive betamocks configuration to enable or disable mock external service responses.
+The script provides interactive betamocks configuration to enable or disable mock external service responses, and automatically configures the appropriate gateway URL based on your selection.
 
 ### What are Betamocks?
 
@@ -325,16 +345,67 @@ Enable betamocks? (Y/n): n
   ✓ Betamocks disabled
 ```
 
+### Gateway URL Configuration
+
+After configuring betamocks, the script automatically configures the appropriate gateway URL:
+
+**With betamocks enabled** (recommended: fake URL):
+```
+========================================
+Configure gateway URL
+========================================
+
+→ Betamocks is enabled
+  When using betamocks, it's recommended to use a fake gateway URL
+  that won't resolve to prevent accidental external service calls.
+
+  Recommended: https://fake-dgi-vets.va.gov/vets-service/v1/
+
+Update gateway URL to fake URL? (Y/n): y
+  ✓ Updated development.yml with fake URL: https://fake-dgi-vets.va.gov/vets-service/v1/
+```
+
+**With betamocks disabled** (use real AIO URL):
+```
+========================================
+Configure gateway URL
+========================================
+
+→ Betamocks is disabled
+  Configure your personal AIO gateway URL for real external service calls.
+
+Enter your AIO username (e.g., brabergeron) or press Enter to skip: brabergeron
+  ✓ Updated development.yml with AIO URL: http://apigw-brabergeron.ld.afsp.io:32512/vets-service/v1/
+```
+
+### Why Use a Fake URL with Betamocks?
+
+When betamocks is enabled, API calls are intercepted and served from local mock data. Using a fake URL that won't resolve provides an extra safety layer:
+- **Prevents accidental external calls**: If mock interception fails, requests will fail immediately rather than hitting real services
+- **Faster failures**: No DNS resolution or network timeout delays
+- **Clear intent**: Signals to other developers that you're using mock data
+- **Safer development**: Eliminates risk of accidentally modifying production data
+
 ### Configuration Details
 
-The script updates `config/settings.local.yml`:
+The script updates two files:
 
+**settings.local.yml** (betamocks):
 ```yaml
 betamocks:
   cache_dir: "../vets-api-mockdata"
   enabled: true          # or false
   recording: false
   services_config: config/betamocks/services_config.yml
+```
+
+**settings/development.yml** (gateway URL):
+```yaml
+# With betamocks enabled:
+base_url: 'https://fake-dgi-vets.va.gov/vets-service/v1/'
+
+# With betamocks disabled:
+base_url: 'http://apigw-yourusername.ld.afsp.io:32512/vets-service/v1/'
 ```
 
 ### When to Enable Betamocks
@@ -344,12 +415,14 @@ betamocks:
 - Testing API responses with consistent mock data
 - Working offline or with limited network connectivity
 - Developing new features that use existing backend endpoints
+- Running automated tests
 
 **Disable when**:
 - Testing actual backend integrations
 - Validating real API response formats
 - Debugging live service issues
 - Verifying authentication flows with real credentials
+- Testing network error handling
 
 ---
 

--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -54,7 +54,8 @@ NC='\033[0m' # No Color
 
 # Git branch management and pull from master
 echo -e "${BLUE}→ Checking vets-api git status...${NC}"
-CURRENT_BRANCH=$(git branch --show-current)
+ORIGINAL_BRANCH=$(git branch --show-current)
+CURRENT_BRANCH="$ORIGINAL_BRANCH"
 echo "  Current branch: $CURRENT_BRANCH"
 
 # Check for uncommitted changes
@@ -363,6 +364,67 @@ echo ""
 echo -e "${GREEN}✓ Installation complete!${NC}"
 echo ""
 
+# Betamocks configuration
+echo "========================================"
+echo "Configure betamocks"
+echo "========================================"
+echo ""
+read -p "Enable betamocks? (Y/n): " ENABLE_BETAMOCKS
+
+# Default to yes if empty
+if [[ -z "$ENABLE_BETAMOCKS" ]]; then
+  ENABLE_BETAMOCKS="y"
+fi
+
+if [[ $ENABLE_BETAMOCKS =~ ^[Yy]$ ]]; then
+  echo -e "${BLUE}→ Enabling betamocks in settings.local.yml...${NC}"
+
+  if [ -f "$SETTINGS_LOCAL_YML" ]; then
+    # Check if betamocks section exists
+    if grep -q "^betamocks:" "$SETTINGS_LOCAL_YML"; then
+      # Update enabled setting
+      if grep -q "^[[:space:]]*enabled:" "$SETTINGS_LOCAL_YML"; then
+        if command -v gsed &> /dev/null; then
+          gsed -i '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: true/' "$SETTINGS_LOCAL_YML"
+        else
+          sed -i '' '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: true/' "$SETTINGS_LOCAL_YML"
+        fi
+        echo -e "${GREEN}  ✓ Betamocks enabled${NC}"
+      else
+        echo -e "${YELLOW}  ⚠ betamocks.enabled not found in settings.local.yml${NC}"
+        echo "  You may need to add it manually under betamocks:"
+      fi
+    else
+      echo -e "${YELLOW}  ⚠ betamocks section not found in settings.local.yml${NC}"
+      echo "  You may need to add it manually"
+    fi
+  else
+    echo -e "${RED}  ✗ settings.local.yml not found${NC}"
+  fi
+else
+  echo -e "${BLUE}→ Disabling betamocks in settings.local.yml...${NC}"
+
+  if [ -f "$SETTINGS_LOCAL_YML" ]; then
+    # Check if betamocks section exists
+    if grep -q "^betamocks:" "$SETTINGS_LOCAL_YML"; then
+      # Update enabled setting
+      if grep -q "^[[:space:]]*enabled:" "$SETTINGS_LOCAL_YML"; then
+        if command -v gsed &> /dev/null; then
+          gsed -i '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: false/' "$SETTINGS_LOCAL_YML"
+        else
+          sed -i '' '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: false/' "$SETTINGS_LOCAL_YML"
+        fi
+        echo -e "${GREEN}  ✓ Betamocks disabled${NC}"
+      else
+        echo -e "${YELLOW}  ⚠ betamocks.enabled not found in settings.local.yml${NC}"
+      fi
+    else
+      echo -e "${YELLOW}  ⚠ betamocks section not found in settings.local.yml${NC}"
+    fi
+  fi
+fi
+echo ""
+
 # Server mode selection
 echo "========================================"
 echo "Select Rails server mode"
@@ -380,6 +442,19 @@ if [[ -z "$SERVER_MODE" ]]; then
   SERVER_MODE="1"
 fi
 
+# Return to original branch if needed
+CURRENT_BRANCH=$(git branch --show-current)
+if [ "$CURRENT_BRANCH" != "$ORIGINAL_BRANCH" ]; then
+  echo -e "${BLUE}→ Returning to original branch: $ORIGINAL_BRANCH${NC}"
+  if git checkout "$ORIGINAL_BRANCH"; then
+    echo -e "${GREEN}  ✓ Switched back to $ORIGINAL_BRANCH${NC}"
+  else
+    echo -e "${YELLOW}  ⚠ Failed to switch back to $ORIGINAL_BRANCH${NC}"
+    echo "  Server will start on: $CURRENT_BRANCH"
+  fi
+  echo ""
+fi
+
 case $SERVER_MODE in
   1)
     # Start with foreman (original behavior)
@@ -388,6 +463,7 @@ case $SERVER_MODE in
     echo "========================================"
     echo ""
     echo "Starting server with: foreman start -m all=1,clamd=0,freshclam=0"
+    echo "Branch: $(git branch --show-current)"
     echo ""
 
     # Start foreman in a new terminal tab
@@ -401,6 +477,7 @@ case $SERVER_MODE in
     echo "========================================"
     echo ""
     echo "Starting server with: bundle exec rails s -p 3000"
+    echo "Branch: $(git branch --show-current)"
     echo -e "${YELLOW}Note: Sidekiq jobs will NOT run in this mode${NC}"
     echo ""
 
@@ -428,10 +505,16 @@ for _ in {1..60}; do
   sleep 1
 done
 
+FINAL_BRANCH=$(git branch --show-current)
+BETAMOCKS_STATUS=$(if [[ $ENABLE_BETAMOCKS =~ ^[Yy]$ ]]; then echo "enabled"; else echo "disabled"; fi)
+
 echo ""
 echo -e "${GREEN}✓ Setup complete!${NC}"
 echo ""
 echo "Rails server is running in the new terminal tab."
+echo "  Branch: $FINAL_BRANCH"
+echo "  Betamocks: $BETAMOCKS_STATUS"
+echo ""
 echo "You can monitor server logs and requests there."
 echo "To stop the server, use Ctrl+C in that tab."
 echo ""

--- a/scripts/vets-api/start-vets-api.sh
+++ b/scripts/vets-api/start-vets-api.sh
@@ -219,38 +219,153 @@ RUBY_VERSION=$(ruby --version)
 echo "  Ruby version: $RUBY_VERSION"
 echo ""
 
-# Configure AIO URL for local development
-echo -e "${BLUE}→ Configuring AIO URL...${NC}"
-echo "  This will update config/settings/development.yml with your AIO gateway URL"
+# Betamocks configuration
+echo "========================================"
+echo "Configure betamocks"
+echo "========================================"
 echo ""
-read -p "Enter your AIO username (e.g., brabergeron) or press Enter to skip: " AIO_USERNAME
+read -p "Enable betamocks? (Y/n): " ENABLE_BETAMOCKS
 
-if [ -n "$AIO_USERNAME" ]; then
-  DEVELOPMENT_YML="$VETS_API_DIR/config/settings/development.yml"
-  AIO_URL="http://apigw-${AIO_USERNAME}.ld.afsp.io:32512/vets-service/v1/"
+# Default to yes if empty
+if [[ -z "$ENABLE_BETAMOCKS" ]]; then
+  ENABLE_BETAMOCKS="y"
+fi
 
-  if [ -f "$DEVELOPMENT_YML" ]; then
-    # Replace the jenkins URL with the AIO URL
-    if grep -q "jenkins.ld.afsp.io:32512/vets-service/v1/" "$DEVELOPMENT_YML"; then
-      if command -v gsed &> /dev/null; then
-        gsed -i "s|https://jenkins.ld.afsp.io:32512/vets-service/v1/|${AIO_URL}|g" "$DEVELOPMENT_YML"
+if [[ $ENABLE_BETAMOCKS =~ ^[Yy]$ ]]; then
+  echo -e "${BLUE}→ Enabling betamocks in settings.local.yml...${NC}"
+
+  if [ -f "$SETTINGS_LOCAL_YML" ]; then
+    # Check if betamocks section exists
+    if grep -q "^betamocks:" "$SETTINGS_LOCAL_YML"; then
+      # Update enabled setting
+      if grep -q "^[[:space:]]*enabled:" "$SETTINGS_LOCAL_YML"; then
+        if command -v gsed &> /dev/null; then
+          gsed -i '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: true/' "$SETTINGS_LOCAL_YML"
+        else
+          sed -i '' '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: true/' "$SETTINGS_LOCAL_YML"
+        fi
+        echo -e "${GREEN}  ✓ Betamocks enabled${NC}"
       else
-        sed -i '' "s|https://jenkins.ld.afsp.io:32512/vets-service/v1/|${AIO_URL}|g" "$DEVELOPMENT_YML"
+        echo -e "${YELLOW}  ⚠ betamocks.enabled not found in settings.local.yml${NC}"
+        echo "  You may need to add it manually under betamocks:"
       fi
-      echo -e "${GREEN}  ✓ Updated development.yml with AIO URL: ${AIO_URL}${NC}"
     else
-      # Check if it's already set to an AIO URL
-      if grep -q "apigw-.*\.ld\.afsp\.io:32512/vets-service/v1/" "$DEVELOPMENT_YML"; then
-        echo -e "${YELLOW}  ⚠ AIO URL already configured in development.yml${NC}"
-      else
-        echo -e "${YELLOW}  ⚠ Jenkins URL not found in expected format${NC}"
-      fi
+      echo -e "${YELLOW}  ⚠ betamocks section not found in settings.local.yml${NC}"
+      echo "  You may need to add it manually"
     fi
   else
-    echo -e "${RED}  ✗ development.yml not found${NC}"
+    echo -e "${RED}  ✗ settings.local.yml not found${NC}"
   fi
 else
-  echo -e "${YELLOW}  Skipping AIO configuration${NC}"
+  echo -e "${BLUE}→ Disabling betamocks in settings.local.yml...${NC}"
+
+  if [ -f "$SETTINGS_LOCAL_YML" ]; then
+    # Check if betamocks section exists
+    if grep -q "^betamocks:" "$SETTINGS_LOCAL_YML"; then
+      # Update enabled setting
+      if grep -q "^[[:space:]]*enabled:" "$SETTINGS_LOCAL_YML"; then
+        if command -v gsed &> /dev/null; then
+          gsed -i '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: false/' "$SETTINGS_LOCAL_YML"
+        else
+          sed -i '' '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: false/' "$SETTINGS_LOCAL_YML"
+        fi
+        echo -e "${GREEN}  ✓ Betamocks disabled${NC}"
+      else
+        echo -e "${YELLOW}  ⚠ betamocks.enabled not found in settings.local.yml${NC}"
+      fi
+    else
+      echo -e "${YELLOW}  ⚠ betamocks section not found in settings.local.yml${NC}"
+    fi
+  fi
+fi
+echo ""
+
+# Configure gateway URL for local development
+echo "========================================"
+echo "Configure gateway URL"
+echo "========================================"
+echo ""
+
+if [[ $ENABLE_BETAMOCKS =~ ^[Yy]$ ]]; then
+  # Betamocks enabled - suggest fake URL
+  echo -e "${BLUE}→ Betamocks is enabled${NC}"
+  echo "  When using betamocks, it's recommended to use a fake gateway URL"
+  echo "  that won't resolve to prevent accidental external service calls."
+  echo ""
+  echo "  Recommended: https://fake-dgi-vets.va.gov/vets-service/v1/"
+  echo ""
+  read -p "Update gateway URL to fake URL? (Y/n): " USE_FAKE_URL
+
+  if [[ -z "$USE_FAKE_URL" ]] || [[ $USE_FAKE_URL =~ ^[Yy]$ ]]; then
+    DEVELOPMENT_YML="$VETS_API_DIR/config/settings/development.yml"
+    FAKE_URL="https://fake-dgi-vets.va.gov/vets-service/v1/"
+
+    if [ -f "$DEVELOPMENT_YML" ]; then
+      # Replace any existing gateway URL with fake URL
+      if grep -q "jenkins.ld.afsp.io:32512/vets-service/v1/" "$DEVELOPMENT_YML"; then
+        if command -v gsed &> /dev/null; then
+          gsed -i "s|https://jenkins.ld.afsp.io:32512/vets-service/v1/|${FAKE_URL}|g" "$DEVELOPMENT_YML"
+        else
+          sed -i '' "s|https://jenkins.ld.afsp.io:32512/vets-service/v1/|${FAKE_URL}|g" "$DEVELOPMENT_YML"
+        fi
+        echo -e "${GREEN}  ✓ Updated development.yml with fake URL: ${FAKE_URL}${NC}"
+      elif grep -q "apigw-.*\.ld\.afsp\.io:32512/vets-service/v1/" "$DEVELOPMENT_YML"; then
+        if command -v gsed &> /dev/null; then
+          gsed -i "s|http://apigw-.*\.ld\.afsp\.io:32512/vets-service/v1/|${FAKE_URL}|g" "$DEVELOPMENT_YML"
+        else
+          sed -i '' "s|http://apigw-.*\.ld\.afsp\.io:32512/vets-service/v1/|${FAKE_URL}|g" "$DEVELOPMENT_YML"
+        fi
+        echo -e "${GREEN}  ✓ Updated development.yml with fake URL: ${FAKE_URL}${NC}"
+      else
+        echo -e "${YELLOW}  ⚠ No gateway URL found in expected format${NC}"
+      fi
+    else
+      echo -e "${RED}  ✗ development.yml not found${NC}"
+    fi
+  else
+    echo -e "${YELLOW}  Skipping fake URL configuration${NC}"
+  fi
+else
+  # Betamocks disabled - use real AIO URL
+  echo -e "${BLUE}→ Betamocks is disabled${NC}"
+  echo "  Configure your personal AIO gateway URL for real external service calls."
+  echo ""
+  read -p "Enter your AIO username (e.g., brabergeron) or press Enter to skip: " AIO_USERNAME
+
+  if [ -n "$AIO_USERNAME" ]; then
+    DEVELOPMENT_YML="$VETS_API_DIR/config/settings/development.yml"
+    AIO_URL="http://apigw-${AIO_USERNAME}.ld.afsp.io:32512/vets-service/v1/"
+
+    if [ -f "$DEVELOPMENT_YML" ]; then
+      # Replace the jenkins URL or fake URL with the AIO URL
+      if grep -q "jenkins.ld.afsp.io:32512/vets-service/v1/" "$DEVELOPMENT_YML"; then
+        if command -v gsed &> /dev/null; then
+          gsed -i "s|https://jenkins.ld.afsp.io:32512/vets-service/v1/|${AIO_URL}|g" "$DEVELOPMENT_YML"
+        else
+          sed -i '' "s|https://jenkins.ld.afsp.io:32512/vets-service/v1/|${AIO_URL}|g" "$DEVELOPMENT_YML"
+        fi
+        echo -e "${GREEN}  ✓ Updated development.yml with AIO URL: ${AIO_URL}${NC}"
+      elif grep -q "fake-dgi-vets.va.gov/vets-service/v1/" "$DEVELOPMENT_YML"; then
+        if command -v gsed &> /dev/null; then
+          gsed -i "s|https://fake-dgi-vets.va.gov/vets-service/v1/|${AIO_URL}|g" "$DEVELOPMENT_YML"
+        else
+          sed -i '' "s|https://fake-dgi-vets.va.gov/vets-service/v1/|${AIO_URL}|g" "$DEVELOPMENT_YML"
+        fi
+        echo -e "${GREEN}  ✓ Updated development.yml with AIO URL: ${AIO_URL}${NC}"
+      else
+        # Check if it's already set to an AIO URL
+        if grep -q "apigw-.*\.ld\.afsp\.io:32512/vets-service/v1/" "$DEVELOPMENT_YML"; then
+          echo -e "${YELLOW}  ⚠ AIO URL already configured in development.yml${NC}"
+        else
+          echo -e "${YELLOW}  ⚠ Gateway URL not found in expected format${NC}"
+        fi
+      fi
+    else
+      echo -e "${RED}  ✗ development.yml not found${NC}"
+    fi
+  else
+    echo -e "${YELLOW}  Skipping AIO configuration${NC}"
+  fi
 fi
 echo ""
 
@@ -362,67 +477,6 @@ fi
 echo ""
 
 echo -e "${GREEN}✓ Installation complete!${NC}"
-echo ""
-
-# Betamocks configuration
-echo "========================================"
-echo "Configure betamocks"
-echo "========================================"
-echo ""
-read -p "Enable betamocks? (Y/n): " ENABLE_BETAMOCKS
-
-# Default to yes if empty
-if [[ -z "$ENABLE_BETAMOCKS" ]]; then
-  ENABLE_BETAMOCKS="y"
-fi
-
-if [[ $ENABLE_BETAMOCKS =~ ^[Yy]$ ]]; then
-  echo -e "${BLUE}→ Enabling betamocks in settings.local.yml...${NC}"
-
-  if [ -f "$SETTINGS_LOCAL_YML" ]; then
-    # Check if betamocks section exists
-    if grep -q "^betamocks:" "$SETTINGS_LOCAL_YML"; then
-      # Update enabled setting
-      if grep -q "^[[:space:]]*enabled:" "$SETTINGS_LOCAL_YML"; then
-        if command -v gsed &> /dev/null; then
-          gsed -i '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: true/' "$SETTINGS_LOCAL_YML"
-        else
-          sed -i '' '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: true/' "$SETTINGS_LOCAL_YML"
-        fi
-        echo -e "${GREEN}  ✓ Betamocks enabled${NC}"
-      else
-        echo -e "${YELLOW}  ⚠ betamocks.enabled not found in settings.local.yml${NC}"
-        echo "  You may need to add it manually under betamocks:"
-      fi
-    else
-      echo -e "${YELLOW}  ⚠ betamocks section not found in settings.local.yml${NC}"
-      echo "  You may need to add it manually"
-    fi
-  else
-    echo -e "${RED}  ✗ settings.local.yml not found${NC}"
-  fi
-else
-  echo -e "${BLUE}→ Disabling betamocks in settings.local.yml...${NC}"
-
-  if [ -f "$SETTINGS_LOCAL_YML" ]; then
-    # Check if betamocks section exists
-    if grep -q "^betamocks:" "$SETTINGS_LOCAL_YML"; then
-      # Update enabled setting
-      if grep -q "^[[:space:]]*enabled:" "$SETTINGS_LOCAL_YML"; then
-        if command -v gsed &> /dev/null; then
-          gsed -i '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: false/' "$SETTINGS_LOCAL_YML"
-        else
-          sed -i '' '/^betamocks:/,/^[[:alpha:]]/ s/^[[:space:]]*enabled:.*/  enabled: false/' "$SETTINGS_LOCAL_YML"
-        fi
-        echo -e "${GREEN}  ✓ Betamocks disabled${NC}"
-      else
-        echo -e "${YELLOW}  ⚠ betamocks.enabled not found in settings.local.yml${NC}"
-      fi
-    else
-      echo -e "${YELLOW}  ⚠ betamocks section not found in settings.local.yml${NC}"
-    fi
-  fi
-fi
 echo ""
 
 # Server mode selection


### PR DESCRIPTION
## Summary
Enhanced the `start-vets-api.sh` script with three usability improvements:

1. **Original branch restoration**: The script now tracks your starting branch and automatically returns to it before launching the Rails server. This prevents accidentally leaving the repository on master and ensures the server runs on your intended working branch.

2. **Betamocks configuration**: Added an interactive prompt (defaults to enabled) that configures betamocks in `settings.local.yml`. This gives developers control over whether to use mock external service responses during development.

3. **Smart gateway URL configuration**: The script now suggests the appropriate gateway URL based on betamocks state:
   - **With betamocks enabled**: Recommends a fake URL (`https://fake-dgi-vets.va.gov/vets-service/v1/`) that won't resolve, preventing accidental external service calls
   - **With betamocks disabled**: Prompts for your personal AIO gateway URL for real external service calls

The final setup summary now displays the active branch and betamocks status for quick reference.

## Type
- [x] Feature
- [ ] Fix
- [ ] Refactor / chore
- [ ] Docs

## Validation
- [x] `shellcheck -S warning` on changed bash
- [ ] Ran the bats suite (`bats scripts/tests/`)
- [ ] Exercised install/verify against an isolated `HOME=$(mktemp -d)` (if behavior changed)

## Checklist
- [ ] New tracked dotfile? Added a line to `config/symlinks.map` and a row to the README table
- [ ] Changed a real `bootstrap.sh` step? Updated its `--dry-run` preview in `scripts/lib/dryrun_helpers.sh`
- [x] Updated docs (`README.md` / `docs/`) and the `CHANGELOG.md` `[Unreleased]` section as needed
- [x] No secrets or machine-specific values committed (gitleaks runs in CI and pre-commit)

## Notes

### Key Benefits

**Branch preservation**:
- Tracks your starting branch throughout the setup process
- Returns to it before launching the server
- Prevents accidentally staying on master after pulling latest

**Betamocks with fake URL**:
- Using a fake URL when betamocks is enabled provides an extra safety layer
- Prevents accidental external calls if mock interception fails
- Faster failures (no DNS resolution or network timeout delays)
- Clear signal to developers that mock data is in use
- Eliminates risk of accidentally modifying production data

**Transparent final state**:
- Shows which branch the server is running on
- Shows betamocks status (enabled/disabled)
- Shows gateway URL configuration

### Documentation

Updated `docs/vets-api.md` with:
- New workflow order (betamocks before gateway URL)
- Gateway URL configuration section with examples for both scenarios
- Explanation of why fake URLs are recommended with betamocks
- Enhanced example output showing all new prompts
- Updated quick reference commands